### PR TITLE
fix default context_length in mqdnn

### DIFF
--- a/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
+++ b/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
@@ -75,7 +75,7 @@ class MQCNNEstimator(MQDNNEstimator):
         self,
         prediction_length: int,
         freq: str,
-        context_length: Optional[int],
+        context_length: Optional[int] = None,
         # FIXME: prefix those so clients know that these are decoder params
         mlp_final_dim: int = 20,
         mlp_hidden_dimension_seq: List[int] = list(),
@@ -112,9 +112,9 @@ class MQRNNEstimator(MQDNNEstimator):
     @validated()
     def __init__(
         self,
-        context_length: int,
         prediction_length: int,
         freq: str,
+        context_length: Optional[int] = None,
         # FIXME: prefix those so clients know that these are decoder params
         mlp_final_dim: int = 20,
         mlp_hidden_dimension_seq: List[int] = list(),


### PR DESCRIPTION
*Description of changes:* The `context_length` was not an optional parameter in `MQRNNEstimator` and `MQCNNEstimator`. This PR defaults it to `None`, in which case in the base class `MQDNNEstimator` it takes the same value as `prediction_length`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
