### PR TITLE
Removed logging for ping.

### DIFF
--- a/src/gluonts/shell/serve.py
+++ b/src/gluonts/shell/serve.py
@@ -165,7 +165,6 @@ def make_flask_app(predictor_factory, execution_params) -> Flask:
 
     @app.route("/ping")
     def ping() -> Response:
-        logger.info("Responding to /ping request")
         return ""
 
     @app.route("/execution-parameters")


### PR DESCRIPTION
Since SageMaker is sending out this request every 5 seconds, the logs get polluted with this info.