### PR TITLE
Pytest-timeout==1.3; removes warnings from logs.

### DIFF
--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -3,4 +3,4 @@ pytest==3.*
 pytest-cov==2.6.*
 pytest-runner<2.12
 pytest-xdist==1.27.*
-pytest-timeout==1.2.*
+pytest-timeout==1.3.*


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
