### PR TITLE
Fix `intersphinx_mapping` in the Sphinx config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,8 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 # import os
-# import sys
+import sys
+
 # sys.path.insert(0, os.path.abspath('.'))
 
 
@@ -176,4 +177,10 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {
+    'python': (f'https://docs.python.org/{sys.version_info.major}', None),
+    'mxnet': ('https://mxnet.apache.org/', None),
+    'numpy': ('http://docs.scipy.org/doc/numpy/', None),
+    'scipy': ('http://docs.scipy.org/doc/scipy/reference', None),
+    'matplotlib': ('http://matplotlib.org/', None),
+}


### PR DESCRIPTION
*Description of changes:*

Allows Sphinx linking of classes, functions, and modules
across projects, as follows.

```
:class:`~mxnet.gluon.HybridBlock`
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
