### PR TITLE
Align the `StyleCheckCommand` with the click 7.* API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,7 @@ class StyleCheckCommand(distutils.cmd.Command):
 
         # import here (after the setup_requires list is loaded),
         # otherwise a module-not-found error is thrown
+        import click
         import black
 
         black_opts = []
@@ -153,6 +154,8 @@ class StyleCheckCommand(distutils.cmd.Command):
             exit_code = black.main.invoke(ctx)
         except SystemExit as e:
             exit_code = e.code
+        except click.exceptions.Exit as e:
+            exit_code = e.exit_code
 
         if exit_code:
             error_msg = dedent(


### PR DESCRIPTION
*Issue #, if available:*

Fixes false negative caused by an uncaught Click error due to an API change between 6.* and 7.* versions.

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
