### PR TITLE
Use `setuptools_scm` to set the project version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@
 .pytest_cache
 tags
 __pycache__
-**/gluonts/version*.py
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,9 +30,9 @@ sys.path.insert(0, os.path.join(curr_path, '..'))
 # -- General configuration ------------------------------------------------
 
 # Version information.
-import gluonts as ts
-version = ts.__version__
-release = ts.__version__
+from pkg_resources import get_distribution
+release = get_distribution('gluonts').version
+version = '.'.join(release.split('.')[:2]) # strip major.minor version only
 
 # General information about the project.
 project = 'GluonTS'

--- a/requirements-setup.txt
+++ b/requirements-setup.txt
@@ -1,6 +1,7 @@
 black==19.3b0
 click==6.*
 mypy==0.630
+notedown
 nbsphinx>=0.3.4,<0.4
 nbconvert
 pytest-runner==2.11.*
@@ -8,6 +9,7 @@ ipython
 ipykernel
 recommonmark
 setuptools>=40.1.0
+setuptools_scm>=3.2.0
 sphinx==1.7.*
 sphinx-autobuild==0.7.*
 sphinx_rtd_theme==0.4.*

--- a/src/gluonts/__init__.py
+++ b/src/gluonts/__init__.py
@@ -15,5 +15,11 @@
 
 from pkgutil import extend_path
 
-__version__ = '0.2.0dev'
+from pkg_resources import get_distribution, DistributionNotFound
+
 __path__ = extend_path(__path__, __name__)  # type: ignore
+
+try:
+    __version__ = get_distribution(__name__).version
+except DistributionNotFound:
+    pass  # package is not installed


### PR DESCRIPTION
*Issue #, if available:*

Derive the verion used in `gluonts.__version__` automatically from the latest tag along the parent chain.

See https://pypi.org/project/setuptools-scm/ for details.

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
