### PR TITLE
Fix issue with generic type in BinnedOutput

### DIFF
--- a/src/gluonts/distribution/binned.py
+++ b/src/gluonts/distribution/binned.py
@@ -169,7 +169,7 @@ class BinnedOutput(DistributionOutput):
     distr_cls: type = Binned
 
     @validated()
-    def __init__(self, bin_centers: List) -> None:
+    def __init__(self, bin_centers: List[float]) -> None:
         # cannot pass directly nd.array because it is not serializable
         bc = mx.nd.array(bin_centers)
         assert len(bc.shape) == 1


### PR DESCRIPTION
*Issue #, if available:*

Fixes #62 and #67.

*Description of changes:*

List was used in a validated() constructor argument without element type, which trips up pydantic on some Python 3.7.x versions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
