### PR TITLE
Fix num_eval_samples

### DIFF
--- a/src/gluonts/model/deepar/_estimator.py
+++ b/src/gluonts/model/deepar/_estimator.py
@@ -80,9 +80,6 @@ class DeepAREstimator(GluonEstimator):
     cell_type
         Type of recurrent cells to use (available: 'lstm' or 'gru';
         default: 'lstm')
-    num_eval_samples
-        Number of samples paths to draw when computing predictions
-        (default: 100)
     dropout_rate
         Dropout regularization parameter (default: 0.1)
     use_feat_dynamic_real
@@ -109,6 +106,9 @@ class DeepAREstimator(GluonEstimator):
     time_features
         Time features to use as inputs of the RNN (default: None, in which
         case these are automatically determined based on freq)
+    _num_eval_samples_per_ts
+        Number of evaluation samples per time series to increase parallelism during inference
+        (default: 100)
     """
 
     @validated()
@@ -121,7 +121,6 @@ class DeepAREstimator(GluonEstimator):
         num_layers: int = 2,
         num_cells: int = 40,
         cell_type: str = "lstm",
-        num_eval_samples: int = 100,
         dropout_rate: float = 0.1,
         use_feat_dynamic_real: bool = False,
         use_feat_static_cat: bool = False,
@@ -131,6 +130,7 @@ class DeepAREstimator(GluonEstimator):
         scaling: bool = True,
         lags_seq: Optional[List[int]] = None,
         time_features: Optional[List[TimeFeature]] = None,
+        _num_eval_samples_per_ts: int = 100,
     ) -> None:
         super().__init__(trainer=trainer)
 
@@ -142,9 +142,6 @@ class DeepAREstimator(GluonEstimator):
         ), "The value of `context_length` should be > 0"
         assert num_layers > 0, "The value of `num_layers` should be > 0"
         assert num_cells > 0, "The value of `num_cells` should be > 0"
-        assert (
-            num_eval_samples > 0
-        ), "The value of `num_eval_samples` should be > 0"
         assert dropout_rate >= 0, "The value of `dropout_rate` should be >= 0"
         assert (
             cardinality is not None or not use_feat_static_cat
@@ -155,6 +152,9 @@ class DeepAREstimator(GluonEstimator):
         assert (
             embedding_dimension > 0
         ), "The value of `embedding_dimension` should be > 0"
+        assert (
+            _num_eval_samples_per_ts > 0
+        ), "The value of `_num_eval_samples_per_ts` should be > 0"
 
         self.freq = freq
         self.context_length = (
@@ -165,7 +165,6 @@ class DeepAREstimator(GluonEstimator):
         self.num_layers = num_layers
         self.num_cells = num_cells
         self.cell_type = cell_type
-        self.num_sample_paths = num_eval_samples
         self.dropout_rate = dropout_rate
         self.use_feat_dynamic_real = use_feat_dynamic_real
         self.use_feat_static_cat = use_feat_static_cat
@@ -184,6 +183,8 @@ class DeepAREstimator(GluonEstimator):
         )
 
         self.history_length = self.context_length + max(self.lags_seq)
+
+        self._num_eval_samples_per_ts = _num_eval_samples_per_ts
 
     def create_transformation(self) -> Transformation:
         remove_field_names = [
@@ -269,7 +270,7 @@ class DeepAREstimator(GluonEstimator):
         self, transformation: Transformation, trained_network: HybridBlock
     ) -> Predictor:
         prediction_network = DeepARPredictionNetwork(
-            num_sample_paths=self.num_sample_paths,
+            _num_eval_samples_per_ts=self._num_eval_samples_per_ts,
             num_layers=self.num_layers,
             num_cells=self.num_cells,
             cell_type=self.cell_type,

--- a/src/gluonts/model/deepar/_network.py
+++ b/src/gluonts/model/deepar/_network.py
@@ -412,9 +412,9 @@ class DeepARTrainingNetwork(DeepARNetwork):
 
 class DeepARPredictionNetwork(DeepARNetwork):
     @validated()
-    def __init__(self, _num_eval_samples_per_ts: int = 100, **kwargs) -> None:
+    def __init__(self, num_parallel_samples: int = 100, **kwargs) -> None:
         super().__init__(**kwargs)
-        self._num_eval_samples_per_ts = _num_eval_samples_per_ts
+        self.num_parallel_samples = num_parallel_samples
 
         # for decoding the lags are shifted by one,
         # at the first time-step of the decoder a lag of one corresponds to the last target value
@@ -450,21 +450,21 @@ class DeepARPredictionNetwork(DeepARNetwork):
             a tensor containing sampled paths. Shape: (batch_size, num_sample_paths, prediction_length).
         """
 
-        # blows-up the dimension of each tensor to batch_size * self._num_eval_samples_per_ts for increasing parallelism
+        # blows-up the dimension of each tensor to batch_size * self.num_parallel_samples for increasing parallelism
         repeated_past_target = past_target.repeat(
-            repeats=self._num_eval_samples_per_ts, axis=0
+            repeats=self.num_parallel_samples, axis=0
         )
         repeated_time_feat = time_feat.repeat(
-            repeats=self._num_eval_samples_per_ts, axis=0
+            repeats=self.num_parallel_samples, axis=0
         )
         repeated_static_feat = static_feat.repeat(
-            repeats=self._num_eval_samples_per_ts, axis=0
+            repeats=self.num_parallel_samples, axis=0
         ).expand_dims(axis=1)
         repeated_scale = scale.repeat(
-            repeats=self._num_eval_samples_per_ts, axis=0
+            repeats=self.num_parallel_samples, axis=0
         )
         repeated_states = [
-            s.repeat(repeats=self._num_eval_samples_per_ts, axis=0)
+            s.repeat(repeats=self.num_parallel_samples, axis=0)
             for s in begin_states
         ]
 
@@ -533,7 +533,7 @@ class DeepARPredictionNetwork(DeepARNetwork):
         # (batch_size, num_samples, *target_shape, prediction_length)
         return samples.reshape(
             shape=(
-                (-1, self._num_eval_samples_per_ts)
+                (-1, self.num_parallel_samples)
                 + self.target_shape
                 + (self.prediction_length,)
             )

--- a/src/gluonts/model/gp_forecaster/_estimator.py
+++ b/src/gluonts/model/gp_forecaster/_estimator.py
@@ -77,8 +77,6 @@ class GaussianProcessEstimator(GluonEstimator):
         Trainer instance to be used for model training.
     context_length
         Training length.
-    num_eval_samples
-        Number of samples to be drawn.
     kernel_output
         KernelOutput instance to determine which kernel subclass to be
         instantiated.
@@ -95,6 +93,9 @@ class GaussianProcessEstimator(GluonEstimator):
     time_features
         Time features to use as inputs of the model (default: None, in which
         case these are automatically determined based on the frequency.)
+    _num_eval_samples_per_ts
+        Number of evaluation samples per time series to increase parallelism during inference
+        (default: 100)
     """
 
     @validated()
@@ -105,7 +106,6 @@ class GaussianProcessEstimator(GluonEstimator):
         cardinality: int,
         trainer: Trainer = Trainer(),
         context_length: Optional[int] = None,
-        num_eval_samples: int = 100,
         kernel_output: KernelOutput = RBFKernelOutput(),
         params_scaling: bool = True,
         float_type: DType = np.float64,
@@ -113,6 +113,7 @@ class GaussianProcessEstimator(GluonEstimator):
         jitter_method: str = "iter",
         sample_noise: bool = True,
         time_features: Optional[List[TimeFeature]] = None,
+        _num_eval_samples_per_ts: int = 100,
     ) -> None:
         self.float_type = float_type
         super().__init__(trainer=trainer, float_type=self.float_type)
@@ -125,8 +126,8 @@ class GaussianProcessEstimator(GluonEstimator):
             context_length is None or context_length > 0
         ), "The value of `context_length` should be > 0"
         assert (
-            num_eval_samples > 0
-        ), "The value of `num_eval_samples` should be > 0"
+            _num_eval_samples_per_ts > 0
+        ), "The value of `_num_eval_samples_per_ts` should be > 0"
 
         self.freq = freq
         self.prediction_length = prediction_length
@@ -134,7 +135,6 @@ class GaussianProcessEstimator(GluonEstimator):
             context_length if context_length is not None else prediction_length
         )
         self.cardinality = cardinality
-        self.num_eval_samples = num_eval_samples
         self.kernel_output = kernel_output
         self.params_scaling = params_scaling
         self.max_iter_jitter = max_iter_jitter
@@ -145,6 +145,7 @@ class GaussianProcessEstimator(GluonEstimator):
             if time_features is not None
             else time_features_from_frequency_str(self.freq)
         )
+        self._num_eval_samples_per_ts = _num_eval_samples_per_ts
 
     def create_transformation(self) -> Transformation:
         return Chain(
@@ -197,7 +198,7 @@ class GaussianProcessEstimator(GluonEstimator):
             prediction_length=self.prediction_length,
             context_length=self.context_length,
             cardinality=self.cardinality,
-            num_samples=self.num_eval_samples,
+            num_samples=self._num_eval_samples_per_ts,
             params=trained_network.collect_params(),
             kernel_output=self.kernel_output,
             params_scaling=self.params_scaling,

--- a/src/gluonts/model/npts/_predictor.py
+++ b/src/gluonts/model/npts/_predictor.py
@@ -152,8 +152,9 @@ class NPTSPredictor(RepresentablePredictor):
     feature_scale
         scale for time (seasonal) features in order to sample past seasons
         with higher probability
-    _num_eval_samples_per_ts
-        Number of evaluation samples per time series
+    num_parallel_samples
+        Number of evaluation samples per time series to increase parallelism during inference.
+        This is a model optimization that does not affect the accuracy
     """
 
     @validated()
@@ -168,11 +169,11 @@ class NPTSPredictor(RepresentablePredictor):
         use_default_time_features: bool = True,
         num_default_time_features: int = 1,
         feature_scale: float = 1000.0,
-        _num_eval_samples_per_ts: int = 100,
+        num_parallel_samples: int = 100,
     ) -> None:
         self.prediction_length = prediction_length
         self.freq = freq
-        self._num_eval_samples_per_ts = _num_eval_samples_per_ts
+        self.num_parallel_samples = num_parallel_samples
         # Similar to lag upper bound in AR2N2 we limit the context length to
         # some maximum value instead of looking at the whole history which
         # might be too large.
@@ -278,7 +279,7 @@ class NPTSPredictor(RepresentablePredictor):
             ts,
             self.prediction_length,
             sampling_weights_iterator,
-            self._num_eval_samples_per_ts,
+            self.num_parallel_samples,
         )
 
         return forecast

--- a/src/gluonts/model/npts/_predictor.py
+++ b/src/gluonts/model/npts/_predictor.py
@@ -152,8 +152,8 @@ class NPTSPredictor(RepresentablePredictor):
     feature_scale
         scale for time (seasonal) features in order to sample past seasons
         with higher probability
-    num_eval_samples
-        number of prediction samples required
+    _num_eval_samples_per_ts
+        Number of evaluation samples per time series
     """
 
     @validated()
@@ -167,12 +167,12 @@ class NPTSPredictor(RepresentablePredictor):
         use_seasonal_model: bool = True,
         use_default_time_features: bool = True,
         num_default_time_features: int = 1,
-        num_eval_samples: int = 100,
         feature_scale: float = 1000.0,
+        _num_eval_samples_per_ts: int = 100,
     ) -> None:
         self.prediction_length = prediction_length
         self.freq = freq
-        self.num_eval_samples = num_eval_samples
+        self._num_eval_samples_per_ts = _num_eval_samples_per_ts
         # Similar to lag upper bound in AR2N2 we limit the context length to
         # some maximum value instead of looking at the whole history which
         # might be too large.
@@ -278,7 +278,7 @@ class NPTSPredictor(RepresentablePredictor):
             ts,
             self.prediction_length,
             sampling_weights_iterator,
-            self.num_eval_samples,
+            self._num_eval_samples_per_ts,
         )
 
         return forecast

--- a/src/gluonts/model/seq2seq/_seq2seq_estimator.py
+++ b/src/gluonts/model/seq2seq/_seq2seq_estimator.py
@@ -63,7 +63,7 @@ class Seq2SeqEstimator(GluonEstimator):
         context_length: Optional[int] = None,
         quantiles: List[float] = [0.1, 0.5, 0.9],
         trainer: Trainer = Trainer(),
-        _num_eval_samples_per_ts: int = 100,
+        num_parallel_samples: int = 100,
     ) -> None:
         assert (
             prediction_length > 0
@@ -88,7 +88,7 @@ class Seq2SeqEstimator(GluonEstimator):
             cardinalities=cardinality,
             embedding_dims=[embedding_dimension for _ in cardinality],
         )
-        self._num_eval_samples_per_ts = _num_eval_samples_per_ts
+        self.num_parallel_samples = num_parallel_samples
 
     def create_transformation(self) -> transform.Transformation:
         return transform.Chain(
@@ -195,7 +195,7 @@ class MLP2QRForecaster(Seq2SeqEstimator):
         context_length: Optional[int] = None,
         quantiles: List[float] = list([0.1, 0.5, 0.9]),
         trainer: Trainer = Trainer(),
-        _num_eval_samples_per_ts: int = 100,
+        num_parallel_samples: int = 100,
     ) -> None:
         encoder = MLPEncoder(layer_sizes=encoder_mlp_layer)
         super(MLP2QRForecaster, self).__init__(
@@ -210,7 +210,7 @@ class MLP2QRForecaster(Seq2SeqEstimator):
             scaler=scaler,
             quantiles=quantiles,
             trainer=trainer,
-            _num_eval_samples_per_ts=_num_eval_samples_per_ts,
+            num_parallel_samples=num_parallel_samples,
         )
 
 
@@ -232,7 +232,7 @@ class RNN2QRForecaster(Seq2SeqEstimator):
         context_length: Optional[int] = None,
         quantiles: List[float] = list([0.1, 0.5, 0.9]),
         trainer: Trainer = Trainer(),
-        _num_eval_samples_per_ts: int = 100,
+        num_parallel_samples: int = 100,
     ) -> None:
         encoder = RNNCovariateEncoder(
             mode=encoder_rnn_model,
@@ -252,7 +252,7 @@ class RNN2QRForecaster(Seq2SeqEstimator):
             scaler=scaler,
             quantiles=quantiles,
             trainer=trainer,
-            _num_eval_samples_per_ts=_num_eval_samples_per_ts,
+            num_parallel_samples=num_parallel_samples,
         )
 
 
@@ -270,7 +270,7 @@ class CNN2QRForecaster(Seq2SeqEstimator):
         context_length: Optional[int] = None,
         quantiles: List[float] = list([0.1, 0.5, 0.9]),
         trainer: Trainer = Trainer(),
-        _num_eval_samples_per_ts: int = 100,
+        num_parallel_samples: int = 100,
     ) -> None:
         encoder = HierarchicalCausalConv1DEncoder(
             dilation_seq=[1, 3, 9],
@@ -292,5 +292,5 @@ class CNN2QRForecaster(Seq2SeqEstimator):
             scaler=scaler,
             quantiles=quantiles,
             trainer=trainer,
-            _num_eval_samples_per_ts=_num_eval_samples_per_ts,
+            num_parallel_samples=num_parallel_samples,
         )

--- a/src/gluonts/model/seq2seq/_seq2seq_estimator.py
+++ b/src/gluonts/model/seq2seq/_seq2seq_estimator.py
@@ -61,9 +61,9 @@ class Seq2SeqEstimator(GluonEstimator):
         decoder_mlp_static_dim: int,
         scaler: Scaler = NOPScaler(),
         context_length: Optional[int] = None,
-        num_eval_samples: int = 100,
         quantiles: List[float] = [0.1, 0.5, 0.9],
         trainer: Trainer = Trainer(),
+        _num_eval_samples_per_ts: int = 100,
     ) -> None:
         assert (
             prediction_length > 0
@@ -74,7 +74,6 @@ class Seq2SeqEstimator(GluonEstimator):
 
         super().__init__(trainer=trainer)
 
-        self.num_eval_samples = num_eval_samples
         self.context_length = (
             context_length if context_length is not None else prediction_length
         )
@@ -89,6 +88,7 @@ class Seq2SeqEstimator(GluonEstimator):
             cardinalities=cardinality,
             embedding_dims=[embedding_dimension for _ in cardinality],
         )
+        self._num_eval_samples_per_ts = _num_eval_samples_per_ts
 
     def create_transformation(self) -> transform.Transformation:
         return transform.Chain(
@@ -193,9 +193,9 @@ class MLP2QRForecaster(Seq2SeqEstimator):
         decoder_mlp_static_dim: int,
         scaler: Scaler = NOPScaler,
         context_length: Optional[int] = None,
-        num_eval_samples: int = 100,
         quantiles: List[float] = list([0.1, 0.5, 0.9]),
         trainer: Trainer = Trainer(),
+        _num_eval_samples_per_ts: int = 100,
     ) -> None:
         encoder = MLPEncoder(layer_sizes=encoder_mlp_layer)
         super(MLP2QRForecaster, self).__init__(
@@ -208,9 +208,9 @@ class MLP2QRForecaster(Seq2SeqEstimator):
             decoder_mlp_static_dim=decoder_mlp_static_dim,
             context_length=context_length,
             scaler=scaler,
-            num_eval_samples=num_eval_samples,
             quantiles=quantiles,
             trainer=trainer,
+            _num_eval_samples_per_ts=_num_eval_samples_per_ts,
         )
 
 
@@ -230,9 +230,9 @@ class RNN2QRForecaster(Seq2SeqEstimator):
         encoder_rnn_bidirectional: bool = True,
         scaler: Scaler = NOPScaler,
         context_length: Optional[int] = None,
-        num_eval_samples: int = 100,
         quantiles: List[float] = list([0.1, 0.5, 0.9]),
         trainer: Trainer = Trainer(),
+        _num_eval_samples_per_ts: int = 100,
     ) -> None:
         encoder = RNNCovariateEncoder(
             mode=encoder_rnn_model,
@@ -250,9 +250,9 @@ class RNN2QRForecaster(Seq2SeqEstimator):
             decoder_mlp_static_dim=decoder_mlp_static_dim,
             context_length=context_length,
             scaler=scaler,
-            num_eval_samples=num_eval_samples,
             quantiles=quantiles,
             trainer=trainer,
+            _num_eval_samples_per_ts=_num_eval_samples_per_ts,
         )
 
 
@@ -268,9 +268,9 @@ class CNN2QRForecaster(Seq2SeqEstimator):
         decoder_mlp_static_dim: int,
         scaler: Scaler = NOPScaler,
         context_length: Optional[int] = None,
-        num_eval_samples: int = 100,
         quantiles: List[float] = list([0.1, 0.5, 0.9]),
         trainer: Trainer = Trainer(),
+        _num_eval_samples_per_ts: int = 100,
     ) -> None:
         encoder = HierarchicalCausalConv1DEncoder(
             dilation_seq=[1, 3, 9],
@@ -290,7 +290,7 @@ class CNN2QRForecaster(Seq2SeqEstimator):
             decoder_mlp_static_dim=decoder_mlp_static_dim,
             context_length=context_length,
             scaler=scaler,
-            num_eval_samples=num_eval_samples,
             quantiles=quantiles,
             trainer=trainer,
+            _num_eval_samples_per_ts=_num_eval_samples_per_ts,
         )

--- a/src/gluonts/model/simple_feedforward/_estimator.py
+++ b/src/gluonts/model/simple_feedforward/_estimator.py
@@ -69,24 +69,26 @@ class SimpleFeedForwardEstimator(GluonEstimator):
     Parameters
     ----------
     freq
-        Time time granularity of the data.
+        Time time granularity of the data
     prediction_length
-        Number of time units to predict.
+        Length of the prediction horizon
     trainer
-        The Trainer instance to be used for model training.
+        Trainer object to be used (default: Trainer())
     num_hidden_dimensions
-        Number of hidden nodes in each layer.
+        Number of hidden nodes in each layer (default: [40, 40])
     context_length
-        Number of time units that condition the predictions.
+        Number of time units that condition the predictions
+        (default: None, in which case context_length = prediction_length)
     distr_output
-        Distribution to fit.
+        Distribution to fit (default: StudentTOutput())
     batch_normalization
-        Whether to use batch normalization.
+        Whether to use batch normalization (default: False)
     mean_scaling
         Scale the network input by the data mean and the network output by
-        its inverse.
-    num_eval_samples
-        Number of samples drawn for evaluations.
+        its inverse (default: True)
+    _num_eval_samples_per_ts
+        Number of evaluation samples per time series to increase parallelism during inference
+        (default: 100)
     """
 
     # The validated() decorator makes sure that parameters are checked by
@@ -104,7 +106,7 @@ class SimpleFeedForwardEstimator(GluonEstimator):
         distr_output: DistributionOutput = StudentTOutput(),
         batch_normalization: bool = False,
         mean_scaling: bool = True,
-        num_eval_samples: int = 100,
+        _num_eval_samples_per_ts: int = 100,
     ) -> None:
         """
         Defines an estimator. All parameters should be serializable.
@@ -121,7 +123,7 @@ class SimpleFeedForwardEstimator(GluonEstimator):
             [d > 0 for d in num_hidden_dimensions]
         ), "Elements of `num_hidden_dimensions` should be > 0"
         assert (
-            num_eval_samples > 0
+            _num_eval_samples_per_ts > 0
         ), "The value of `num_eval_samples` should be > 0"
 
         self.num_hidden_dimensions = num_hidden_dimensions
@@ -132,8 +134,8 @@ class SimpleFeedForwardEstimator(GluonEstimator):
         self.freq = freq
         self.distr_output = distr_output
         self.batch_normalization = batch_normalization
-        self.num_sample_paths = num_eval_samples
         self.mean_scaling = mean_scaling
+        self._num_eval_samples_per_ts = _num_eval_samples_per_ts
 
     # here we do only a simple operation to convert the input data to a form
     # that can be digested by our model by only splitting the target in two, a
@@ -182,8 +184,8 @@ class SimpleFeedForwardEstimator(GluonEstimator):
             distr_output=self.distr_output,
             batch_normalization=self.batch_normalization,
             mean_scaling=self.mean_scaling,
-            num_sample_paths=self.num_sample_paths,
             params=trained_network.collect_params(),
+            _num_eval_samples_per_ts=self._num_eval_samples_per_ts,
         )
 
         return RepresentableBlockPredictor(

--- a/src/gluonts/model/simple_feedforward/_estimator.py
+++ b/src/gluonts/model/simple_feedforward/_estimator.py
@@ -86,9 +86,9 @@ class SimpleFeedForwardEstimator(GluonEstimator):
     mean_scaling
         Scale the network input by the data mean and the network output by
         its inverse (default: True)
-    _num_eval_samples_per_ts
-        Number of evaluation samples per time series to increase parallelism during inference
-        (default: 100)
+    num_parallel_samples
+        Number of evaluation samples per time series to increase parallelism during inference.
+        This is a model optimization that does not affect the accuracy (default: 100)
     """
 
     # The validated() decorator makes sure that parameters are checked by
@@ -106,7 +106,7 @@ class SimpleFeedForwardEstimator(GluonEstimator):
         distr_output: DistributionOutput = StudentTOutput(),
         batch_normalization: bool = False,
         mean_scaling: bool = True,
-        _num_eval_samples_per_ts: int = 100,
+        num_parallel_samples: int = 100,
     ) -> None:
         """
         Defines an estimator. All parameters should be serializable.
@@ -123,8 +123,8 @@ class SimpleFeedForwardEstimator(GluonEstimator):
             [d > 0 for d in num_hidden_dimensions]
         ), "Elements of `num_hidden_dimensions` should be > 0"
         assert (
-            _num_eval_samples_per_ts > 0
-        ), "The value of `num_eval_samples` should be > 0"
+            num_parallel_samples > 0
+        ), "The value of `num_parallel_samples` should be > 0"
 
         self.num_hidden_dimensions = num_hidden_dimensions
         self.prediction_length = prediction_length
@@ -135,7 +135,7 @@ class SimpleFeedForwardEstimator(GluonEstimator):
         self.distr_output = distr_output
         self.batch_normalization = batch_normalization
         self.mean_scaling = mean_scaling
-        self._num_eval_samples_per_ts = _num_eval_samples_per_ts
+        self.num_parallel_samples = num_parallel_samples
 
     # here we do only a simple operation to convert the input data to a form
     # that can be digested by our model by only splitting the target in two, a
@@ -185,7 +185,7 @@ class SimpleFeedForwardEstimator(GluonEstimator):
             batch_normalization=self.batch_normalization,
             mean_scaling=self.mean_scaling,
             params=trained_network.collect_params(),
-            _num_eval_samples_per_ts=self._num_eval_samples_per_ts,
+            num_parallel_samples=self.num_parallel_samples,
         )
 
         return RepresentableBlockPredictor(

--- a/src/gluonts/model/simple_feedforward/_network.py
+++ b/src/gluonts/model/simple_feedforward/_network.py
@@ -158,10 +158,10 @@ class SimpleFeedForwardTrainingNetwork(SimpleFeedForwardNetworkBase):
 class SimpleFeedForwardPredictionNetwork(SimpleFeedForwardNetworkBase):
     @validated()
     def __init__(
-        self, _num_eval_samples_per_ts: int = 100, *args, **kwargs
+        self, num_parallel_samples: int = 100, *args, **kwargs
     ) -> None:
         super().__init__(*args, **kwargs)
-        self._num_eval_samples_per_ts = _num_eval_samples_per_ts
+        self.num_parallel_samples = num_parallel_samples
 
     # noinspection PyMethodOverriding,PyPep8Naming
     def hybrid_forward(self, F, past_target: Tensor) -> Tensor:
@@ -184,7 +184,7 @@ class SimpleFeedForwardPredictionNetwork(SimpleFeedForwardNetworkBase):
         distr = self.get_distr(F, past_target)
 
         # (num_samples, batch_size, prediction_length)
-        samples = distr.sample(self._num_eval_samples_per_ts)
+        samples = distr.sample(self.num_parallel_samples)
 
         # (batch_size, num_samples, prediction_length)
         return samples.swapaxes(0, 1)

--- a/src/gluonts/model/simple_feedforward/_network.py
+++ b/src/gluonts/model/simple_feedforward/_network.py
@@ -157,9 +157,11 @@ class SimpleFeedForwardTrainingNetwork(SimpleFeedForwardNetworkBase):
 
 class SimpleFeedForwardPredictionNetwork(SimpleFeedForwardNetworkBase):
     @validated()
-    def __init__(self, num_sample_paths: int, *args, **kwargs) -> None:
+    def __init__(
+        self, _num_eval_samples_per_ts: int = 100, *args, **kwargs
+    ) -> None:
         super().__init__(*args, **kwargs)
-        self.num_sample_paths = num_sample_paths
+        self._num_eval_samples_per_ts = _num_eval_samples_per_ts
 
     # noinspection PyMethodOverriding,PyPep8Naming
     def hybrid_forward(self, F, past_target: Tensor) -> Tensor:
@@ -182,7 +184,7 @@ class SimpleFeedForwardPredictionNetwork(SimpleFeedForwardNetworkBase):
         distr = self.get_distr(F, past_target)
 
         # (num_samples, batch_size, prediction_length)
-        samples = distr.sample(self.num_sample_paths)
+        samples = distr.sample(self._num_eval_samples_per_ts)
 
         # (batch_size, num_samples, prediction_length)
         return samples.swapaxes(0, 1)

--- a/src/gluonts/model/transformer/_estimator.py
+++ b/src/gluonts/model/transformer/_estimator.py
@@ -112,10 +112,10 @@ class TransformerEstimator(GluonEstimator):
         time_features
             Time features to use as inputs of the RNN (default: None, in which
             case these are automatically determined based on freq)
-        _num_eval_samples_per_ts
-            Number of evaluation samples per time series to increase parallelism during inference
-            (default: 100)
-        """
+        num_parallel_samples
+            Number of evaluation samples per time series to increase parallelism during inference.
+            This is a model optimization that does not affect the accuracy (default: 100)
+    """
 
     @validated()
     def __init__(
@@ -139,7 +139,7 @@ class TransformerEstimator(GluonEstimator):
         time_features: Optional[List[TimeFeature]] = None,
         use_feat_dynamic_real: bool = False,
         use_feat_static_cat: bool = False,
-        _num_eval_samples_per_ts: int = 100,
+        num_parallel_samples: int = 100,
     ) -> None:
         super().__init__(trainer=trainer)
 
@@ -160,8 +160,8 @@ class TransformerEstimator(GluonEstimator):
             embedding_dimension > 0
         ), "The value of `embedding_dimension` should be > 0"
         assert (
-            _num_eval_samples_per_ts > 0
-        ), "The value of `_num_eval_samples_per_ts` should be > 0"
+            num_parallel_samples > 0
+        ), "The value of `num_parallel_samples` should be > 0"
 
         self.freq = freq
         self.prediction_length = prediction_length
@@ -174,7 +174,7 @@ class TransformerEstimator(GluonEstimator):
         self.use_feat_static_cat = use_feat_static_cat
         self.cardinality = cardinality if use_feat_static_cat else [1]
         self.embedding_dimension = embedding_dimension
-        self._num_eval_samples_per_ts = _num_eval_samples_per_ts
+        self.num_parallel_samples = num_parallel_samples
         self.lags_seq = (
             lags_seq
             if lags_seq is not None
@@ -301,7 +301,7 @@ class TransformerEstimator(GluonEstimator):
             embedding_dimension=self.embedding_dimension,
             lags_seq=self.lags_seq,
             scaling=True,
-            _num_eval_samples_per_ts=self._num_eval_samples_per_ts,
+            num_parallel_samples=self.num_parallel_samples,
         )
 
         copy_parameters(trained_network, prediction_network)

--- a/src/gluonts/model/transformer/_estimator.py
+++ b/src/gluonts/model/transformer/_estimator.py
@@ -74,9 +74,6 @@ class TransformerEstimator(GluonEstimator):
             (default: None, in which case context_length = prediction_length)
         trainer
             Trainer object to be used (default: Trainer())
-        num_eval_samples
-            Number of samples paths to draw when computing predictions
-            (default: 100)
         dropout_rate
             Dropout regularization parameter (default: 0.1)
         cardinality
@@ -115,6 +112,9 @@ class TransformerEstimator(GluonEstimator):
         time_features
             Time features to use as inputs of the RNN (default: None, in which
             case these are automatically determined based on freq)
+        _num_eval_samples_per_ts
+            Number of evaluation samples per time series to increase parallelism during inference
+            (default: 100)
         """
 
     @validated()
@@ -124,7 +124,6 @@ class TransformerEstimator(GluonEstimator):
         prediction_length: int,
         context_length: Optional[int] = None,
         trainer: Trainer = Trainer(),
-        num_eval_samples: int = 100,
         dropout_rate: float = 0.1,
         cardinality: Optional[List[int]] = None,
         embedding_dimension: int = 20,
@@ -140,7 +139,9 @@ class TransformerEstimator(GluonEstimator):
         time_features: Optional[List[TimeFeature]] = None,
         use_feat_dynamic_real: bool = False,
         use_feat_static_cat: bool = False,
+        _num_eval_samples_per_ts: int = 100,
     ) -> None:
+        super().__init__(trainer=trainer)
 
         assert (
             prediction_length > 0
@@ -148,9 +149,6 @@ class TransformerEstimator(GluonEstimator):
         assert (
             context_length is None or context_length > 0
         ), "The value of `context_length` should be > 0"
-        assert (
-            num_eval_samples > 0
-        ), "The value of `num_eval_samples` should be > 0"
         assert dropout_rate >= 0, "The value of `dropout_rate` should be >= 0"
         assert (
             cardinality is not None or not use_feat_static_cat
@@ -161,8 +159,9 @@ class TransformerEstimator(GluonEstimator):
         assert (
             embedding_dimension > 0
         ), "The value of `embedding_dimension` should be > 0"
-
-        super().__init__(trainer=trainer)
+        assert (
+            _num_eval_samples_per_ts > 0
+        ), "The value of `_num_eval_samples_per_ts` should be > 0"
 
         self.freq = freq
         self.prediction_length = prediction_length
@@ -175,7 +174,7 @@ class TransformerEstimator(GluonEstimator):
         self.use_feat_static_cat = use_feat_static_cat
         self.cardinality = cardinality if use_feat_static_cat else [1]
         self.embedding_dimension = embedding_dimension
-        self.num_sample_paths = num_eval_samples
+        self._num_eval_samples_per_ts = _num_eval_samples_per_ts
         self.lags_seq = (
             lags_seq
             if lags_seq is not None
@@ -302,7 +301,7 @@ class TransformerEstimator(GluonEstimator):
             embedding_dimension=self.embedding_dimension,
             lags_seq=self.lags_seq,
             scaling=True,
-            num_sample_paths=self.num_sample_paths,
+            _num_eval_samples_per_ts=self._num_eval_samples_per_ts,
         )
 
         copy_parameters(trained_network, prediction_network)

--- a/src/gluonts/model/transformer/_network.py
+++ b/src/gluonts/model/transformer/_network.py
@@ -307,9 +307,9 @@ class TransformerTrainingNetwork(TransformerNetwork):
 
 class TransformerPredictionNetwork(TransformerNetwork):
     @validated()
-    def __init__(self, _num_eval_samples_per_ts: int = 100, **kwargs) -> None:
+    def __init__(self, num_parallel_samples: int = 100, **kwargs) -> None:
         super().__init__(**kwargs)
-        self._num_eval_samples_per_ts = _num_eval_samples_per_ts
+        self.num_parallel_samples = num_parallel_samples
 
         # for decoding the lags are shifted by one,
         # at the first time-step of the decoder a lag of one corresponds to the last target value
@@ -346,21 +346,21 @@ class TransformerPredictionNetwork(TransformerNetwork):
             a tensor containing sampled paths. Shape: (batch_size, num_sample_paths, prediction_length).
         """
 
-        # blows-up the dimension of each tensor to batch_size * self._num_eval_samples_per_ts for increasing parallelism
+        # blows-up the dimension of each tensor to batch_size * self.num_parallel_samples for increasing parallelism
         repeated_past_target = past_target.repeat(
-            repeats=self._num_eval_samples_per_ts, axis=0
+            repeats=self.num_parallel_samples, axis=0
         )
         repeated_time_feat = time_feat.repeat(
-            repeats=self._num_eval_samples_per_ts, axis=0
+            repeats=self.num_parallel_samples, axis=0
         )
         repeated_static_feat = static_feat.repeat(
-            repeats=self._num_eval_samples_per_ts, axis=0
+            repeats=self.num_parallel_samples, axis=0
         ).expand_dims(axis=1)
         repeated_enc_out = enc_out.repeat(
-            repeats=self._num_eval_samples_per_ts, axis=0
+            repeats=self.num_parallel_samples, axis=0
         ).expand_dims(axis=1)
         repeated_scale = scale.repeat(
-            repeats=self._num_eval_samples_per_ts, axis=0
+            repeats=self.num_parallel_samples, axis=0
         )
 
         future_samples = []
@@ -422,7 +422,7 @@ class TransformerPredictionNetwork(TransformerNetwork):
         # (batch_size, num_samples, *target_shape, prediction_length)
         return samples.reshape(
             shape=(
-                (-1, self._num_eval_samples_per_ts)
+                (-1, self.num_parallel_samples)
                 + self.target_shape
                 + (self.prediction_length,)
             )

--- a/src/gluonts/model/transformer/_network.py
+++ b/src/gluonts/model/transformer/_network.py
@@ -307,9 +307,9 @@ class TransformerTrainingNetwork(TransformerNetwork):
 
 class TransformerPredictionNetwork(TransformerNetwork):
     @validated()
-    def __init__(self, num_sample_paths: int, **kwargs) -> None:
+    def __init__(self, _num_eval_samples_per_ts: int = 100, **kwargs) -> None:
         super().__init__(**kwargs)
-        self.num_sample_paths = num_sample_paths
+        self._num_eval_samples_per_ts = _num_eval_samples_per_ts
 
         # for decoding the lags are shifted by one,
         # at the first time-step of the decoder a lag of one corresponds to the last target value
@@ -346,20 +346,22 @@ class TransformerPredictionNetwork(TransformerNetwork):
             a tensor containing sampled paths. Shape: (batch_size, num_sample_paths, prediction_length).
         """
 
-        # blows-up the dimension of each tensor to batch_size * self.num_sample_paths for increasing parallelism
+        # blows-up the dimension of each tensor to batch_size * self._num_eval_samples_per_ts for increasing parallelism
         repeated_past_target = past_target.repeat(
-            repeats=self.num_sample_paths, axis=0
+            repeats=self._num_eval_samples_per_ts, axis=0
         )
         repeated_time_feat = time_feat.repeat(
-            repeats=self.num_sample_paths, axis=0
+            repeats=self._num_eval_samples_per_ts, axis=0
         )
         repeated_static_feat = static_feat.repeat(
-            repeats=self.num_sample_paths, axis=0
+            repeats=self._num_eval_samples_per_ts, axis=0
         ).expand_dims(axis=1)
         repeated_enc_out = enc_out.repeat(
-            repeats=self.num_sample_paths, axis=0
+            repeats=self._num_eval_samples_per_ts, axis=0
         ).expand_dims(axis=1)
-        repeated_scale = scale.repeat(repeats=self.num_sample_paths, axis=0)
+        repeated_scale = scale.repeat(
+            repeats=self._num_eval_samples_per_ts, axis=0
+        )
 
         future_samples = []
 
@@ -420,7 +422,7 @@ class TransformerPredictionNetwork(TransformerNetwork):
         # (batch_size, num_samples, *target_shape, prediction_length)
         return samples.reshape(
             shape=(
-                (-1, self.num_sample_paths)
+                (-1, self._num_eval_samples_per_ts)
                 + self.target_shape
                 + (self.prediction_length,)
             )

--- a/src/gluonts/model/wavenet/_estimator.py
+++ b/src/gluonts/model/wavenet/_estimator.py
@@ -146,9 +146,9 @@ class WaveNetEstimator(GluonEstimator):
         act_type
             Activation type used after before output layer (default: "elu").
             Can be any of 'elu', 'relu', 'sigmoid', 'tanh', 'softrelu', 'softsign'.
-        _num_eval_samples_per_ts
-            Number of evaluation samples per time series to increase parallelism during inference
-            (default: 200)
+        num_parallel_samples
+            Number of evaluation samples per time series to increase parallelism during inference.
+            This is a model optimization that does not affect the accuracy (default: 200)
     """
 
     @validated()
@@ -172,7 +172,7 @@ class WaveNetEstimator(GluonEstimator):
         n_stacks: int = 1,
         temperature: float = 1.0,
         act_type: str = "elu",
-        _num_eval_samples_per_ts: int = 200,
+        num_parallel_samples: int = 200,
     ) -> None:
         super().__init__(trainer=trainer)
 
@@ -188,7 +188,7 @@ class WaveNetEstimator(GluonEstimator):
         self.n_stacks = n_stacks
         self.temperature = temperature
         self.act_type = act_type
-        self._num_eval_samples_per_ts = _num_eval_samples_per_ts
+        self.num_parallel_samples = num_parallel_samples
 
         seasonality = _get_seasonality(
             self.freq, {"H": 7 * 24, "D": 7, "W": 52, "M": 12, "B": 7 * 5}
@@ -326,7 +326,7 @@ class WaveNetEstimator(GluonEstimator):
     ) -> Predictor:
 
         prediction_network = WaveNetSampler(
-            num_samples=self._num_eval_samples_per_ts,
+            num_samples=self.num_parallel_samples,
             temperature=self.temperature,
             **self._get_wavenet_args(bin_values),
         )

--- a/src/gluonts/model/wavenet/_network.py
+++ b/src/gluonts/model/wavenet/_network.py
@@ -290,11 +290,18 @@ class WaveNetSampler(WaveNet):
     def __init__(self, num_samples: int, temperature: float = 1.0, **kwargs):
         """
         Same arguments as WaveNet. In addition
-        :param pred_length: prediction length
-        :param num_samples: number of sample paths to generate in parallel in the graph
-        :param temperature: if set to 1.0 (default), sample according to estimated probabilities
-          if set to 0.0 most likely sample at each step is chosen.
-        :param post_transform: An optional post transform that will be applied to the samples.
+
+        Parameters
+        ----------
+        pred_length
+            Length of the prediction horizon
+        num_samples
+            Number of sample paths to generate in parallel in the graph
+        temperature
+            If set to 1.0 (default), sample according to estimated probabilities, if set to 0.0
+            most likely sample at each step is chosen.
+        post_transform
+            An optional post transform that will be applied to the samples
         """
         super().__init__(**kwargs)
         self.num_samples = num_samples

--- a/test/model/test_models.py
+++ b/test/model/test_models.py
@@ -59,7 +59,7 @@ def seq2seq_base(seq2seq_model, hybridize: bool = True, batches_per_epoch=1):
             num_batches_per_epoch=batches_per_epoch,
             quantiles=[0.1, 0.5, 0.9],
             use_symbol_block_predictor=True,
-            _num_eval_samples_per_ts=num_eval_samples,
+            num_parallel_samples=num_eval_samples,
         ),
     )
 
@@ -79,7 +79,7 @@ def npts_estimator():
             kernel_type="uniform",
             use_default_features=True,
             prediction_length=prediction_length,
-            _num_eval_samples_per_ts=num_eval_samples,
+            num_parallel_samples=num_eval_samples,
         ),
     )
 
@@ -100,7 +100,7 @@ def simple_feedforward_estimator(hybridize: bool = True, batches_per_epoch=1):
             prediction_length=prediction_length,
             num_batches_per_epoch=batches_per_epoch,
             use_symbol_block_predictor=True,
-            _num_eval_samples_per_ts=num_eval_samples,
+            num_parallel_samples=num_eval_samples,
         ),
     )
 
@@ -118,7 +118,7 @@ def gp_estimator(hybridize: bool = True, batches_per_epoch=1):
             num_batches_per_epoch=batches_per_epoch,
             time_features=time_features,
             use_symbol_block_predictor=False,
-            _num_eval_samples_per_ts=num_eval_samples,
+            num_parallel_samples=num_eval_samples,
             # FIXME: test_shell fails with use_symbol_block_predictor=True
             # FIXME and float_type = np.float64
         ),
@@ -139,7 +139,7 @@ def deepar_estimator(hybridize: bool = True, batches_per_epoch=1):
             context_length=2,
             num_batches_per_epoch=batches_per_epoch,
             use_symbol_block_predictor=False,
-            _num_eval_samples_per_ts=2,
+            num_parallel_samples=2,
         ),
     )
 
@@ -159,7 +159,7 @@ def transformer_estimator(hybridize: bool = False, batches_per_epoch=1):
             context_length=2,
             num_batches_per_epoch=batches_per_epoch,
             use_symbol_block_predictor=False,
-            _num_eval_samples_per_ts=2,
+            num_parallel_samples=2,
         ),
     )
 

--- a/test/model/test_models.py
+++ b/test/model/test_models.py
@@ -56,10 +56,10 @@ def seq2seq_base(seq2seq_model, hybridize: bool = True, batches_per_epoch=1):
             hybridize=hybridize,
             prediction_length=prediction_length,
             context_length=prediction_length,
-            num_eval_samples=num_eval_samples,
             num_batches_per_epoch=batches_per_epoch,
             quantiles=[0.1, 0.5, 0.9],
             use_symbol_block_predictor=True,
+            _num_eval_samples_per_ts=num_eval_samples,
         ),
     )
 
@@ -79,7 +79,7 @@ def npts_estimator():
             kernel_type="uniform",
             use_default_features=True,
             prediction_length=prediction_length,
-            num_eval_samples=num_eval_samples,
+            _num_eval_samples_per_ts=num_eval_samples,
         ),
     )
 
@@ -98,9 +98,9 @@ def simple_feedforward_estimator(hybridize: bool = True, batches_per_epoch=1):
             hybridize=hybridize,
             num_hidden_dimensions=[3],
             prediction_length=prediction_length,
-            num_eval_samples=num_eval_samples,
             num_batches_per_epoch=batches_per_epoch,
             use_symbol_block_predictor=True,
+            _num_eval_samples_per_ts=num_eval_samples,
         ),
     )
 
@@ -115,10 +115,10 @@ def gp_estimator(hybridize: bool = True, batches_per_epoch=1):
             hybridize=hybridize,
             prediction_length=prediction_length,
             cardinality=cardinality,
-            num_eval_samples=num_eval_samples,
             num_batches_per_epoch=batches_per_epoch,
             time_features=time_features,
             use_symbol_block_predictor=False,
+            _num_eval_samples_per_ts=num_eval_samples,
             # FIXME: test_shell fails with use_symbol_block_predictor=True
             # FIXME and float_type = np.float64
         ),
@@ -137,9 +137,9 @@ def deepar_estimator(hybridize: bool = True, batches_per_epoch=1):
             num_layers=1,
             prediction_length=prediction_length,
             context_length=2,
-            num_eval_samples=2,
             num_batches_per_epoch=batches_per_epoch,
             use_symbol_block_predictor=False,
+            _num_eval_samples_per_ts=2,
         ),
     )
 
@@ -157,9 +157,9 @@ def transformer_estimator(hybridize: bool = False, batches_per_epoch=1):
             num_heads=2,
             prediction_length=prediction_length,
             context_length=2,
-            num_eval_samples=2,
             num_batches_per_epoch=batches_per_epoch,
             use_symbol_block_predictor=False,
+            _num_eval_samples_per_ts=2,
         ),
     )
 

--- a/test/model/test_models_synthetic.py
+++ b/test/model/test_models_synthetic.py
@@ -65,8 +65,8 @@ def deepar_estimator(hybridize: bool = False, batches_per_epoch=1):
             prediction_length=prediction_length,
             context_length=context_length,
             freq=freq,
-            num_eval_samples=2,
             num_batches_per_epoch=batches_per_epoch,
+            _num_eval_samples_per_ts=2,
         ),
     )
 
@@ -83,8 +83,8 @@ def gp_estimator(hybridize: bool = True, batches_per_epoch=1):
             context_length=context_length,
             freq=freq,
             cardinality=cardinality,
-            num_eval_samples=5,
             num_batches_per_epoch=batches_per_epoch,
+            _num_eval_samples_per_ts=5,
         ),
     )
 
@@ -100,8 +100,8 @@ def wavenet_estimator(hybridize: bool = False, batches_per_epoch=1):
             prediction_length=prediction_length,
             freq=freq,
             cardinality=[cardinality],
-            num_eval_samples=5,
             num_batches_per_epoch=batches_per_epoch,
+            _num_eval_samples_per_ts=5,
         ),
     )
 
@@ -121,13 +121,13 @@ def transformer_estimator(hybridize: bool = False, batches_per_epoch=1):
             prediction_length=prediction_length,
             context_length=context_length,
             freq=freq,
-            num_eval_samples=2,
             num_batches_per_epoch=batches_per_epoch,
+            _num_eval_samples_per_ts=2,
         ),
     )
 
 
-@pytest.mark.timeout(5)  # DeepAR occasionally fails the 5 second timeout
+@pytest.mark.timeout(15)  # DeepAR occasionally fails the 5 second timeout
 @pytest.mark.parametrize(
     "Estimator, hyperparameters, accuracy",
     [

--- a/test/model/test_models_synthetic.py
+++ b/test/model/test_models_synthetic.py
@@ -66,7 +66,7 @@ def deepar_estimator(hybridize: bool = False, batches_per_epoch=1):
             context_length=context_length,
             freq=freq,
             num_batches_per_epoch=batches_per_epoch,
-            _num_eval_samples_per_ts=2,
+            num_parallel_samples=2,
         ),
     )
 
@@ -84,7 +84,7 @@ def gp_estimator(hybridize: bool = True, batches_per_epoch=1):
             freq=freq,
             cardinality=cardinality,
             num_batches_per_epoch=batches_per_epoch,
-            _num_eval_samples_per_ts=5,
+            num_parallel_samples=5,
         ),
     )
 
@@ -101,7 +101,7 @@ def wavenet_estimator(hybridize: bool = False, batches_per_epoch=1):
             freq=freq,
             cardinality=[cardinality],
             num_batches_per_epoch=batches_per_epoch,
-            _num_eval_samples_per_ts=5,
+            num_parallel_samples=5,
         ),
     )
 
@@ -122,12 +122,12 @@ def transformer_estimator(hybridize: bool = False, batches_per_epoch=1):
             context_length=context_length,
             freq=freq,
             num_batches_per_epoch=batches_per_epoch,
-            _num_eval_samples_per_ts=2,
+            num_parallel_samples=2,
         ),
     )
 
 
-@pytest.mark.timeout(15)  # DeepAR occasionally fails the 5 second timeout
+@pytest.mark.timeout(5)  # DeepAR occasionally fails the 5 second timeout
 @pytest.mark.parametrize(
     "Estimator, hyperparameters, accuracy",
     [

--- a/test/model/test_npts.py
+++ b/test/model/test_npts.py
@@ -102,7 +102,7 @@ def test_climatological_forecaster(
         freq=freq,
         use_seasonal_model=use_seasonal_model,
         kernel_type=KernelType.uniform,
-        _num_eval_samples_per_ts=2000,
+        num_parallel_samples=2000,
     )
 
     dataset = ListDataset(
@@ -267,7 +267,7 @@ def test_npts_forecaster(
         kernel_type=KernelType.exponential,
         feature_scale=feature_scale,
         use_seasonal_model=use_seasonal_model,
-        _num_eval_samples_per_ts=2000,
+        num_parallel_samples=2000,
     )
 
     dataset = ListDataset(
@@ -430,7 +430,7 @@ def test_npts_custom_features(
         feature_scale=feature_scale,
         use_seasonal_model=use_seasonal_model,
         use_default_time_features=False,  # disable default time features
-        _num_eval_samples_per_ts=2000,
+        num_parallel_samples=2000,
     )
 
     dataset = ListDataset(

--- a/test/model/test_npts.py
+++ b/test/model/test_npts.py
@@ -102,7 +102,7 @@ def test_climatological_forecaster(
         freq=freq,
         use_seasonal_model=use_seasonal_model,
         kernel_type=KernelType.uniform,
-        num_eval_samples=2000,
+        _num_eval_samples_per_ts=2000,
     )
 
     dataset = ListDataset(
@@ -267,7 +267,7 @@ def test_npts_forecaster(
         kernel_type=KernelType.exponential,
         feature_scale=feature_scale,
         use_seasonal_model=use_seasonal_model,
-        num_eval_samples=2000,
+        _num_eval_samples_per_ts=2000,
     )
 
     dataset = ListDataset(
@@ -430,7 +430,7 @@ def test_npts_custom_features(
         feature_scale=feature_scale,
         use_seasonal_model=use_seasonal_model,
         use_default_time_features=False,  # disable default time features
-        num_eval_samples=2000,
+        _num_eval_samples_per_ts=2000,
     )
 
     dataset = ListDataset(


### PR DESCRIPTION
With this PR I am trying to clear the ambiguity around `num_eval_samples`.

Currently, `num_eval_samples` can be defined in two places: In the estimator and in the `make_evaluation_predictions`. This is confusing to an external user since it is not clear what is the difference between these two, if one overwrites the other, or if they have a different usage.

The actual place that defines how many samples we get for prediction is `num_eval_samples` in the `make_evaluation_predictions`. We introduce `num_eval_samples` in an estimator just to increase the output dimension of the prediction network for computational efficiency. This suggests that we should distinguish between these two `num_eval_samples` hyperparameters. It also suggests that `num_eval_samples` in an estimator should be a bit "hidden" or something that the user shouldn't really try to define (unless he knows what he is doing).

For this, I changed `num_eval_samples` to `_num_eval_samples_per_ts` in all models. 

As a side, I fixed some documentation too.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
