### PR TITLE
Use date_range to get rid of FutureWarnings from pandas

### DIFF
--- a/src/gluonts/dataset/artificial/_base.py
+++ b/src/gluonts/dataset/artificial/_base.py
@@ -523,7 +523,7 @@ class ComplexSeasonalTimeSeries(ArtificialDataset):
             if self.is_noise:
                 noise = D * state.normal(size=length)
             t = np.arange(length)
-            idx = pd.DatetimeIndex(
+            idx = pd.date_range(
                 start=start, freq=self.freq_str, periods=length
             )
             special_tp_indicator = self._special_time_point_indicator(idx)

--- a/src/gluonts/dataset/repository/_lstnet.py
+++ b/src/gluonts/dataset/repository/_lstnet.py
@@ -139,7 +139,7 @@ def generate_lstnet_dataset(dataset_path: Path, dataset_name: str):
     train_file = dataset_path / "train" / "data.json"
     test_file = dataset_path / "test" / "data.json"
 
-    time_index = pd.DatetimeIndex(
+    time_index = pd.date_range(
         start=ds_info.start_date,
         freq=ds_info.freq,
         periods=ds_info.num_time_steps,

--- a/src/gluonts/dataset/split/splitter.py
+++ b/src/gluonts/dataset/split/splitter.py
@@ -64,7 +64,7 @@ class TimeSeriesSlice(pydantic.BaseModel):
         if freq is None:
             freq = item.start.freq
 
-        index = pd.DatetimeIndex(
+        index = pd.date_range(
             start=item.start, freq=freq, periods=len(item.target)
         )
 

--- a/src/gluonts/dataset/util.py
+++ b/src/gluonts/dataset/util.py
@@ -81,5 +81,5 @@ def to_pandas(instance: dict, freq: str = None) -> pd.Series:
     start = instance['start']
     if not freq:
         freq = start.freqstr
-    index = pd.DatetimeIndex(start=start, periods=len(target), freq=freq)
+    index = pd.date_range(start=start, periods=len(target), freq=freq)
     return pd.Series(target, index=index)


### PR DESCRIPTION
*Description of changes:*
Using pd.DatetimeIndex for generating a time index as a date range is deprecated and it raises a FutureWarning with pandas 0.24.2. All relevant instances in the codebase are replaced with pandas.date_range function.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
