### PR TITLE
fixes fieldname issues

### DIFF
--- a/docs/examples/basic_forecasting_tutorial/tutorial.md
+++ b/docs/examples/basic_forecasting_tutorial/tutorial.md
@@ -351,7 +351,8 @@ from gluonts.model.estimator import GluonEstimator
 from gluonts.model.predictor import Predictor, RepresentableBlockPredictor
 from gluonts.core.component import validated
 from gluonts.support.util import copy_parameters
-from gluonts.transform import ExpectedNumInstanceSampler, Transformation, InstanceSplitter, FieldName
+from gluonts.transform import ExpectedNumInstanceSampler, Transformation, InstanceSplitter
+from gluonts.dataset.field_names import FieldName
 from mxnet.gluon import HybridBlock
 ```
 

--- a/docs/examples/extended_forecasting_tutorial/extended_tutorial.md
+++ b/docs/examples/extended_forecasting_tutorial/extended_tutorial.md
@@ -237,7 +237,7 @@ As already mentioned a dataset is required to have at least the `target` and the
 
 
 ```python
-from gluonts.transform import FieldName
+from gluonts.dataset.field_names import FieldName
 ```
 
 
@@ -423,7 +423,6 @@ from gluonts.transform import (
     AddObservedValuesIndicator,
     Chain,
     ExpectedNumInstanceSampler,
-    FieldName,
     InstanceSplitter,
     SetFieldIfNotPresent,
 )
@@ -835,7 +834,7 @@ from gluonts.model.predictor import Predictor, RepresentableBlockPredictor
 from gluonts.core.component import validated
 from gluonts.trainer import Trainer
 from gluonts.support.util import copy_parameters
-from gluonts.transform import ExpectedNumInstanceSampler, Transformation, InstanceSplitter, FieldName
+from gluonts.transform import ExpectedNumInstanceSampler, Transformation, InstanceSplitter
 from mxnet.gluon import HybridBlock
 ```
 

--- a/src/gluonts/dataset/field_names.py
+++ b/src/gluonts/dataset/field_names.py
@@ -1,0 +1,37 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+class FieldName:
+    """
+    A bundle of default field names to be used by clients when instantiating
+    transformer instances.
+    """
+
+    ITEM_ID = "item_id"
+
+    START = "start"
+    TARGET = "target"
+
+    FEAT_STATIC_CAT = "feat_static_cat"
+    FEAT_STATIC_REAL = "feat_static_real"
+    FEAT_DYNAMIC_CAT = "feat_dynamic_cat"
+    FEAT_DYNAMIC_REAL = "feat_dynamic_real"
+
+    FEAT_TIME = "time_feat"
+    FEAT_CONST = "feat_dynamic_const"
+    FEAT_AGE = "feat_dynamic_age"
+
+    OBSERVED_VALUES = "observed_values"
+    IS_PAD = "is_pad"
+    FORECAST_START = "forecast_start"

--- a/src/gluonts/model/canonical/_estimator.py
+++ b/src/gluonts/model/canonical/_estimator.py
@@ -22,6 +22,7 @@ from gluonts import transform
 from gluonts.block.feature import FeatureEmbedder
 from gluonts.block.rnn import RNN
 from gluonts.core.component import validated
+from gluonts.dataset.field_names import FieldName
 from gluonts.distribution import DistributionOutput, StudentTOutput
 from gluonts.model.estimator import GluonEstimator
 from gluonts.model.predictor import Predictor, RepresentableBlockPredictor
@@ -31,7 +32,7 @@ from gluonts.transform import (
     AddTimeFeatures,
     AsNumpyArray,
     Chain,
-    FieldName,
+    InstanceSplitter,
     SetFieldIfNotPresent,
     TestSplitSampler,
     Transformation,
@@ -84,11 +85,11 @@ class CanonicalEstimator(GluonEstimator):
                     field=FieldName.FEAT_STATIC_CAT, value=[0.0]
                 ),
                 AsNumpyArray(field=FieldName.FEAT_STATIC_CAT, expected_ndim=1),
-                transform.InstanceSplitter(
-                    target_field=transform.FieldName.TARGET,
-                    is_pad_field=transform.FieldName.IS_PAD,
-                    start_field=transform.FieldName.START,
-                    forecast_start_field=transform.FieldName.FORECAST_START,
+                InstanceSplitter(
+                    target_field=FieldName.TARGET,
+                    is_pad_field=FieldName.IS_PAD,
+                    start_field=FieldName.START,
+                    forecast_start_field=FieldName.FORECAST_START,
                     train_sampler=TestSplitSampler(),
                     time_series_fields=[FieldName.FEAT_TIME],
                     past_length=self.context_length,

--- a/src/gluonts/model/deep_factor/_estimator.py
+++ b/src/gluonts/model/deep_factor/_estimator.py
@@ -20,6 +20,7 @@ from gluonts.evaluation import Evaluator
 from gluonts import transform
 from gluonts.block.feature import FeatureEmbedder
 from gluonts.core.component import validated
+from gluonts.dataset.field_names import FieldName
 from gluonts.distribution import DistributionOutput, StudentTOutput
 from gluonts.evaluation.backtest import make_evaluation_predictions
 
@@ -36,7 +37,6 @@ from gluonts.transform import (
     AddTimeFeatures,
     AsNumpyArray,
     Chain,
-    FieldName,
     SetFieldIfNotPresent,
     TestSplitSampler,
     Transformation,

--- a/src/gluonts/model/deepar/_estimator.py
+++ b/src/gluonts/model/deepar/_estimator.py
@@ -19,6 +19,7 @@ from mxnet.gluon import HybridBlock
 
 # First-party imports
 from gluonts.core.component import validated
+from gluonts.dataset.field_names import FieldName
 from gluonts.distribution import DistributionOutput, StudentTOutput
 from gluonts.model.estimator import GluonEstimator
 from gluonts.model.predictor import Predictor, RepresentableBlockPredictor
@@ -36,7 +37,6 @@ from gluonts.transform import (
     AsNumpyArray,
     Chain,
     ExpectedNumInstanceSampler,
-    FieldName,
     InstanceSplitter,
     RemoveFields,
     SetField,

--- a/src/gluonts/model/deepstate/_estimator.py
+++ b/src/gluonts/model/deepstate/_estimator.py
@@ -20,6 +20,7 @@ from pandas.tseries.frequencies import to_offset
 
 # First-party imports
 from gluonts.core.component import validated
+from gluonts.dataset.field_names import FieldName
 from gluonts.model.deepstate.issm import ISSM, CompositeISSM
 from gluonts.model.estimator import GluonEstimator
 from gluonts.model.predictor import Predictor, RepresentableBlockPredictor
@@ -37,7 +38,6 @@ from gluonts.transform import (
     Chain,
     CanonicalInstanceSplitter,
     ExpandDimArray,
-    FieldName,
     RemoveFields,
     SetField,
     TestSplitSampler,

--- a/src/gluonts/model/gp_forecaster/_estimator.py
+++ b/src/gluonts/model/gp_forecaster/_estimator.py
@@ -21,6 +21,7 @@ from mxnet.gluon import HybridBlock
 # First-party imports
 from gluonts import transform
 from gluonts.core.component import DType, validated
+from gluonts.dataset.field_names import FieldName
 from gluonts.kernels import KernelOutput, RBFKernelOutput
 from gluonts.model.estimator import GluonEstimator
 from gluonts.model.predictor import Predictor, RepresentableBlockPredictor
@@ -35,7 +36,6 @@ from gluonts.transform import (
     AsNumpyArray,
     CanonicalInstanceSplitter,
     Chain,
-    FieldName,
     SetFieldIfNotPresent,
     TestSplitSampler,
     Transformation,
@@ -161,9 +161,7 @@ class GaussianProcessEstimator(GluonEstimator):
                 SetFieldIfNotPresent(
                     field=FieldName.FEAT_STATIC_CAT, value=[0.0]
                 ),
-                AsNumpyArray(
-                    field=transform.FieldName.FEAT_STATIC_CAT, expected_ndim=1
-                ),
+                AsNumpyArray(field=FieldName.FEAT_STATIC_CAT, expected_ndim=1),
                 CanonicalInstanceSplitter(
                     target_field=FieldName.TARGET,
                     is_pad_field=FieldName.IS_PAD,

--- a/src/gluonts/model/predictor.py
+++ b/src/gluonts/model/predictor.py
@@ -47,6 +47,7 @@ from gluonts.core.component import (
 from gluonts.core.exception import GluonTSException
 from gluonts.core.serde import dump_json, fqname_for, load_json
 from gluonts.dataset.common import DataEntry, Dataset, ListDataset
+from gluonts.dataset.field_names import FieldName
 from gluonts.dataset.loader import DataBatch, InferenceDataLoader
 from gluonts.model.forecast import Forecast, SampleForecast
 from gluonts.support.util import (
@@ -57,7 +58,7 @@ from gluonts.support.util import (
     import_repr_block,
     import_symb_block,
 )
-from gluonts.transform import Transformation, FieldName
+from gluonts.transform import Transformation
 
 if TYPE_CHECKING:  # avoid circular import
     from gluonts.model.estimator import Estimator  # noqa

--- a/src/gluonts/model/seq2seq/_forking_estimator.py
+++ b/src/gluonts/model/seq2seq/_forking_estimator.py
@@ -20,6 +20,7 @@ from gluonts.block.enc2dec import PassThroughEnc2Dec
 from gluonts.block.encoder import Seq2SeqEncoder
 from gluonts.block.quantile_output import QuantileOutput
 from gluonts.core.component import validated
+from gluonts.dataset.field_names import FieldName
 from gluonts.model.estimator import GluonEstimator
 from gluonts.model.forecast import QuantileForecast, Quantile
 from gluonts.model.predictor import Predictor, RepresentableBlockPredictor
@@ -28,7 +29,6 @@ from gluonts.trainer import Trainer
 from gluonts.transform import (
     AsNumpyArray,
     Chain,
-    FieldName,
     TestSplitSampler,
     Transformation,
 )

--- a/src/gluonts/model/seq2seq/_seq2seq_estimator.py
+++ b/src/gluonts/model/seq2seq/_seq2seq_estimator.py
@@ -31,13 +31,14 @@ from gluonts.block.feature import FeatureEmbedder
 from gluonts.block.quantile_output import QuantileOutput
 from gluonts.block.scaler import NOPScaler, Scaler
 from gluonts.core.component import validated
+from gluonts.dataset.field_names import FieldName
 from gluonts.model.estimator import GluonEstimator
 from gluonts.model.forecast import QuantileForecast, Quantile
 from gluonts.model.predictor import Predictor, RepresentableBlockPredictor
 from gluonts.support.util import copy_parameters
 from gluonts.time_feature.lag import time_features_from_frequency_str
 from gluonts.trainer import Trainer
-from gluonts.transform import ExpectedNumInstanceSampler, FieldName
+from gluonts.transform import ExpectedNumInstanceSampler
 
 # Relative imports
 from ._seq2seq_network import Seq2SeqPredictionNetwork, Seq2SeqTrainingNetwork
@@ -97,9 +98,9 @@ class Seq2SeqEstimator(GluonEstimator):
                     field=FieldName.TARGET, expected_ndim=1
                 ),
                 transform.AddTimeFeatures(
-                    start_field=transform.FieldName.START,
-                    target_field=transform.FieldName.TARGET,
-                    output_field=transform.FieldName.FEAT_TIME,
+                    start_field=FieldName.START,
+                    target_field=FieldName.TARGET,
+                    output_field=FieldName.FEAT_TIME,
                     time_features=time_features_from_frequency_str(self.freq),
                     pred_length=self.prediction_length,
                 ),
@@ -114,10 +115,10 @@ class Seq2SeqEstimator(GluonEstimator):
                     field=FieldName.FEAT_STATIC_CAT, expected_ndim=1
                 ),
                 transform.InstanceSplitter(
-                    target_field=transform.FieldName.TARGET,
-                    is_pad_field=transform.FieldName.IS_PAD,
-                    start_field=transform.FieldName.START,
-                    forecast_start_field=transform.FieldName.FORECAST_START,
+                    target_field=FieldName.TARGET,
+                    is_pad_field=FieldName.IS_PAD,
+                    start_field=FieldName.START,
+                    forecast_start_field=FieldName.FORECAST_START,
                     train_sampler=ExpectedNumInstanceSampler(num_instances=1),
                     past_length=self.context_length,
                     future_length=self.prediction_length,

--- a/src/gluonts/model/simple_feedforward/_estimator.py
+++ b/src/gluonts/model/simple_feedforward/_estimator.py
@@ -19,6 +19,7 @@ from mxnet.gluon import HybridBlock
 
 # First-party imports
 from gluonts.core.component import validated
+from gluonts.dataset.field_names import FieldName
 from gluonts.distribution import DistributionOutput, StudentTOutput
 from gluonts.model.estimator import GluonEstimator
 from gluonts.model.predictor import Predictor, RepresentableBlockPredictor
@@ -26,7 +27,6 @@ from gluonts.trainer import Trainer
 from gluonts.transform import (
     Chain,
     ExpectedNumInstanceSampler,
-    FieldName,
     InstanceSplitter,
     Transformation,
 )

--- a/src/gluonts/model/transformer/_estimator.py
+++ b/src/gluonts/model/transformer/_estimator.py
@@ -19,6 +19,7 @@ from mxnet.gluon import HybridBlock
 
 # First-party imports
 from gluonts.core.component import validated
+from gluonts.dataset.field_names import FieldName
 from gluonts.distribution import StudentTOutput, DistributionOutput
 from gluonts.model.estimator import GluonEstimator
 from gluonts.model.predictor import Predictor, RepresentableBlockPredictor
@@ -36,7 +37,6 @@ from gluonts.transform import (
     AsNumpyArray,
     Chain,
     ExpectedNumInstanceSampler,
-    FieldName,
     InstanceSplitter,
     RemoveFields,
     SetField,

--- a/src/gluonts/model/trivial/constant.py
+++ b/src/gluonts/model/trivial/constant.py
@@ -21,10 +21,10 @@ import numpy as np
 # First-party imports
 from gluonts.core.component import validated
 from gluonts.dataset.common import DataEntry
+from gluonts.dataset.field_names import FieldName
 from gluonts.model.forecast import SampleForecast
 from gluonts.model.predictor import RepresentablePredictor, FallbackPredictor
 from gluonts.support.pandas import forecast_start
-from gluonts.transform import FieldName
 
 
 class ConstantPredictor(RepresentablePredictor):

--- a/src/gluonts/model/trivial/identity.py
+++ b/src/gluonts/model/trivial/identity.py
@@ -20,9 +20,9 @@ import numpy as np
 # First-party imports
 from gluonts.core.component import validated
 from gluonts.dataset.common import DataEntry
+from gluonts.dataset.field_names import FieldName
 from gluonts.model.forecast import Forecast, SampleForecast
 from gluonts.model.predictor import RepresentablePredictor
-from gluonts.transform import FieldName
 
 
 class IdentityPredictor(RepresentablePredictor):

--- a/src/gluonts/model/trivial/mean.py
+++ b/src/gluonts/model/trivial/mean.py
@@ -21,12 +21,12 @@ from pydantic import PositiveInt
 # First-party imports
 from gluonts.core.component import validated
 from gluonts.dataset.common import DataEntry, Dataset
+from gluonts.dataset.field_names import FieldName
 from gluonts.model.trivial.constant import ConstantPredictor
 from gluonts.model.estimator import Estimator
 from gluonts.model.forecast import Forecast, SampleForecast
 from gluonts.model.predictor import RepresentablePredictor, FallbackPredictor
 from gluonts.support.pandas import frequency_add
-from gluonts.transform import FieldName
 
 
 class MeanPredictor(RepresentablePredictor, FallbackPredictor):

--- a/src/gluonts/model/wavenet/_estimator.py
+++ b/src/gluonts/model/wavenet/_estimator.py
@@ -24,6 +24,7 @@ import numpy as np
 from gluonts import transform
 from gluonts.core.component import validated
 from gluonts.dataset.common import Dataset
+from gluonts.dataset.field_names import FieldName
 from gluonts.dataset.loader import TrainDataLoader
 from gluonts.model.estimator import GluonEstimator
 from gluonts.model.predictor import Predictor, RepresentableBlockPredictor
@@ -42,7 +43,6 @@ from gluonts.transform import (
     Chain,
     DataEntry,
     ExpectedNumInstanceSampler,
-    FieldName,
     InstanceSplitter,
     SetFieldIfNotPresent,
     SimpleTransformation,

--- a/src/gluonts/transform.py
+++ b/src/gluonts/transform.py
@@ -52,31 +52,6 @@ def serialize_data_entry(data_entry: DataEntry) -> Dict:
     }
 
 
-class FieldName:
-    """
-    A bundle of default field names to be used by clients when instantiating
-    transformer instances.
-    """
-
-    ITEM_ID = "item_id"
-
-    START = "start"
-    TARGET = "target"
-
-    FEAT_STATIC_CAT = "feat_static_cat"
-    FEAT_STATIC_REAL = "feat_static_real"
-    FEAT_DYNAMIC_CAT = "feat_dynamic_cat"
-    FEAT_DYNAMIC_REAL = "feat_dynamic_real"
-
-    FEAT_TIME = "time_feat"
-    FEAT_CONST = "feat_dynamic_const"
-    FEAT_AGE = "feat_dynamic_age"
-
-    OBSERVED_VALUES = "observed_values"
-    IS_PAD = "is_pad"
-    FORECAST_START = "forecast_start"
-
-
 def shift_timestamp(ts: pd.Timestamp, offset: int) -> pd.Timestamp:
     """
     Computes a shifted timestamp.

--- a/test/dataset/test_fieldnames.py
+++ b/test/dataset/test_fieldnames.py
@@ -1,0 +1,30 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# First-party imports
+from gluonts.dataset.field_names import FieldName
+
+
+def test_dataset_fields():
+    assert (
+        "feat_static_cat" == FieldName.FEAT_STATIC_CAT
+    ), "Error in the FieldName 'feat_static_cat'."
+    assert (
+        "feat_static_real" == FieldName.FEAT_STATIC_REAL
+    ), "Error in the FieldName 'feat_static_real'."
+    assert (
+        "feat_dynamic_cat" == FieldName.FEAT_DYNAMIC_CAT
+    ), "Error in the FieldName 'feat_dynamic_cat'."
+    assert (
+        "feat_dynamic_real" == FieldName.FEAT_DYNAMIC_REAL
+    ), "Error in the FieldName 'feat_dynamic_real'."

--- a/test/model/seq2seq/test_forking_sequence_splitter.py
+++ b/test/model/seq2seq/test_forking_sequence_splitter.py
@@ -17,6 +17,7 @@ import numpy as np
 # First-party imports
 from gluonts import transform
 from gluonts.dataset.common import ListDataset
+from gluonts.dataset.field_names import FieldName
 from gluonts.model.seq2seq._transform import ForkingSequenceSplitter
 from gluonts.transform import TestSplitSampler
 
@@ -41,7 +42,7 @@ def test_forking_sequence_splitter() -> None:
     trans = transform.Chain(
         trans=[
             transform.AddAgeFeature(
-                target_field=transform.FieldName.TARGET,
+                target_field=FieldName.TARGET,
                 output_field="age",
                 pred_length=10,
             ),
@@ -75,7 +76,7 @@ def test_forking_sequence_splitter() -> None:
     trans_oob = transform.Chain(
         trans=[
             transform.AddAgeFeature(
-                target_field=transform.FieldName.TARGET,
+                target_field=FieldName.TARGET,
                 output_field="age",
                 pred_length=10,
             ),

--- a/test/model/test_deepar_smoke.py
+++ b/test/model/test_deepar_smoke.py
@@ -20,8 +20,8 @@ import pytest
 
 # First-party imports
 from gluonts.dataset.common import ListDataset
+from gluonts.dataset.field_names import FieldName
 from gluonts.model.deepar import DeepAREstimator
-from gluonts.transform import FieldName
 from gluonts.trainer import Trainer
 
 

--- a/test/paper_examples/test_axiv_paper_examples.py
+++ b/test/paper_examples/test_axiv_paper_examples.py
@@ -13,6 +13,7 @@
 
 # First-party imports
 from gluonts.dataset.artificial import constant_dataset
+from gluonts.dataset.field_names import FieldName
 
 
 def test_listing_1():
@@ -64,7 +65,6 @@ def test_appendix_c():
     from gluonts.trainer import Trainer
     from gluonts.transform import (
         InstanceSplitter,
-        FieldName,
         Transformation,
         ExpectedNumInstanceSampler,
     )

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -25,6 +25,7 @@ from gluonts import time_feature, transform
 from gluonts.core import fqname_for
 from gluonts.core.serde import dump_code, dump_json, load_code, load_json
 from gluonts.dataset.common import ProcessStartField
+from gluonts.dataset.field_names import FieldName
 from gluonts.dataset.stat import ScaleHistogram, calculate_dataset_statistics
 
 FREQ = "1D"
@@ -105,8 +106,8 @@ def test_align_timestamp():
 def test_AddTimeFeatures(start, target, is_train):
     pred_length = 13
     t = transform.AddTimeFeatures(
-        start_field=transform.FieldName.START,
-        target_field=transform.FieldName.TARGET,
+        start_field=FieldName.START,
+        target_field=FieldName.TARGET,
         output_field="myout",
         pred_length=pred_length,
         time_features=[time_feature.DayOfWeek(), time_feature.DayOfMonth()],
@@ -133,7 +134,7 @@ def test_AddAgeFeatures(start, target, is_train):
     pred_length = 13
     t = transform.AddAgeFeature(
         pred_length=pred_length,
-        target_field=transform.FieldName.TARGET,
+        target_field=FieldName.TARGET,
         output_field="age",
         log_scale=True,
     )
@@ -159,10 +160,10 @@ def test_InstanceSplitter(start, target, is_train):
     train_length = 100
     pred_length = 13
     t = transform.InstanceSplitter(
-        target_field=transform.FieldName.TARGET,
-        is_pad_field=transform.FieldName.IS_PAD,
-        start_field=transform.FieldName.START,
-        forecast_start_field=transform.FieldName.FORECAST_START,
+        target_field=FieldName.TARGET,
+        is_pad_field=FieldName.IS_PAD,
+        start_field=FieldName.START,
+        forecast_start_field=FieldName.FORECAST_START,
         train_sampler=transform.UniformSplitSampler(p=1.0),
         past_length=train_length,
         future_length=pred_length,
@@ -222,10 +223,10 @@ def test_CanonicalInstanceSplitter(
     train_length = 100
     pred_length = 13
     t = transform.CanonicalInstanceSplitter(
-        target_field=transform.FieldName.TARGET,
-        is_pad_field=transform.FieldName.IS_PAD,
-        start_field=transform.FieldName.START,
-        forecast_start_field=transform.FieldName.FORECAST_START,
+        target_field=FieldName.TARGET,
+        is_pad_field=FieldName.IS_PAD,
+        start_field=FieldName.START,
+        forecast_start_field=FieldName.FORECAST_START,
         instance_sampler=transform.UniformSplitSampler(p=1.0),
         instance_length=train_length,
         prediction_length=pred_length,
@@ -278,8 +279,8 @@ def test_Transformation():
     t = transform.Chain(
         trans=[
             transform.AddTimeFeatures(
-                start_field=transform.FieldName.START,
-                target_field=transform.FieldName.TARGET,
+                start_field=FieldName.START,
+                target_field=FieldName.TARGET,
                 output_field="time_feat",
                 time_features=[
                     time_feature.DayOfWeek(),
@@ -289,14 +290,13 @@ def test_Transformation():
                 pred_length=pred_length,
             ),
             transform.AddAgeFeature(
-                target_field=transform.FieldName.TARGET,
+                target_field=FieldName.TARGET,
                 output_field="age",
                 pred_length=pred_length,
                 log_scale=True,
             ),
             transform.AddObservedValuesIndicator(
-                target_field=transform.FieldName.TARGET,
-                output_field="observed_values",
+                target_field=FieldName.TARGET, output_field="observed_values"
             ),
             transform.VstackFeatures(
                 output_field="dynamic_feat",
@@ -304,10 +304,10 @@ def test_Transformation():
                 drop_inputs=True,
             ),
             transform.InstanceSplitter(
-                target_field=transform.FieldName.TARGET,
-                is_pad_field=transform.FieldName.IS_PAD,
-                start_field=transform.FieldName.START,
-                forecast_start_field=transform.FieldName.FORECAST_START,
+                target_field=FieldName.TARGET,
+                is_pad_field=FieldName.IS_PAD,
+                start_field=FieldName.START,
+                forecast_start_field=FieldName.FORECAST_START,
                 train_sampler=transform.ExpectedNumInstanceSampler(
                     num_instances=4
                 ),
@@ -348,8 +348,8 @@ def test_multi_dim_transformation(is_train):
     t = transform.Chain(
         trans=[
             transform.AddTimeFeatures(
-                start_field=transform.FieldName.START,
-                target_field=transform.FieldName.TARGET,
+                start_field=FieldName.START,
+                target_field=FieldName.TARGET,
                 output_field="time_feat",
                 time_features=[
                     time_feature.DayOfWeek(),
@@ -359,13 +359,13 @@ def test_multi_dim_transformation(is_train):
                 pred_length=pred_length,
             ),
             transform.AddAgeFeature(
-                target_field=transform.FieldName.TARGET,
+                target_field=FieldName.TARGET,
                 output_field="age",
                 pred_length=pred_length,
                 log_scale=True,
             ),
             transform.AddObservedValuesIndicator(
-                target_field=transform.FieldName.TARGET,
+                target_field=FieldName.TARGET,
                 output_field="observed_values",
                 convert_nans=False,
             ),
@@ -375,10 +375,10 @@ def test_multi_dim_transformation(is_train):
                 drop_inputs=True,
             ),
             transform.InstanceSplitter(
-                target_field=transform.FieldName.TARGET,
-                is_pad_field=transform.FieldName.IS_PAD,
-                start_field=transform.FieldName.START,
-                forecast_start_field=transform.FieldName.FORECAST_START,
+                target_field=FieldName.TARGET,
+                is_pad_field=FieldName.IS_PAD,
+                start_field=FieldName.START,
+                forecast_start_field=FieldName.FORECAST_START,
                 train_sampler=transform.ExpectedNumInstanceSampler(
                     num_instances=4
                 ),
@@ -437,10 +437,10 @@ def test_ExpectedNumInstanceSampler():
     t = transform.Chain(
         trans=[
             transform.InstanceSplitter(
-                target_field=transform.FieldName.TARGET,
-                is_pad_field=transform.FieldName.IS_PAD,
-                start_field=transform.FieldName.START,
-                forecast_start_field=transform.FieldName.FORECAST_START,
+                target_field=FieldName.TARGET,
+                is_pad_field=FieldName.IS_PAD,
+                start_field=FieldName.START,
+                forecast_start_field=FieldName.FORECAST_START,
                 train_sampler=transform.ExpectedNumInstanceSampler(
                     num_instances=4
                 ),
@@ -479,10 +479,10 @@ def test_BucketInstanceSampler():
     t = transform.Chain(
         trans=[
             transform.InstanceSplitter(
-                target_field=transform.FieldName.TARGET,
-                is_pad_field=transform.FieldName.IS_PAD,
-                start_field=transform.FieldName.START,
-                forecast_start_field=transform.FieldName.FORECAST_START,
+                target_field=FieldName.TARGET,
+                is_pad_field=FieldName.IS_PAD,
+                start_field=FieldName.START,
+                forecast_start_field=FieldName.FORECAST_START,
                 train_sampler=transform.BucketInstanceSampler(
                     dataset_stats.scale_histogram
                 ),


### PR DESCRIPTION
The field names of a dataset are not checked for consistency across the different modules. If a field changes in the `FieldName` class, there is no error raised, the old fields are never there in the new datasets and therefore ignored, and the new fields are not processed.

This caused issue #283 in the dataset statistics calculation `dataset.calc_stats()`.

This PR includes the following changes:
- fixes the `calc_stats` issue (fixes issue #283 )
- moves the `FieldName` class to a separate module to avoid circular dependencies and to increase visibility for potential future changes (it was in the `transform` package with all the transformations and it did not really belong there)
- adds tests for potential change on the `FieldName` class so people are warned at least that they should not touch it without a larger refactoring
- adds tests for the `calc_stats` method

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
