### PR TITLE
Disable warnings-as-failure for doc builds on master

### DIFF
--- a/ci/jenkins/build_steps.groovy
+++ b/ci/jenkins/build_steps.groovy
@@ -105,7 +105,10 @@ def create_website(workspace_name, conda_env_name) {
 }
 
 def website_linkcheck(workspace_name, conda_env_name) {
-  enforce_linkcheck = env.BRANCH_NAME.startsWith('PR-')?'false':'true'
+  // TODO: re-enable to enforce no-WARNING doc builds on master
+  // enforce_linkcheck = env.BRANCH_NAME.startsWith('PR-')?'false':'true'
+  enforce_linkcheck = 'false'
+
   return ["${conda_env_name}: website link check'": {
     node(NODE_LINUX_CPU) {
       ws("workspace/${workspace_name}") {


### PR DESCRIPTION

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
