### PR TITLE
Fixed path requirements for shell serve.

### DIFF
--- a/src/gluonts/shell/__main__.py
+++ b/src/gluonts/shell/__main__.py
@@ -74,7 +74,7 @@ def cli() -> None:
 @cli.command(name='serve')
 @click.option(
     "--data-path",
-    type=click.Path(exists=True),
+    type=click.Path(),
     envvar="SAGEMAKER_DATA_PATH",
     default='/opt/ml',
     help='The root path of all folders mounted by the SageMaker runtime.',
@@ -107,11 +107,10 @@ def serve_command(
 ) -> None:
     from gluonts.shell import serve
 
-    env = ServeEnv(Path(data_path))
-
     if not force_static and forecaster is not None:
-        serve.run_inference_server(env, forecaster_type_by_name(forecaster))
+        serve.run_inference_server(None, forecaster_type_by_name(forecaster))
     else:
+        env = ServeEnv(Path(data_path))
         serve.run_inference_server(env, None)
 
 

--- a/src/gluonts/shell/serve/__init__.py
+++ b/src/gluonts/shell/serve/__init__.py
@@ -98,7 +98,8 @@ class Application(BaseApplication):
 
 
 def run_inference_server(
-    env: ServeEnv, forecaster_type: Optional[Type[Union[Estimator, Predictor]]]
+    env: Optional[ServeEnv],
+    forecaster_type: Optional[Type[Union[Estimator, Predictor]]],
 ) -> None:
     if forecaster_type is not None:
         ctor = forecaster_type.from_hyperparameters
@@ -107,6 +108,7 @@ def run_inference_server(
             return ctor(**request['configuration'])
 
     else:
+        assert env is not None
         predictor = Predictor.deserialize(env.path.model)
 
         def predictor_factory(request) -> Predictor:


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

When we use the dynamic forecaster, we don't require the `/opt/ml` path to exist.