### PR TITLE
Remove type- and style-checks from the build toolchain

### DIFF
--- a/ci/jenkins/Jenkinsfile_py3-master_cpu_unittest
+++ b/ci/jenkins/Jenkinsfile_py3-master_cpu_unittest
@@ -34,7 +34,7 @@ utils.assign_node_labels(linux_gpu: 'linux-gpu', linux_cpu: 'linux-cpu')
 utils.main_wrapper(
 core_logic: {
   utils.parallel_stage('Sanity', [
-    build_steps.sanity_lint('gluon-ts-cpu-py3', 'cpu/py3-master', 'src/gluonts')
+    build_steps.sanity_checks('gluon-ts-cpu-py3', 'cpu/py3-master', 'src/gluonts')
   ])
 
   utils.parallel_stage('Tests', [

--- a/ci/jenkins/Jenkinsfile_py3_cpu_unittest
+++ b/ci/jenkins/Jenkinsfile_py3_cpu_unittest
@@ -34,7 +34,7 @@ utils.assign_node_labels(linux_gpu: 'linux-gpu', linux_cpu: 'linux-cpu')
 utils.main_wrapper(
 core_logic: {
   utils.parallel_stage('Sanity', [
-    build_steps.sanity_lint('gluon-ts-cpu-py3', 'cpu/py3', 'src/gluonts')
+    build_steps.sanity_checks('gluon-ts-cpu-py3', 'cpu/py3', 'src/gluonts')
   ])
 
   utils.parallel_stage('Tests', [

--- a/ci/jenkins/build_steps.groovy
+++ b/ci/jenkins/build_steps.groovy
@@ -22,7 +22,7 @@
 
 utils = load('ci/jenkins/utils.groovy')
 
-def sanity_lint(workspace_name, conda_env_name, path) {
+def sanity_checks(workspace_name, conda_env_name, path) {
   return ['Lint': {
     node {
       ws("workspace/${workspace_name}") {
@@ -30,7 +30,8 @@ def sanity_lint(workspace_name, conda_env_name, path) {
         sh """
         set -ex
         source ci/prepare_clean_env.sh ${conda_env_name}
-        make lintdir=${path} lint
+        python setup.py style_check
+        python setup.py type_check
         set +ex
         """
       }

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,6 @@ from pathlib import Path
 from textwrap import dedent
 
 # Third-party imports
-import setuptools
-import setuptools.command.build_py
 from setuptools import find_namespace_packages, setup
 
 ROOT = Path(__file__).parent
@@ -180,15 +178,6 @@ class StyleCheckCommand(distutils.cmd.Command):
             sys.exit(exit_code)
 
 
-class BuildPyCommand(setuptools.command.build_py.build_py):
-    """Custom `build_py` command that preprends a `typecheck` call."""
-
-    def run(self):
-        self.run_command("type_check")
-        self.run_command("style_check")
-        setuptools.command.build_py.build_py.run(self)
-
-
 setup_kwargs: dict = dict(
     name="gluonts",
     use_scm_version=True,
@@ -222,14 +211,13 @@ setup_kwargs: dict = dict(
     },
     entry_points=dict(
         console_scripts=[
-            "gluonts-validate-dataset=gluonts.dataset.validate:run",
+            "gluonts-validate-dataset=gluonts.dataset.validate:run"
         ]
     ),
-    cmdclass=dict(
-        type_check=TypeCheckCommand,
-        style_check=StyleCheckCommand,
-        build_py=BuildPyCommand,
-    ),
+    cmdclass={
+        'type_check': TypeCheckCommand,
+        'style_check': StyleCheckCommand,
+    },
 )
 
 if HAS_SPHINX:


### PR DESCRIPTION
The checks are now performed by Jenkins.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
