### PR TITLE
fix readme links and tutorial titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ centered around the median (dark green line).
 The following are good entry-points to understand how to use
 many features of GluonTS:
 
-* [GluonTS Forecasting Tutorial](https://github.com/awslabs/gluon-ts/tree/master/docs/examples/forecasting/tutorial.md): a tutorial on forecasting.
+* [Quick Start Tutorial](https://github.com/awslabs/gluon-ts/tree/master/docs/examples/basic_forecasting_tutorial/tutorial.md): a quick start guide.
+* [Extended Forecasting Tutorial](https://github.com/awslabs/gluon-ts/tree/master/docs/examples/extended_forecasting_tutorial/extended_tutorial.md): a detailed tutorial on forecasting.
 * [evaluate_model.py](https://github.com/awslabs/gluon-ts/tree/master/examples/evaluate_model.py): how to train a model and compute evaluation metrics.
 * [benchmark_m4.py](https://github.com/awslabs/gluon-ts/tree/master/examples/benchmark_m4.py): how to evaluate and compare multiple models on multiple datasets.
 

--- a/docs/examples/basic_forecasting_tutorial/tutorial.md
+++ b/docs/examples/basic_forecasting_tutorial/tutorial.md
@@ -1,4 +1,4 @@
-# Time Series Forecasting
+# Quick Start Tutorial
 
 The GluonTS toolkit contains components and tools for building time series models using MXNet. The models that are currently included are forecasting models but the components also support other time series use cases, such as classification or anomaly detection.
 

--- a/docs/examples/extended_forecasting_tutorial/extended_tutorial.md
+++ b/docs/examples/extended_forecasting_tutorial/extended_tutorial.md
@@ -1,5 +1,5 @@
 
-# GluonTS <span style="color:orange"> Tutorial</span> 
+# Extended Forecasting Tutorial 
 
 ---
 > ## Table of contents


### PR DESCRIPTION
Fixed readme links to the tutorials since we changed the paths and changed the tutorial titles to be consistent in the website.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
