### PR TITLE
Bump pandas version and remove timestamp workarounds

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,7 +3,7 @@ holidays==0.9.*
 matplotlib==3.*
 mxnet>=1.3.1,<1.5.*
 numpy==1.14.*
-pandas>=0.22.0
+pandas>=0.25.0
 pydantic==0.28.*
 tqdm>=4.23.0
 ujson>=1.35

--- a/src/gluonts/model/npts/_model.py
+++ b/src/gluonts/model/npts/_model.py
@@ -168,11 +168,7 @@ class NPTS:
         # of the prediction range, and the frequency of the time series.
         samples_pred_range = samples[:, train_length:]  # prediction range only
 
-        # For freq M and W pandas seems to lose the freq of the timestamp,
-        # so we explicitly set it.
-        forecast_start = pd.Timestamp(
-            targets.index[-1] + 1 * targets.index.freq, freq=targets.index.freq
-        )
+        forecast_start = targets.index[-1] + 1 * targets.index.freq
 
         return SampleForecast(
             samples=samples_pred_range,

--- a/src/gluonts/transform.py
+++ b/src/gluonts/transform.py
@@ -104,9 +104,6 @@ def _shift_timestamp_helper(
         # bounds values over year 9999 raise a ValueError
         # values over 2262-04-11 raise a pandas OutOfBoundsDatetime
         result = ts + offset * ts.freq
-        # For freq M and W pandas seems to lose the freq of the timestamp,
-        # so we explicitly set it.
-        return pd.Timestamp(result, freq=ts.freq)
     except (ValueError, pd._libs.OutOfBoundsDatetime) as ex:
         raise GluonTSDateBoundsError(ex)
 

--- a/src/gluonts/transform.py
+++ b/src/gluonts/transform.py
@@ -103,7 +103,7 @@ def _shift_timestamp_helper(
         # this line looks innocent, but can create a date which is out of
         # bounds values over year 9999 raise a ValueError
         # values over 2262-04-11 raise a pandas OutOfBoundsDatetime
-        result = ts + offset * ts.freq
+        return ts + offset * ts.freq
     except (ValueError, pd._libs.OutOfBoundsDatetime) as ex:
         raise GluonTSDateBoundsError(ex)
 


### PR DESCRIPTION
*Issue #, if available:* #177 

*Description of changes:* Pandas 0.25.0 was released, which fixes an issues with timestamp frequencies in the case of "W" and "M" frequency. This PR removes related workarounds. See [here](https://github.com/pandas-dev/pandas/blob/e95d2dd2201d67307ebc236a6006a3428b7eead8/pandas/tests/scalar/timestamp/test_arithmetic.py#L101-L130) for related tests in the 0.25.x branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
