### PR TITLE
ignoring version.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,6 @@ conda
 
 # vscode
 .vscode
+
+# version.py
+src/gluonts/version.py


### PR DESCRIPTION
*Description of changes:* A `version.py` file is created in `src/gluonts` which should not be edited nor committed: this PR adds it to the `.gitignore. Otherwise I think it's easy to stage this by mistake (especially when committing changes to many files).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
