### PR TITLE
Shell test infrastructure

### DIFF
--- a/src/gluonts/dataset/repository/datasets.py
+++ b/src/gluonts/dataset/repository/datasets.py
@@ -116,6 +116,7 @@ def materialize_dataset(
         f"{dataset_recipes.keys()}."
     )
 
+    path.mkdir(parents=True, exist_ok=True)
     dataset_path = path / dataset_name
 
     dataset_recipe = dataset_recipes[dataset_name]

--- a/src/gluonts/shell/testutil.py
+++ b/src/gluonts/shell/testutil.py
@@ -1,0 +1,167 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# Standard library imports
+import json
+import socket
+import tempfile
+import time
+from contextlib import closing, contextmanager
+from multiprocessing import Process
+from pathlib import Path
+from typing import Any, ContextManager, Dict, Optional, Type
+
+# First-party imports
+from gluonts.dataset.repository.datasets import materialize_dataset
+from gluonts.model.predictor import Predictor
+from gluonts.shell.sagemaker import ServeEnv, ServePaths, TrainEnv, TrainPaths
+from gluonts.shell.sagemaker.params import encode_sagemaker_parameters
+from gluonts.shell.serve import ServerFacade, Settings, make_gunicorn_app
+
+
+def free_port() -> int:
+    """Returns a random unbound port."""
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.bind(("", 0))
+        return sock.getsockname()[1]
+
+
+@contextmanager  # type: ignore
+def temporary_server(
+    env: Optional[ServeEnv],
+    forecaster_type: Optional[Type[Predictor]],
+    settings: Settings = Settings(),
+) -> ContextManager[ServerFacade]:
+    """
+    A context manager that instantiates a Gunicorn inference server in a
+    separate process (using the :func:`make_inference_server` call)
+
+    Parameters
+    ----------
+    env
+        The :class:`ServeEnv` to use in static inference mode.
+        Either `env` or `forecaster_type` must be set.
+    forecaster_type
+        The :class:`Predictor` type to use in dynamic inference mode.
+        Either `env` or `forecaster_type` must be set.
+    settings
+        Settings to use when instantiating the Gunicorn server.
+
+    Returns
+    -------
+    ContextManager[ServerFacade]
+        A context manager that yields the :class:`InferenceServer` instance
+        wrapping the spawned inference server.
+    """
+
+    gunicorn_app = make_gunicorn_app(env, forecaster_type, settings)
+    process = Process(target=gunicorn_app.run)
+    process.start()
+
+    endpoint = ServerFacade(
+        base_address="http://{address}:{port}".format(
+            address=settings.sagemaker_server_address,
+            port=settings.sagemaker_server_port,
+        )
+    )
+
+    # try to ping the server (signalling liveness)
+    # poll for n seconds in t second intervals
+    n, t = 10, 2
+    max_time = time.time() + n
+    while not endpoint.ping():
+        if time.time() < max_time:
+            time.sleep(t)
+        else:
+            msg = f"Failed to start the inference server within {n} seconds"
+            raise TimeoutError(msg)
+
+    yield endpoint
+
+    process.terminate()
+    process.join()
+
+
+@contextmanager  # type: ignore
+def temporary_train_env(
+    hyperparameters: Dict[str, Any], dataset_name: str
+) -> ContextManager[TrainEnv]:
+    """
+    A context manager that instantiates a training environment from a given
+    combination of `hyperparameters` and `dataset_name` in a temporary
+    directory and removes the directory on exit.
+
+    Parameters
+    ----------
+    hyperparameters
+        The name of the repository dataset to use when instantiating the
+        training environment.
+    dataset_name
+        The name of the repository dataset to use when instantiating the
+        training environment.
+
+    Returns
+    -------
+    ContextManager[TrainEnv]
+        A context manager that yields the :class:`TrainEnv` instance.
+    """
+
+    with tempfile.TemporaryDirectory(prefix="gluonts-train-env") as base:
+        paths = TrainPaths(base=Path(base))
+
+        # write hyperparameters
+        with paths.hyperparameters.open(mode="w") as fp:
+            hps_encoded = encode_sagemaker_parameters(hyperparameters)
+            json.dump(hps_encoded, fp, indent=2, sort_keys=True)
+
+        # save dataset
+        ds_path = materialize_dataset(dataset_name)
+
+        path_metadata = paths.data / "metadata" / "metadata.json"
+        path_train = paths.data / "train"
+        path_test = paths.data / "test"
+
+        path_metadata.parent.mkdir(exist_ok=True)
+
+        path_metadata.symlink_to(ds_path / "metadata.json")
+        path_train.symlink_to(ds_path / "train", target_is_directory=True)
+        path_test.symlink_to(ds_path / "test", target_is_directory=True)
+
+        yield TrainEnv(path=paths.base)
+
+
+@contextmanager  # type: ignore
+def temporary_serve_env(predictor: Predictor) -> ContextManager[ServeEnv]:
+    """
+    A context manager that instantiates a serve environment for a given
+    :class:`Predictor` in a temporary directory and removes the directory on
+    exit.
+
+    Parameters
+    ----------
+    predictor
+        A predictor to serialize in :class:`ServeEnv` `model` folder.
+
+    Returns
+    -------
+    ContextManager[TrainEnv]
+        A context manager that yields the :class:`ServeEnv` instance.
+    """
+
+    with tempfile.TemporaryDirectory(prefix="gluonts-serve-env") as base:
+        paths = ServePaths(base=Path(base))
+
+        # serialize model
+        predictor.serialize(paths.model)
+
+        yield ServeEnv(path=paths.base)

--- a/test/model/log.txt
+++ b/test/model/log.txt
@@ -1,6 +1,6 @@
 gluonts[train_dataset_stats]: DatasetStatistics(cats=[], integer_dataset=True, max_target=9.0, mean_abs_target=4.5, mean_target=4.5, mean_target_length=24.0, min_target=0.0, num_dynamic_feat=0, num_missing_values=0, num_time_observations=240, num_time_series=10, scale_histogram=gluonts.dataset.stat.ScaleHistogram(base=2.0, bin_counts={0: 1, 1: 2, 2: 4, 3: 3}, empty_target_count=0))
 gluonts[test_dataset_stats]: DatasetStatistics(cats=[], integer_dataset=True, max_target=9.0, mean_abs_target=4.5, mean_target=4.5, mean_target_length=30.0, min_target=0.0, num_dynamic_feat=0, num_missing_values=0, num_time_observations=300, num_time_series=10, scale_histogram=gluonts.dataset.stat.ScaleHistogram(base=2.0, bin_counts={0: 1, 1: 2, 2: 4, 3: 3}, empty_target_count=0))
-gluonts[estimator]: gluonts.model.testutil.MeanEstimator(freq="1H", num_samples=5, prediction_length=2)
+gluonts[estimator]: gluonts.model.testutil.MeanEstimator(freq="1H", num_eval_samples=5, prediction_length=2)
 gluonts[metric-MSE]: 8.25
 gluonts[metric-abs_error]: 50.0
 gluonts[metric-abs_target_sum]: 90.0

--- a/test/model/test_backtest.py
+++ b/test/model/test_backtest.py
@@ -37,7 +37,7 @@ root.setLevel(logging.DEBUG)
 def make_estimator(freq, prediction_length):
     # noinspection PyTypeChecker
     return MeanEstimator(
-        prediction_length=prediction_length, freq=freq, num_samples=5
+        prediction_length=prediction_length, freq=freq, num_eval_samples=5
     )
 
 

--- a/test/model/test_predictor.py
+++ b/test/model/test_predictor.py
@@ -61,7 +61,9 @@ def test_localizer():
         freq="1H",
     )
 
-    estimator = MeanEstimator(prediction_length=10, freq="1H", num_samples=50)
+    estimator = MeanEstimator(
+        prediction_length=10, freq="1H", num_eval_samples=50
+    )
 
     local_pred = Localizer(estimator=estimator)
     agg_metrics, _ = backtest_metrics(

--- a/test/shell/test_shell.py
+++ b/test/shell/test_shell.py
@@ -1,0 +1,163 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# Standard library imports
+from typing import ContextManager
+
+# Third-party imports
+import numpy as np
+import pytest
+
+# First-party imports
+from gluonts.core.component import equals
+from gluonts.model.testutil import MeanPredictor
+from gluonts.shell import testutil
+from gluonts.shell.sagemaker import ServeEnv, TrainEnv
+from gluonts.shell.serve import Settings
+from gluonts.shell.train import run_train_and_test
+
+context_length = 5
+prediction_length = 6
+num_eval_samples = 4
+
+
+@pytest.fixture(scope="function")  # type: ignore
+def train_env() -> ContextManager[TrainEnv]:
+    hyperparameters = {
+        "context_length": context_length,
+        "prediction_length": prediction_length,
+        "num_eval_samples": num_eval_samples,
+    }
+    with testutil.temporary_train_env(hyperparameters, "constant") as env:
+        yield env
+
+
+@pytest.fixture(scope="function")  # type: ignore
+def static_server(
+    train_env: TrainEnv
+) -> ContextManager[testutil.ServerFacade]:
+    predictor = MeanPredictor.from_hyperparameters(**train_env.hyperparameters)
+    predictor.serialize(train_env.path.model)
+
+    serve_env = ServeEnv(train_env.path.base)
+    settings = Settings(sagemaker_server_port=testutil.free_port())
+    with testutil.temporary_server(serve_env, None, settings) as server:
+        yield server
+
+
+@pytest.fixture(scope="function")  # type: ignore
+def dynamic_server(
+    train_env: TrainEnv
+) -> ContextManager[testutil.ServerFacade]:
+    settings = Settings(sagemaker_server_port=testutil.free_port())
+    with testutil.temporary_server(None, MeanPredictor, settings) as server:
+        yield server
+
+
+def test_train_shell(train_env: TrainEnv, caplog) -> None:
+    run_train_and_test(env=train_env, forecaster_type=MeanPredictor)
+
+    for _, _, line in caplog.record_tuples:
+        if "#test_score (local, QuantileLoss" in line:
+            assert line.endswith("0.0")
+        if "local, wQuantileLoss" in line:
+            assert line.endswith("0.0")
+        if "local, Coverage" in line:
+            assert line.endswith("0.0")
+        if "MASE" in line or "MSIS" in line:
+            assert line.endswith("nan")
+        if "abs_target_sum" in line:
+            assert line.endswith("270.0")
+
+
+def test_server_shell(
+    train_env: TrainEnv, static_server: testutil.ServerFacade, caplog
+) -> None:
+    execution_parameters = static_server.execution_parameters()
+
+    assert "BatchStrategy" in execution_parameters
+    assert "MaxConcurrentTransforms" in execution_parameters
+    assert "MaxPayloadInMB" in execution_parameters
+
+    assert execution_parameters["BatchStrategy"] == "SINGLE_RECORD"
+    assert execution_parameters["MaxPayloadInMB"] == 6
+
+    configuration = {
+        "num_eval_samples": 1,  # FIXME: this is ignored
+        "output_types": ["mean", "samples"],
+        "quantiles": [],
+    }
+
+    for entry in train_env.datasets["train"]:
+        forecast = static_server.invocations([entry], configuration)[0]
+
+        for output_type in configuration["output_types"]:
+            assert output_type in forecast
+
+        act_mean = np.array(forecast["mean"])
+        act_samples = np.array(forecast["samples"])
+
+        mean = np.mean(entry["target"])
+
+        exp_mean_shape = (prediction_length,)
+        exp_samples_shape = (num_eval_samples, prediction_length)
+
+        exp_mean = mean * np.ones(shape=(prediction_length,))
+        exp_samples = mean * np.ones(shape=exp_samples_shape)
+
+        assert exp_mean_shape == act_mean.shape
+        assert exp_samples_shape == act_samples.shape
+        assert equals(exp_mean, act_mean)
+        assert equals(exp_samples, act_samples)
+
+
+def test_dynamic_shell(
+    train_env: TrainEnv, dynamic_server: testutil.ServerFacade, caplog
+) -> None:
+    execution_parameters = dynamic_server.execution_parameters()
+
+    assert "BatchStrategy" in execution_parameters
+    assert "MaxConcurrentTransforms" in execution_parameters
+    assert "MaxPayloadInMB" in execution_parameters
+
+    assert execution_parameters["BatchStrategy"] == "SINGLE_RECORD"
+    assert execution_parameters["MaxPayloadInMB"] == 6
+
+    configuration = {
+        "num_eval_samples": 1,  # FIXME: this is ignored
+        "output_types": ["mean", "samples"],
+        "quantiles": [],
+        **train_env.hyperparameters,
+    }
+
+    for entry in train_env.datasets["train"]:
+        forecast = dynamic_server.invocations([entry], configuration)[0]
+
+        for output_type in configuration["output_types"]:
+            assert output_type in forecast
+
+        act_mean = np.array(forecast["mean"])
+        act_samples = np.array(forecast["samples"])
+
+        mean = np.mean(entry["target"])
+
+        exp_mean_shape = (prediction_length,)
+        exp_samples_shape = (num_eval_samples, prediction_length)
+
+        exp_mean = mean * np.ones(shape=(prediction_length,))
+        exp_samples = mean * np.ones(shape=exp_samples_shape)
+
+        assert exp_mean_shape == act_mean.shape
+        assert exp_samples_shape == act_samples.shape
+        assert equals(exp_mean, act_mean)
+        assert equals(exp_samples, act_samples)


### PR DESCRIPTION
*Description of changes:*

Provides support for writing integration tests of predictors and estimators working within workflow of a SageMaker shell, as well as a test module that uses a dummy `MeanPredictor` in order to tests the shell itself. 

I tried to split this readable commits, but the main point of the PR is the third one (i.e., the `test_shell` test module and the utility functions in the `shell.testutil` module).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
