### PR TITLE
Fix shapes in CanonicalNetworkBase

### DIFF
--- a/src/gluonts/model/canonical/_network.py
+++ b/src/gluonts/model/canonical/_network.py
@@ -41,7 +41,7 @@ class CanonicalNetworkBase(HybridBlock):
 
         with self.name_scope():
             self.proj_distr_args = self.distr_output.get_args_proj()
-            self.scaler = MeanScaler()
+            self.scaler = MeanScaler(keepdims=True)
 
     def assemble_features(
         self,
@@ -107,8 +107,7 @@ class CanonicalTrainingNetwork(CanonicalNetworkBase):
         outputs = self.model(input_feat)
 
         distr = self.distr_output.distribution(
-            self.proj_distr_args(outputs),
-            scale=target_scale.expand_dims(axis=1).expand_dims(axis=2),
+            self.proj_distr_args(outputs), scale=target_scale
         )
 
         loss = distr.loss(past_target)
@@ -176,8 +175,7 @@ class CanonicalPredictionNetwork(CanonicalNetworkBase):
             )
 
         distr = self.distr_output.distribution(
-            self.proj_distr_args(outputs),
-            scale=target_scale.expand_dims(axis=0).expand_dims(axis=2),
+            self.proj_distr_args(outputs), scale=target_scale
         )
         samples = distr.sample(
             self.num_sample_paths

--- a/test/model/test_models.py
+++ b/test/model/test_models.py
@@ -222,8 +222,10 @@ def seasonal_estimator():
         # mqcnn_estimator(batches_per_epoch=200) + (0.2,),
         # mqrnn_estimator(batches_per_epoch=200) + (0.2,),
         transformer_estimator(batches_per_epoch=80) + (0.2,),
-        rnn_estimator() + (10.0,),
-        mlp_estimator() + (10.0,),
+        rnn_estimator(hybridize=False) + (10.0,),
+        rnn_estimator(hybridize=True) + (10.0,),
+        mlp_estimator(hybridize=False) + (10.0,),
+        mlp_estimator(hybridize=True) + (10.0,),
     ],
 )
 def test_accuracy(Estimator, hyperparameters, accuracy):

--- a/test/model/test_models.py
+++ b/test/model/test_models.py
@@ -214,19 +214,23 @@ def seasonal_estimator():
 @pytest.mark.parametrize(
     "Estimator, hyperparameters, accuracy",
     [
-        simple_feedforward_estimator(batches_per_epoch=200) + (0.3,),
-        gp_estimator(batches_per_epoch=200) + (0.2,),
-        npts_estimator() + (0.0,),
-        # deepar_estimator(batches_per_epoch=50) + (1.5,), # large value as this test is breaking frequently
-        seasonal_estimator() + (0.0,),
-        # mqcnn_estimator(batches_per_epoch=200) + (0.2,),
-        # mqrnn_estimator(batches_per_epoch=200) + (0.2,),
-        transformer_estimator(batches_per_epoch=80) + (0.2,),
-        rnn_estimator(hybridize=False) + (10.0,),
-        rnn_estimator(hybridize=True) + (10.0,),
-        mlp_estimator(hybridize=False) + (10.0,),
-        mlp_estimator(hybridize=True) + (10.0,),
-    ],
+        estimator
+        for hyb in [False, True]
+        for estimator in [
+            deepar_estimator(hybridize=hyb, batches_per_epoch=50)
+            + (1.5,),  # large value as this test is breaking frequently
+            gp_estimator(hybridize=hyb, batches_per_epoch=200) + (0.2,),
+            mlp_estimator(hybridize=hyb) + (10.0,),
+            mqcnn_estimator(hybridize=hyb, batches_per_epoch=200) + (0.2,),
+            mqrnn_estimator(hybridize=hyb, batches_per_epoch=200) + (0.2,),
+            rnn_estimator(hybridize=hyb) + (10.0,),
+            simple_feedforward_estimator(hybridize=hyb, batches_per_epoch=200)
+            + (0.3,),
+            transformer_estimator(hybridize=hyb, batches_per_epoch=80)
+            + (0.2,),
+        ]
+    ]
+    + [npts_estimator() + (0.0,), seasonal_estimator() + (0.0,)],
 )
 def test_accuracy(Estimator, hyperparameters, accuracy):
     estimator = Estimator.from_hyperparameters(freq=freq, **hyperparameters)
@@ -253,24 +257,6 @@ def test_accuracy(Estimator, hyperparameters, accuracy):
 def test_repr(Estimator, hyperparameters):
     estimator = Estimator.from_hyperparameters(freq=freq, **hyperparameters)
     assert repr(estimator) == repr(load_code(repr(estimator)))
-
-
-@pytest.mark.parametrize(
-    "Estimator, hyperparameters",
-    [
-        simple_feedforward_estimator(hybridize=True),
-        deepar_estimator(hybridize=True),
-        mqcnn_estimator(hybridize=True),
-        mqrnn_estimator(hybridize=True),
-        gp_estimator(hybridize=True),
-        transformer_estimator(hybridize=True),
-    ],
-)
-def test_hybridize(Estimator, hyperparameters):
-    estimator = Estimator.from_hyperparameters(freq=freq, **hyperparameters)
-    backtest_metrics(
-        train_dataset=train_ds, test_dataset=test_ds, forecaster=estimator
-    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
*Issue #, if available:* #161 

*Description of changes:* The time series scale tensor had some unnecessary additional axes in `CanonicalNetworkBase`, which resulted in wrong shapes (but no error) when `hybridize=False`, and in MXNet errors when `hybridize=True`. This PR hardens tests for *all* estimators by running with both `hybridize=False` and `hybridize=True`: this now clearly raises the problem with `CanonicalNetworkBase`-based estimators. Shapes are also fixed in `CanonicalNetworkBase`, and now tests pass.

*Bonus:* I uncommented a few test cases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
