### PR TITLE
fix artificial dataset bug

### DIFF
--- a/src/gluonts/dataset/artificial/_base.py
+++ b/src/gluonts/dataset/artificial/_base.py
@@ -442,8 +442,8 @@ class ComplexSeasonalTimeSeries(ArtificialDataset):
             start_y = my_random.randint(2000, 2018)
             start_m = my_random.randint(1, 12)
             start_d = my_random.randint(1, 28)
-            start_h = my_random.randint(0, 24)
-            start_min = my_random.randint(0, 60)
+            start_h = my_random.randint(0, 23)
+            start_min = my_random.randint(0, 59)
         else:
             start_y, start_m, start_d = 2013, 11, 28
             start_h, start_min = 18, 36

--- a/src/gluonts/distribution/binned.py
+++ b/src/gluonts/distribution/binned.py
@@ -65,7 +65,7 @@ class Binned(Distribution):
         Returns
         -------
         Tensor
-            Tensor of shape (*gamma.shape, num_bins+1)
+            Tensor of shape (*batch.shape, num_bins+1)
         """
 
         low = (


### PR DESCRIPTION
Fix issue #82 

The hour and minute random values were out of bound since the `random.Random.randint(low, high)` gives samples with the limits inclusive (`numpy` does not). 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
