### PR TITLE
Assert that static cat features are used in case cardinality is explicitly set

### DIFF
--- a/src/gluonts/model/deepar/_estimator.py
+++ b/src/gluonts/model/deepar/_estimator.py
@@ -140,9 +140,9 @@ class DeepAREstimator(GluonEstimator):
         assert num_layers > 0, "The value of `num_layers` should be > 0"
         assert num_cells > 0, "The value of `num_cells` should be > 0"
         assert dropout_rate >= 0, "The value of `dropout_rate` should be >= 0"
-        assert (
-            cardinality is not None or not use_feat_static_cat
-        ), "You must set `cardinality` if `use_feat_static_cat=True`"
+        assert (cardinality is not None and use_feat_static_cat) or (
+            cardinality is None and not use_feat_static_cat
+        ), "You should set `cardinality` if and only if `use_feat_static_cat=True`"
         assert cardinality is None or [
             c > 0 for c in cardinality
         ], "Elements of `cardinality` should be > 0"

--- a/src/gluonts/model/deepstate/_estimator.py
+++ b/src/gluonts/model/deepstate/_estimator.py
@@ -169,9 +169,9 @@ class DeepStateEstimator(GluonEstimator):
             num_eval_samples > 0
         ), "The value of `num_eval_samples` should be > 0"
         assert dropout_rate >= 0, "The value of `dropout_rate` should be >= 0"
-        assert (
-            cardinality is not None or not use_feat_static_cat
-        ), "You must set `cardinality` if `use_feat_static_cat=True`"
+        assert (cardinality is not None and use_feat_static_cat) or (
+            cardinality is None and not use_feat_static_cat
+        ), "You should set `cardinality` if and only if `use_feat_static_cat=True`"
         assert cardinality is None or [
             c > 0 for c in cardinality
         ], "Elements of `cardinality` should be > 0"


### PR DESCRIPTION
This is extra safeguard to make sure that `use_feat_static_cat` is explicitly set if  cardinality is set. I saw people leaving the defaults for `use_feat_static_cat` and believing the static features are used by deepar since they have set `cardinality`.

There is already issue/enhancement #144 opened to change the default behavior of setting `use_feat_static_cat=False`. We at least need the current fix until #144 is resolved. 

*Description of changes:*
Currently it asserts one way implication:  `use_feat_static_cat=True` \implies `cardinality is not None`.
We need the converse as well: `cardinality is not None` \implies `use_feat_static_cat=True`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
