### PR TITLE
Set `samples` in `as_json_dict` for all Forecast classes

### DIFF
--- a/src/gluonts/model/forecast.py
+++ b/src/gluonts/model/forecast.py
@@ -169,6 +169,9 @@ class Forecast:
                 self.quantile(q).tolist() for q in config.quantiles
             ]
 
+        if OutputType.samples in config.output_types:
+            result['samples'] = []
+
         return result
 
 


### PR DESCRIPTION
Set the empty list as a default value of `samples` in all Forecast classes.

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
