### PR TITLE
fix forecast_start date computation for multivarite R forecasts.

### DIFF
--- a/src/gluonts/model/r_forecast/_predictor.py
+++ b/src/gluonts/model/r_forecast/_predictor.py
@@ -174,9 +174,9 @@ class RForecastPredictor(RepresentablePredictor):
             forecast_dict, console_output = self._run_r_forecast(
                 data, params, save_info=save_info
             )
-            forecast_start = pd.Timestamp(data['start'], freq=self.freq) + len(
-                data['target']
-            )
+            forecast_start = pd.Timestamp(data['start'], freq=self.freq) + \
+                data['target'].shape[0]
+
             samples = np.array(forecast_dict['samples'])
             expected_shape = (params['num_samples'], self.prediction_length)
             assert (


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Computes the number of sequential observations in the target using `shape[0]` instead of `len()` as the former is valid for multi-dimensional arrays as well. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
