### PR TITLE
make tensors and distributions serializable

### DIFF
--- a/src/gluonts/core/serde.py
+++ b/src/gluonts/core/serde.py
@@ -476,6 +476,16 @@ def encode_np_dtype(v: np.dtype) -> Any:
     }
 
 
+@encode.register(mx.nd.NDArray)
+def encode_mx_ndarray(v: mx.nd.NDArray) -> Any:
+    return {
+        "__kind__": kind_inst,
+        "class": "mxnet.nd.array",
+        "args": encode([v.asnumpy().tolist()]),
+        "kwargs": {"dtype": encode(v.dtype)},
+    }
+
+
 def decode(r: Any) -> Any:
     """
     Decodes a value from an intermediate representation `r`.

--- a/src/gluonts/distribution/bijection.py
+++ b/src/gluonts/distribution/bijection.py
@@ -19,6 +19,7 @@ import numpy as np
 
 # First-party imports
 from gluonts.model.common import Tensor
+from gluonts.core.component import validated
 
 # Relative imports
 from .distribution import getF
@@ -31,6 +32,10 @@ class Bijection:
     This is defined through the forward tranformation (computed by the
     `f` method) and the inverse transformation (`f_inv`).
     """
+
+    @validated()
+    def __init__(self):
+        pass
 
     def f(self, x: Tensor) -> Tensor:
         r"""
@@ -89,6 +94,7 @@ class InverseBijection(Bijection):
         The transformation to invert.
     """
 
+    @validated()
     def __init__(self, bijection: Bijection) -> None:
         self._bijection = bijection
 
@@ -197,6 +203,7 @@ class AffineTransformation(Bijection):
         Scaling parameter.
     """
 
+    @validated()
     def __init__(
         self, loc: Optional[Tensor] = None, scale: Optional[Tensor] = None
     ) -> None:

--- a/src/gluonts/distribution/binned.py
+++ b/src/gluonts/distribution/binned.py
@@ -43,6 +43,7 @@ class Binned(Distribution):
 
     is_reparameterizable = False
 
+    @validated()
     def __init__(self, bin_probs: Tensor, bin_centers: Tensor, F=None) -> None:
         self.bin_centers = bin_centers
         self.bin_probs = bin_probs

--- a/src/gluonts/distribution/box_cox_tranform.py
+++ b/src/gluonts/distribution/box_cox_tranform.py
@@ -115,6 +115,7 @@ class BoxCoxTranform(Bijection):
     """
     arg_names = ["box_cox.lambda_1", "box_cox.lambda_2"]
 
+    @validated()
     def __init__(
         self,
         lambda_1: Tensor,
@@ -271,6 +272,7 @@ class InverseBoxCoxTransform(InverseBijection):
 
     arg_names = ["box_cox.lambda_1", "box_cox.lambda_2"]
 
+    @validated()
     def __init__(
         self,
         lambda_1: Tensor,

--- a/src/gluonts/distribution/distribution_output.py
+++ b/src/gluonts/distribution/distribution_output.py
@@ -125,7 +125,7 @@ class DistributionOutput(Output):
         else:
             distr = self.distr_cls(*distr_args)
             return TransformedDistribution(
-                distr, AffineTransformation(scale=scale)
+                distr, [AffineTransformation(scale=scale)]
             )
 
     @property

--- a/src/gluonts/distribution/gaussian.py
+++ b/src/gluonts/distribution/gaussian.py
@@ -18,6 +18,7 @@ from typing import Dict, Optional, Tuple
 # First-party imports
 from gluonts.model.common import Tensor
 from gluonts.support.util import erf
+from gluonts.core.component import validated
 
 # Relative imports
 from .distribution import Distribution, _sample_multiple, getF, softplus
@@ -40,6 +41,7 @@ class Gaussian(Distribution):
 
     is_reparameterizable = True
 
+    @validated()
     def __init__(self, mu: Tensor, sigma: Tensor, F=None) -> None:
         self.mu = mu
         self.sigma = sigma

--- a/src/gluonts/distribution/laplace.py
+++ b/src/gluonts/distribution/laplace.py
@@ -16,6 +16,7 @@ from typing import Dict, Tuple
 
 # First-party imports
 from gluonts.model.common import Tensor
+from gluonts.core.component import validated
 
 # Relative imports
 from .distribution import Distribution, _sample_multiple, getF, softplus
@@ -38,6 +39,7 @@ class Laplace(Distribution):
 
     is_reparameterizable = True
 
+    @validated()
     def __init__(self, mu: Tensor, b: Tensor, F=None) -> None:
         self.mu = mu
         self.b = b

--- a/src/gluonts/distribution/lds.py
+++ b/src/gluonts/distribution/lds.py
@@ -19,6 +19,7 @@ import numpy as np
 from gluonts.distribution import Distribution, Gaussian, MultivariateGaussian
 from gluonts.distribution.distribution import getF
 from gluonts.model.common import Tensor
+from gluonts.core.component import validated
 from gluonts.support.util import make_nd_diag, _broadcast_param
 from gluonts.support.linalg_util import jitter_cholesky
 
@@ -75,6 +76,7 @@ class LDS(Distribution):
     F
     """
 
+    @validated()
     def __init__(
         self,
         emission_coeff: Tensor,

--- a/src/gluonts/distribution/lowrank_multivariate_gaussian.py
+++ b/src/gluonts/distribution/lowrank_multivariate_gaussian.py
@@ -185,6 +185,7 @@ class LowrankMultivariateGaussian(Distribution):
 
     is_reparameterizable = True
 
+    @validated()
     def __init__(
         self, dim: int, rank: int, mu: Tensor, D: Tensor, W: Tensor
     ) -> None:

--- a/src/gluonts/distribution/mixture.py
+++ b/src/gluonts/distribution/mixture.py
@@ -50,6 +50,7 @@ class MixtureDistribution(Distribution):
 
     is_reparameterizable = False
 
+    @validated()
     def __init__(
         self, mixture_probs: Tensor, components: List[Distribution], F=None
     ) -> None:

--- a/src/gluonts/distribution/multivariate_gaussian.py
+++ b/src/gluonts/distribution/multivariate_gaussian.py
@@ -49,6 +49,7 @@ class MultivariateGaussian(Distribution):
 
     is_reparameterizable = True
 
+    @validated()
     def __init__(
         self, mu: Tensor, L: Tensor, F=None, float_type: DType = np.float32
     ) -> None:

--- a/src/gluonts/distribution/neg_binomial.py
+++ b/src/gluonts/distribution/neg_binomial.py
@@ -16,6 +16,7 @@ from typing import Dict, Optional, Tuple
 
 # First-party imports
 from gluonts.model.common import Tensor
+from gluonts.core.component import validated
 
 # Relative imports
 from .distribution import Distribution, _sample_multiple, getF, softplus
@@ -38,6 +39,7 @@ class NegativeBinomial(Distribution):
 
     is_reparameterizable = False
 
+    @validated()
     def __init__(self, mu: Tensor, alpha: Tensor, F=None) -> None:
         self.mu = mu
         self.alpha = alpha

--- a/src/gluonts/distribution/piecewise_linear.py
+++ b/src/gluonts/distribution/piecewise_linear.py
@@ -12,7 +12,7 @@
 # permissions and limitations under the License.
 
 # Standard library imports
-from typing import Dict, Optional, Tuple, cast
+from typing import Dict, Optional, Tuple, cast, List
 
 # First-party imports
 from gluonts.core.component import validated
@@ -60,6 +60,7 @@ class PiecewiseLinear(Distribution):
 
     is_reparameterizable = False
 
+    @validated()
     def __init__(
         self, gamma: Tensor, slopes: Tensor, knot_spacings: Tensor, F=None
     ) -> None:
@@ -342,7 +343,7 @@ class PiecewiseLinearOutput(DistributionOutput):
         else:
             distr = self.distr_cls(*distr_args)
             return TransformedPiecewiseLinear(
-                distr, AffineTransformation(scale=scale)
+                distr, [AffineTransformation(scale=scale)]
             )
 
     @property
@@ -352,10 +353,11 @@ class PiecewiseLinearOutput(DistributionOutput):
 
 # Need to inherit from PiecewiseLinear to get the overwritten loss method.
 class TransformedPiecewiseLinear(TransformedDistribution, PiecewiseLinear):
+    @validated()
     def __init__(
-        self, base_distribution: PiecewiseLinear, *transforms: Bijection
+        self, base_distribution: PiecewiseLinear, transforms: List[Bijection]
     ) -> None:
-        super().__init__(base_distribution, *transforms)
+        super().__init__(base_distribution, transforms)
 
     def crps(self, y: Tensor) -> Tensor:
         # TODO: use event_shape

--- a/src/gluonts/distribution/student_t.py
+++ b/src/gluonts/distribution/student_t.py
@@ -17,6 +17,7 @@ from typing import Dict, Optional, Tuple
 
 # First-party imports
 from gluonts.model.common import Tensor
+from gluonts.core.component import validated
 
 # Relative imports
 from .distribution import (
@@ -48,6 +49,7 @@ class StudentT(Distribution):
 
     is_reparameterizable = False
 
+    @validated()
     def __init__(self, mu: Tensor, sigma: Tensor, nu: Tensor, F=None) -> None:
         self.mu = mu
         self.sigma = sigma

--- a/src/gluonts/distribution/transformed_distribution.py
+++ b/src/gluonts/distribution/transformed_distribution.py
@@ -12,13 +12,14 @@
 # permissions and limitations under the License.
 
 # Standard library imports
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List
 
 # Third-party imports
 from mxnet import autograd
 
 # First-party imports
 from gluonts.model.common import Tensor
+from gluonts.core.component import validated
 
 # Relative imports
 from . import bijection as bij
@@ -31,8 +32,9 @@ class TransformedDistribution(Distribution):
     of a base distribution.
     """
 
+    @validated()
     def __init__(
-        self, base_distribution: Distribution, *transforms: bij.Bijection
+        self, base_distribution: Distribution, transforms: List[bij.Bijection]
     ) -> None:
         self.base_distribution = base_distribution
         self.transforms = transforms

--- a/src/gluonts/distribution/transformed_distribution_output.py
+++ b/src/gluonts/distribution/transformed_distribution_output.py
@@ -13,7 +13,7 @@
 
 # Standard library imports
 from collections import ChainMap
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List
 
 # Third-party imports
 import numpy as np
@@ -31,6 +31,7 @@ from gluonts.distribution.transformed_distribution import (
     TransformedDistribution,
 )
 from gluonts.model.common import Tensor
+from gluonts.core.component import validated
 
 
 class TransformedDistributionOutput(DistributionOutput):
@@ -39,10 +40,11 @@ class TransformedDistributionOutput(DistributionOutput):
     by a sequence of learnable bijections.
     """
 
+    @validated()
     def __init__(
         self,
         base_distr_output: DistributionOutput,
-        *transforms_output: BijectionOutput,
+        transforms_output: List[BijectionOutput],
     ) -> None:
         super().__init__()
         self.base_distr_output = base_distr_output

--- a/src/gluonts/distribution/uniform.py
+++ b/src/gluonts/distribution/uniform.py
@@ -16,6 +16,7 @@ from typing import Dict, Optional, Tuple
 
 # First-party imports
 from gluonts.model.common import Tensor
+from gluonts.core.component import validated
 
 # Relative imports
 from .distribution import Distribution, _sample_multiple, getF, softplus
@@ -37,6 +38,7 @@ class Uniform(Distribution):
 
     is_reparameterizable = True
 
+    @validated()
     def __init__(self, low: Tensor, high: Tensor, F=None) -> None:
         self.low = low
         self.high = high

--- a/test/core/test_serde.py
+++ b/test/core/test_serde.py
@@ -126,3 +126,31 @@ def test_json_serialization(e) -> None:
 @pytest.mark.parametrize("e", examples)
 def test_code_serialization(e) -> None:
     assert equals(e, serde.load_code(serde.dump_code(e)))
+
+
+@pytest.mark.parametrize(
+    "a",
+    [
+        mx.nd.random.uniform(shape=(3, 5, 2), dtype="float16"),
+        mx.nd.random.uniform(shape=(3, 5, 2), dtype="float32"),
+        mx.nd.random.uniform(shape=(3, 5, 2), dtype="float64"),
+        mx.nd.array([[1, 2, 3], [-1, -2, 0]], dtype=np.uint8),
+        mx.nd.array([[1, 2, 3], [-1, -2, 0]], dtype=np.int32),
+        mx.nd.array([[1, 2, 3], [-1, -2, 0]], dtype=np.int64),
+        mx.nd.array([[1, 2, 3], [1, 2, 0]], dtype=np.uint8),
+    ],
+)
+@pytest.mark.parametrize(
+    "serialize_fn",
+    [
+        lambda x: serde.load_json(serde.dump_json(x)),
+        lambda x: serde.load_binary(serde.dump_binary(x)),
+        lambda x: serde.load_code(serde.dump_code(x)),
+    ],
+)
+def test_ndarray_serialization(a, serialize_fn) -> None:
+    b = serialize_fn(a)
+    assert type(a) == type(b)
+    assert a.dtype == b.dtype
+    assert a.shape == b.shape
+    assert np.all((a == b).asnumpy())

--- a/test/distribution/test_distribution_inference.py
+++ b/test/distribution/test_distribution_inference.py
@@ -558,7 +558,7 @@ def test_box_cox_tranform(
     # Here the base distribution is Guassian which is transformed to
     # non-Gaussian via the inverse Box-Cox transform.
     # Sampling from `trans_distr` gives non-Gaussian samples
-    trans_distr = TransformedDistribution(gausian_distr, transform)
+    trans_distr = TransformedDistribution(gausian_distr, [transform])
 
     # Given the non-Gaussian samples find the true parameters
     # of the Box-Cox transformation as well as the underlying Gaussian distribution.

--- a/test/distribution/test_distribution_methods.py
+++ b/test/distribution/test_distribution_methods.py
@@ -29,6 +29,8 @@ from gluonts.distribution import (
     TransformedDistribution,
 )
 
+from gluonts.core.serde import load_json, dump_json
+
 test_cases = [
     (
         Gaussian,
@@ -117,9 +119,14 @@ DISTRIBUTIONS = [
 ]
 
 
+serialize_fn_list = [lambda x: x, lambda x: load_json(dump_json(x))]
+
+
 @pytest.mark.parametrize("distr_class, params", test_cases)
-def test_means(distr_class, params) -> None:
+@pytest.mark.parametrize("serialize_fn", serialize_fn_list)
+def test_means(distr_class, params, serialize_fn) -> None:
     distr = distr_class(**params)
+    distr = serialize_fn(distr)
     means = distr.mean
     distr_name = distr.__class__.__name__
     assert means.shape == test_output[distr_name]["mean"].shape
@@ -130,8 +137,10 @@ def test_means(distr_class, params) -> None:
 
 
 @pytest.mark.parametrize("distr_class, params", test_cases)
-def test_stdevs(distr_class, params) -> None:
+@pytest.mark.parametrize("serialize_fn", serialize_fn_list)
+def test_stdevs(distr_class, params, serialize_fn) -> None:
     distr = distr_class(**params)
+    distr = serialize_fn(distr)
     stddevs = distr.stddev
     distr_name = distr.__class__.__name__
     assert stddevs.shape == test_output[distr_name]["stddev"].shape
@@ -143,8 +152,10 @@ def test_stdevs(distr_class, params) -> None:
 
 
 @pytest.mark.parametrize("distr_class, params", test_cases)
-def test_variances(distr_class, params) -> None:
+@pytest.mark.parametrize("serialize_fn", serialize_fn_list)
+def test_variances(distr_class, params, serialize_fn) -> None:
     distr = distr_class(**params)
+    distr = serialize_fn(distr)
     variances = distr.variance
     distr_name = distr.__class__.__name__
     assert variances.shape == test_output[distr_name]["variance"].shape

--- a/test/distribution/test_distribution_sampling.py
+++ b/test/distribution/test_distribution_sampling.py
@@ -28,6 +28,7 @@ from gluonts.distribution import (
     Binned,
     TransformedDistribution,
 )
+from gluonts.core.serde import dump_json, load_json, dump_code, load_code
 
 from gluonts.testutil import empirical_cdf
 
@@ -77,12 +78,17 @@ test_cases = [
 ]
 
 
+serialize_fn_list = [lambda x: x, lambda x: load_json(dump_json(x))]
+
+
 DISTRIBUTIONS_WITH_CDF = [Gaussian, Uniform, Laplace, Binned]
 
 
 @pytest.mark.parametrize("distr_class, params", test_cases)
-def test_sampling(distr_class, params) -> None:
+@pytest.mark.parametrize("serialize_fn", serialize_fn_list)
+def test_sampling(distr_class, params, serialize_fn) -> None:
     distr = distr_class(**params)
+    distr = serialize_fn(distr)
     samples = distr.sample()
     assert samples.shape == (2,)
     num_samples = 100_000
@@ -118,8 +124,10 @@ test_cases_multivariate = [
 
 
 @pytest.mark.parametrize("distr, params", test_cases_multivariate)
-def test_multivariate_sampling(distr, params) -> None:
+@pytest.mark.parametrize("serialize_fn", serialize_fn_list)
+def test_multivariate_sampling(distr, params, serialize_fn) -> None:
     distr = distr(**params)
+    distr = serialize_fn(distr)
     samples = distr.sample()
     assert samples.shape == (2,)
     num_samples = 100_000
@@ -161,8 +169,10 @@ test_cases_pwl_sqf = [
 
 
 @pytest.mark.parametrize("distr, params", test_cases_pwl_sqf)
-def test_piecewise_linear_sampling(distr, params):
+@pytest.mark.parametrize("serialize_fn", serialize_fn_list)
+def test_piecewise_linear_sampling(distr, params, serialize_fn):
     distr = distr(**params)
+    distr = serialize_fn(distr)
     samples = distr.sample()
     assert samples.shape == (2,)
     num_samples = 100_000

--- a/test/distribution/test_distribution_shapes.py
+++ b/test/distribution/test_distribution_shapes.py
@@ -147,9 +147,11 @@ from gluonts.distribution.box_cox_tranform import BoxCoxTranform
                     sigma=mx.nd.ones(shape=(3, 4, 5)),
                     nu=mx.nd.ones(shape=(3, 4, 5)),
                 ),
-                AffineTransformation(
-                    scale=1e-1 + mx.nd.random.uniform(shape=(3, 4, 5))
-                ),
+                [
+                    AffineTransformation(
+                        scale=1e-1 + mx.nd.random.uniform(shape=(3, 4, 5))
+                    )
+                ],
             ),
             (3, 4, 5),
             (),
@@ -162,9 +164,11 @@ from gluonts.distribution.box_cox_tranform import BoxCoxTranform
                         F=mx.nd, x=mx.nd.ones(shape=(3, 4, 5)), d=5
                     ),
                 ),
-                AffineTransformation(
-                    scale=1e-1 + mx.nd.random.uniform(shape=(3, 4, 5))
-                ),
+                [
+                    AffineTransformation(
+                        scale=1e-1 + mx.nd.random.uniform(shape=(3, 4, 5))
+                    )
+                ],
             ),
             (3, 4),
             (5,),
@@ -175,10 +179,12 @@ from gluonts.distribution.box_cox_tranform import BoxCoxTranform
                     low=mx.nd.zeros(shape=(3, 4, 5)),
                     high=mx.nd.ones(shape=(3, 4, 5)),
                 ),
-                BoxCoxTranform(
-                    lambda_1=mx.nd.ones(shape=(3, 4, 5)),
-                    lambda_2=mx.nd.zeros(shape=(3, 4, 5)),
-                ),
+                [
+                    BoxCoxTranform(
+                        lambda_1=mx.nd.ones(shape=(3, 4, 5)),
+                        lambda_2=mx.nd.zeros(shape=(3, 4, 5)),
+                    )
+                ],
             ),
             (3, 4, 5),
             (),

--- a/test/distribution/test_transformed_distribution.py
+++ b/test/distribution/test_transformed_distribution.py
@@ -14,6 +14,7 @@
 # Third-party imports
 import mxnet.ndarray as nd
 import numpy as np
+import pytest
 
 # First-party imports
 from gluonts.distribution import Uniform
@@ -21,22 +22,27 @@ from gluonts.distribution.transformed_distribution import (
     TransformedDistribution,
 )
 from gluonts.distribution import bijection
+from gluonts.core.serde import dump_json, load_json
+
+
+serialize_fn_list = [lambda x: x, lambda x: load_json(dump_json(x))]
 
 
 def exp_cdf(x: np.ndarray) -> np.ndarray:
     return 1.0 - np.exp(-x)
 
 
-def test_transformed_distribution() -> None:
+@pytest.mark.parametrize("serialize_fn", serialize_fn_list)
+def test_transformed_distribution(serialize_fn) -> None:
     zero = nd.zeros(1)
     one = nd.ones(1)
 
     # If Y = -log(U) with U ~ Uniform(0, 1), then Y ~ Exponential(1)
     exponential = TransformedDistribution(
         Uniform(zero, one),
-        bijection.log,
-        bijection.AffineTransformation(scale=-1 * one),
+        [bijection.log, bijection.AffineTransformation(scale=-1 * one)],
     )
+    exponential = serialize_fn(exponential)
 
     # For Y ~ Exponential(1), P(Y) = e^{-x) ==> log P(Y) = -x
     assert exponential.log_prob(1 * one).asscalar() == -1.0
@@ -48,10 +54,13 @@ def test_transformed_distribution() -> None:
     # If Y ~ Exponential(1), then U = 1 - e^{-Y} has Uniform(0, 1) distribution
     uniform = TransformedDistribution(
         exponential,
-        bijection.AffineTransformation(scale=-1 * one),
-        bijection.log.inverse_bijection(),  # == bijection.exp
-        bijection.AffineTransformation(loc=one, scale=-1 * one),
+        [
+            bijection.AffineTransformation(scale=-1 * one),
+            bijection.log.inverse_bijection(),  # == bijection.exp
+            bijection.AffineTransformation(loc=one, scale=-1 * one),
+        ],
     )
+    uniform = serialize_fn(uniform)
     # For U ~ Uniform(0, 1), log P(U) = 0
     assert uniform.log_prob(0.5 * one).asscalar() == 0
     assert uniform.log_prob(0.2 * one).asscalar() == 0

--- a/test/model/test_models.py
+++ b/test/model/test_models.py
@@ -238,7 +238,7 @@ def seasonal_estimator():
             deepar_estimator(hybridize=hyb, batches_per_epoch=50)
             + (1.5,),  # large value as this test is breaking frequently
             deep_factor_estimator(hybridize=hyb, batches_per_epoch=200)
-            + (0.2,),
+            + (0.3,),
             gp_estimator(hybridize=hyb, batches_per_epoch=200) + (0.2,),
             mlp_estimator(hybridize=hyb) + (10.0,),
             mqcnn_estimator(hybridize=hyb, batches_per_epoch=200) + (0.2,),


### PR DESCRIPTION
*Description of changes:*
This change makes mxnet tensors serializable with our `validated` mechanism and uses this to make all distributions serializable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
