### PR TITLE
Bump down `pytest-cov` and `pytest-xdist` versions

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
 flake8==3.4.*
 pytest==3.*
-pytest-cov==2.6.*
+pytest-cov==2.4.*
 pytest-runner<2.12
-pytest-xdist==1.27.*
+pytest-xdist==1.20.*
 pytest-timeout==1.2.*


### PR DESCRIPTION
*Issue #, if available:*

Reverts the versions of `pytest-cov` and `pytest-xdist` to older values (otherwise pytest fails if `pytest < 3.6`). 