### PR TITLE
Added paper code examples as tests

### DIFF
--- a/test/paper_examples/test_axiv_paper_examples.py
+++ b/test/paper_examples/test_axiv_paper_examples.py
@@ -2,7 +2,7 @@
 from gluonts.dataset.artificial import constant_dataset
 
 
-def test_icml_example():
+def test_listing_1():
     """
     Test GluonTS paper examples from arxiv paper:
     https://arxiv.org/abs/1906.05264
@@ -37,7 +37,7 @@ def test_icml_example():
     )
 
 
-def test_arxiv_example():
+def test_appendix_c():
     """
     Test GluonTS paper examples from arxiv paper:
     https://arxiv.org/abs/1906.05264

--- a/test/paper_examples/test_paper_examples.py
+++ b/test/paper_examples/test_paper_examples.py
@@ -1,0 +1,169 @@
+# First-party imports
+from gluonts.dataset.artificial import constant_dataset
+
+
+def test_icml_example():
+    """
+    Test GluonTS paper examples from arxiv paper:
+    https://arxiv.org/abs/1906.05264
+
+    Listing 1
+    """
+    from gluonts.dataset.repository.datasets import get_dataset
+    from gluonts.model.deepar import DeepAREstimator
+    from gluonts.trainer import Trainer
+    from gluonts.evaluation import Evaluator
+    from gluonts.evaluation.backtest import backtest_metrics
+
+    # We use electricity in the paper but that would take too long to run in
+    # the unit test
+    dataset_info, train_ds, test_ds = constant_dataset()
+
+    meta = dataset_info.metadata
+
+    estimator = DeepAREstimator(
+        freq=meta.time_granularity,
+        prediction_length=1,
+        trainer=Trainer(epochs=1, batch_size=32),
+    )
+    predictor = estimator.train(train_ds)
+
+    evaluator = Evaluator(quantiles=(0.1, 0.5, 0.9))
+    agg_metrics, item_metrics = backtest_metrics(
+        train_dataset=train_ds,
+        test_dataset=test_ds,
+        forecaster=predictor,
+        evaluator=evaluator,
+    )
+
+
+def test_arxiv_example():
+    """
+    Test GluonTS paper examples from arxiv paper:
+    https://arxiv.org/abs/1906.05264
+
+    Appendix C
+    """
+    from typing import List
+    from mxnet import gluon
+    from gluonts.model.estimator import GluonEstimator
+    from gluonts.model.predictor import Predictor, RepresentableBlockPredictor
+    from gluonts.trainer import Trainer
+    from gluonts.transform import (
+        InstanceSplitter,
+        FieldName,
+        Transformation,
+        ExpectedNumInstanceSampler,
+    )
+    from gluonts.core.component import validated
+    from gluonts.support.util import copy_parameters
+
+    class MyTrainNetwork(gluon.HybridBlock):
+        def __init__(self, prediction_length, cells, act_type, **kwargs):
+            super().__init__(**kwargs)
+            self.prediction_length = prediction_length
+            with self.name_scope():
+                # Set up a network that predicts the target
+                self.nn = gluon.nn.HybridSequential()
+                for c in cells:
+                    self.nn.add(gluon.nn.Dense(units=c, activation=act_type))
+                    self.nn.add(
+                        gluon.nn.Dense(
+                            units=self.prediction_length, activation=act_type
+                        )
+                    )
+
+        def hybrid_forward(self, F, past_target, future_target):
+            prediction = self.nn(past_target)
+            # calculate L1 loss to learn the median
+            return (prediction - future_target).abs().mean(axis=-1)
+
+    class MyPredNetwork(MyTrainNetwork):
+        # The prediction network only receives
+        # past target and returns predictions
+        def hybrid_forward(self, F, past_target):
+            prediction = self.nn(past_target)
+            return prediction.expand_dims(axis=1)
+
+    class MyEstimator(GluonEstimator):
+        @validated()
+        def __init__(
+            self,
+            freq: str,
+            prediction_length: int,
+            act_type: str = "relu",
+            context_length: int = 30,
+            cells: List[int] = [40, 40, 40],
+            trainer: Trainer = Trainer(epochs=10),
+        ) -> None:
+            super().__init__(trainer=trainer)
+            self.freq = freq
+            self.prediction_length = prediction_length
+            self.act_type = act_type
+            self.context_length = context_length
+            self.cells = cells
+
+        def create_training_network(self) -> MyTrainNetwork:
+            return MyTrainNetwork(
+                prediction_length=self.prediction_length,
+                cells=self.cells,
+                act_type=self.act_type,
+            )
+
+        def create_predictor(
+            self,
+            transformation: Transformation,
+            trained_network: gluon.HybridBlock,
+        ) -> Predictor:
+            prediction_network = MyPredNetwork(
+                prediction_length=self.prediction_length,
+                cells=self.cells,
+                act_type=self.act_type,
+            )
+
+            copy_parameters(trained_network, prediction_network)
+
+            return RepresentableBlockPredictor(
+                input_transform=transformation,
+                prediction_net=prediction_network,
+                batch_size=self.trainer.batch_size,
+                freq=self.freq,
+                prediction_length=self.prediction_length,
+                ctx=self.trainer.ctx,
+            )
+
+        def create_transformation(self):
+            # Model specific input transform
+            # Here we use a transformation that randomly
+            # selects training samples from all series.
+            return InstanceSplitter(
+                target_field=FieldName.TARGET,
+                is_pad_field=FieldName.IS_PAD,
+                start_field=FieldName.START,
+                forecast_start_field=FieldName.FORECAST_START,
+                train_sampler=ExpectedNumInstanceSampler(num_instances=1),
+                past_length=self.context_length,
+                future_length=self.prediction_length,
+            )
+
+    from gluonts.trainer import Trainer
+    from gluonts.evaluation import Evaluator
+    from gluonts.evaluation.backtest import backtest_metrics
+
+    dataset_info, train_ds, test_ds = constant_dataset()
+
+    meta = dataset_info.metadata
+    estimator = MyEstimator(
+        freq=meta.time_granularity,
+        prediction_length=1,
+        trainer=Trainer(epochs=1, batch_size=32),
+    )
+    predictor = estimator.train(train_ds)
+
+    evaluator = Evaluator(quantiles=(0.1, 0.5, 0.9))
+    agg_metrics, item_metrics = backtest_metrics(
+        train_dataset=train_ds,
+        test_dataset=test_ds,
+        forecaster=predictor,
+        evaluator=evaluator,
+    )


### PR DESCRIPTION
Added paper code examples from the arxiv paper as tests. If these break, we need to update the arxiv paper code examples. One caveat is that the tests do not pull and run electricity because it takes too long. So if this line changes, the example would still break. But we should be able to catch a lot of other API changes this way. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
