### PR TITLE
Update requirements files

### DIFF
--- a/requirements-setup.txt
+++ b/requirements-setup.txt
@@ -2,13 +2,16 @@ black>=18.*
 click==6.*
 mypy==0.630
 nbsphinx>=0.3.4,<0.4
+nbconvert
 pytest-runner==2.11.*
 ipython
+ipykernel
 recommonmark
 setuptools>=40.1.0
-sphinx==1.6.*
+sphinx==1.7.*
 sphinx-autobuild==0.7.*
 sphinx_rtd_theme==0.4.*
 sphinx-gallery
 sphinx-autorun
+tornado==5.1.1
 https://github.com/mli/mx-theme/archive/0.3.1.tar.gz

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,6 @@
 flake8==3.4.*
 pytest==3.*
-pytest-cov==2.4.*
-pytest-xdist==1.20.*
+pytest-cov==2.6.*
+pytest-runner<2.12
+pytest-xdist==1.27.*
 pytest-timeout==1.2.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ boto3==1.*
 holidays==0.9.*
 matplotlib==3.*
 mxnet>=1.3.0
-numpy>=1.14.0
+numpy==1.14.*
 pandas>=0.22.0
 pydantic==0.12.*
 tqdm>=4.23.0


### PR DESCRIPTION
*Issue #, if available:*

#54 

*Description of changes:*

The numpy version needs to be fixed to `1.14.*` because MXNet does not support versions 1.15.* or higher yet (fixes #54).

Also, align the contents of the requirements files with the Conda packages listed in the env folder that are used in the Jenkins pipelines.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
