### PR TITLE
Add --no-dir-entries to zip file creation to prune empty directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ compile_notebooks:
 
 dist_notebooks: compile_notebooks
 	cd docs/examples && \
-	find * -type d -prune | grep -v 'tests\|__pycache__' | xargs -t -n 1 -I{} zip -r {}.zip {} -x "*.md" -x "__pycache__" -x "*.pyc" -x "*.txt" -x "*.log" -x "*.params" -x "*.npz" -x "*.json"
+	find * -type d -prune | grep -v 'tests\|__pycache__' | xargs -t -n 1 -I{} zip --no-dir-entries -r {}.zip {} -x "*.md" -x "__pycache__" -x "*.pyc" -x "*.txt" -x "*.log" -x "*.params" -x "*.npz" -x "*.json"
 
 release: dist_notebooks
 	python setup.py sdist


### PR DESCRIPTION
*Issue #, if available:*

Addresses #66 

*Description of changes:*

Disable the creating of directory entries in the zip file (which then omits empty directories as a side effect).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
