### PR TITLE
Adding FieldNames to artificial dataset module

### DIFF
--- a/src/gluonts/dataset/artificial/_base.py
+++ b/src/gluonts/dataset/artificial/_base.py
@@ -158,7 +158,9 @@ class ConstantDataset(ArtificialDataset):
                     }
                 ],
                 feat_static_real=[{"name": "feat_static_real_000"}],
-                feat_dynamic_real=[BasicFeatureInfo(name=FieldName.FEAT_DYNAMIC_REAL)],
+                feat_dynamic_real=[
+                    BasicFeatureInfo(name=FieldName.FEAT_DYNAMIC_REAL)
+                ],
                 prediction_length=self.prediction_length,
             )
         return metadata
@@ -196,7 +198,9 @@ class ConstantDataset(ArtificialDataset):
             recipe.append(
                 ("binary_causal", BinaryMarkovChain(one_to_zero, zero_to_one))
             )
-            recipe.append((FieldName.FEAT_DYNAMIC_REAL, Stack(["binary_causal"])))
+            recipe.append(
+                (FieldName.FEAT_DYNAMIC_REAL, Stack(["binary_causal"]))
+            )
             recipe_type += scale_features * Lag("binary_causal", lag=0)
         if self.holidays:
             timestamp = self.init_date()
@@ -206,7 +210,9 @@ class ConstantDataset(ArtificialDataset):
                 dates.append(timestamp)
                 timestamp += 1
             recipe.append(("binary_holidays", Binary(dates, self.holidays)))
-            recipe.append((FieldName.FEAT_DYNAMIC_REAL, Stack(["binary_holidays"])))
+            recipe.append(
+                (FieldName.FEAT_DYNAMIC_REAL, Stack(["binary_holidays"]))
+            )
             recipe_type += scale_features * Lag("binary_holidays", lag=0)
         recipe.append((FieldName.TARGET, recipe_type))
         max_train_length = num_steps - self.prediction_length
@@ -688,9 +694,13 @@ class RecipeDataset(ArtificialDataset):
         )
 
         if FieldName.FEAT_DYNAMIC_CAT in x:
-            y[FieldName.FEAT_DYNAMIC_CAT] = x[FieldName.FEAT_DYNAMIC_CAT][:, :-length]
+            y[FieldName.FEAT_DYNAMIC_CAT] = x[FieldName.FEAT_DYNAMIC_CAT][
+                :, :-length
+            ]
         if FieldName.FEAT_DYNAMIC_REAL in x:
-            y[FieldName.FEAT_DYNAMIC_REAL] = x[FieldName.FEAT_DYNAMIC_REAL][:, :-length]
+            y[FieldName.FEAT_DYNAMIC_REAL] = x[FieldName.FEAT_DYNAMIC_REAL][
+                :, :-length
+            ]
         if FieldName.FEAT_DYNAMIC_CAT in x:
             y[FieldName.FEAT_DYNAMIC_CAT] = x[FieldName.FEAT_DYNAMIC_CAT]
         if FieldName.FEAT_DYNAMIC_REAL in x:
@@ -712,9 +722,13 @@ class RecipeDataset(ArtificialDataset):
         )
 
         if FieldName.FEAT_DYNAMIC_CAT in x:
-            y[FieldName.FEAT_DYNAMIC_CAT] = x[FieldName.FEAT_DYNAMIC_CAT][:, length:]
+            y[FieldName.FEAT_DYNAMIC_CAT] = x[FieldName.FEAT_DYNAMIC_CAT][
+                :, length:
+            ]
         if FieldName.FEAT_DYNAMIC_REAL in x:
-            y[FieldName.FEAT_DYNAMIC_REAL] = x[FieldName.FEAT_DYNAMIC_REAL][:, length:]
+            y[FieldName.FEAT_DYNAMIC_REAL] = x[FieldName.FEAT_DYNAMIC_REAL][
+                :, length:
+            ]
         if FieldName.FEAT_DYNAMIC_CAT in x:
             y[FieldName.FEAT_DYNAMIC_CAT] = x[FieldName.FEAT_DYNAMIC_CAT]
         if FieldName.FEAT_DYNAMIC_REAL in x:
@@ -764,11 +778,17 @@ def default_synthetic() -> Tuple[DatasetInfo, Dataset, Dataset]:
         recipe=recipe,
         metadata=MetaData(
             freq="D",
-            feat_static_real=[BasicFeatureInfo(name=FieldName.FEAT_STATIC_REAL)],
-            feat_static_cat=[
-                CategoricalFeatureInfo(name=FieldName.FEAT_STATIC_CAT, cardinality=10)
+            feat_static_real=[
+                BasicFeatureInfo(name=FieldName.FEAT_STATIC_REAL)
             ],
-            feat_dynamic_real=[BasicFeatureInfo(name=FieldName.FEAT_DYNAMIC_REAL)],
+            feat_static_cat=[
+                CategoricalFeatureInfo(
+                    name=FieldName.FEAT_STATIC_CAT, cardinality=10
+                )
+            ],
+            feat_dynamic_real=[
+                BasicFeatureInfo(name=FieldName.FEAT_DYNAMIC_REAL)
+            ],
         ),
         max_train_length=20,
         prediction_length=10,
@@ -805,7 +825,7 @@ def constant_dataset() -> Tuple[DatasetInfo, Dataset, Dataset]:
                 FieldName.ITEM_ID: str(i),
                 FieldName.START: start_date,
                 FieldName.TARGET: [float(i)] * 24,
-                FieldName.FEAT_STATIC_CAT : [i],
+                FieldName.FEAT_STATIC_CAT: [i],
                 FieldName.FEAT_STATIC_REAL: [float(i)],
             }
             for i in range(10)

--- a/src/gluonts/dataset/artificial/_base.py
+++ b/src/gluonts/dataset/artificial/_base.py
@@ -701,11 +701,6 @@ class RecipeDataset(ArtificialDataset):
             y[FieldName.FEAT_DYNAMIC_REAL] = x[FieldName.FEAT_DYNAMIC_REAL][
                 :, :-length
             ]
-        if FieldName.FEAT_DYNAMIC_CAT in x:
-            y[FieldName.FEAT_DYNAMIC_CAT] = x[FieldName.FEAT_DYNAMIC_CAT]
-        if FieldName.FEAT_DYNAMIC_REAL in x:
-            y[FieldName.FEAT_DYNAMIC_REAL] = x[FieldName.FEAT_DYNAMIC_REAL]
-
         return y
 
     @staticmethod
@@ -729,11 +724,6 @@ class RecipeDataset(ArtificialDataset):
             y[FieldName.FEAT_DYNAMIC_REAL] = x[FieldName.FEAT_DYNAMIC_REAL][
                 :, length:
             ]
-        if FieldName.FEAT_DYNAMIC_CAT in x:
-            y[FieldName.FEAT_DYNAMIC_CAT] = x[FieldName.FEAT_DYNAMIC_CAT]
-        if FieldName.FEAT_DYNAMIC_REAL in x:
-            y[FieldName.FEAT_DYNAMIC_REAL] = x[FieldName.FEAT_DYNAMIC_REAL]
-
         return y
 
     def generate(self) -> TrainDatasets:

--- a/src/gluonts/dataset/artificial/generate_synthetic.py
+++ b/src/gluonts/dataset/artificial/generate_synthetic.py
@@ -29,6 +29,7 @@ from gluonts.dataset.artificial._base import (
     ComplexSeasonalTimeSeries,
     ConstantDataset,
 )
+from gluonts.dataset.field_names import FieldName
 
 
 def write_csv_row(
@@ -51,13 +52,13 @@ def write_csv_row(
     }
     for i in range(len(time_series)):
         data = time_series[i]
-        timestamp = pd.Timestamp(data["start"])
+        timestamp = pd.Timestamp(data[FieldName.START])
         freq_week_start = freq
         if freq_week_start == "W":
             freq_week_start = f"W-{week_dict[timestamp.weekday()]}"
-        timestamp = pd.Timestamp(data["start"], freq=freq_week_start)
-        item_id = int(data["item_id"])
-        for j, target in enumerate(data["target"]):
+        timestamp = pd.Timestamp(data[FieldName.START]], freq=freq_week_start)
+        item_id = int(data[FieldName.ITEM_ID]])
+        for j, target in enumerate(data[FieldName.TARGET]]):
             # Using convention that there are no missing values before the start date
             if is_missing and j != 0 and j % num_missing == 0:
                 timestamp += 1
@@ -68,8 +69,8 @@ def write_csv_row(
                     timestamp_row = timestamp.date()
                 row = [item_id, timestamp_row, target]
                 # Check if related time series is present
-                if "feat_dynamic_real" in data.keys():
-                    for feat_dynamic_real in data["feat_dynamic_real"]:
+                if FieldName.FEAT_DYNAMIC_REAL in data.keys():
+                    for feat_dynamic_real in data[FieldName.FEAT_DYNAMIC_REAL]:
                         row.append(feat_dynamic_real[j])
                 csv_writer.writerow(row)
                 timestamp += 1
@@ -86,21 +87,21 @@ def generate_sf2(
             if is_missing:
                 target = []  # type: List
                 # For Forecast don't output feat_static_cat and feat_static_real
-                for j, val in enumerate(ts["target"]):
+                for j, val in enumerate(ts[FieldName.TARGET]):
                     # only add ones that are not missing
                     if j != 0 and j % num_missing == 0:
                         target.append(None)
                     else:
                         target.append(val)
-                ts["target"] = target
-            ts.pop("feat_static_cat", None)
-            ts.pop("feat_static_real", None)
+                ts[FieldName.TARGET] = target
+            ts.pop(FieldName.FEAT_STATIC_CAT, None)
+            ts.pop(FieldName.FEAT_STATIC_REAL, None)
             # Chop features in training set
-            if "feat_dynamic_real" in ts.keys() and "train" in filename:
+            if FieldName.FEAT_DYNAMIC_REAL in ts.keys() and "train" in filename:
                 # TODO: Fix for missing values
-                for i, feat_dynamic_real in enumerate(ts["feat_dynamic_real"]):
-                    ts["feat_dynamic_real"][i] = feat_dynamic_real[
-                        : len(ts["target"])
+                for i, feat_dynamic_real in enumerate(ts[FieldName.FEAT_DYNAMIC_REAL]):
+                    ts[FieldName.FEAT_DYNAMIC_REAL][i] = feat_dynamic_real[
+                        : len(ts[FieldName.TARGET])
                     ]
             json.dump(ts, json_file)
             json_file.write("\n")

--- a/src/gluonts/dataset/artificial/generate_synthetic.py
+++ b/src/gluonts/dataset/artificial/generate_synthetic.py
@@ -56,9 +56,9 @@ def write_csv_row(
         freq_week_start = freq
         if freq_week_start == "W":
             freq_week_start = f"W-{week_dict[timestamp.weekday()]}"
-        timestamp = pd.Timestamp(data[FieldName.START]], freq=freq_week_start)
-        item_id = int(data[FieldName.ITEM_ID]])
-        for j, target in enumerate(data[FieldName.TARGET]]):
+        timestamp = pd.Timestamp(data[FieldName.START], freq=freq_week_start)
+        item_id = int(data[FieldName.ITEM_ID])
+        for j, target in enumerate(data[FieldName.TARGET]):
             # Using convention that there are no missing values before the start date
             if is_missing and j != 0 and j % num_missing == 0:
                 timestamp += 1
@@ -97,9 +97,14 @@ def generate_sf2(
             ts.pop(FieldName.FEAT_STATIC_CAT, None)
             ts.pop(FieldName.FEAT_STATIC_REAL, None)
             # Chop features in training set
-            if FieldName.FEAT_DYNAMIC_REAL in ts.keys() and "train" in filename:
+            if (
+                FieldName.FEAT_DYNAMIC_REAL in ts.keys()
+                and "train" in filename
+            ):
                 # TODO: Fix for missing values
-                for i, feat_dynamic_real in enumerate(ts[FieldName.FEAT_DYNAMIC_REAL]):
+                for i, feat_dynamic_real in enumerate(
+                    ts[FieldName.FEAT_DYNAMIC_REAL]
+                ):
                     ts[FieldName.FEAT_DYNAMIC_REAL][i] = feat_dynamic_real[
                         : len(ts[FieldName.TARGET])
                     ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Updating the artificial dataset module to use the default field names from `gluonts.dataset.field_names.FieldName` as requested in PR 321
- Prior each string was hard-coded
- More flexible for future design if the field strings are changed can be done all in `gluonts.dataset.field_names.FieldName`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.