### PR TITLE
Exclude MXNet 1.5.* from allowed requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 boto3==1.*
 holidays==0.9.*
 matplotlib==3.*
-mxnet>=1.3.1
+mxnet>=1.3.1,<1.5.*
 numpy==1.14.*
 pandas>=0.22.0
 pydantic==0.28.*


### PR DESCRIPTION
Seems that GluonTS has an issue with the new MXNet version.

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
