### PR TITLE
Input format

### DIFF
--- a/src/gluonts/dataset/field_names.py
+++ b/src/gluonts/dataset/field_names.py
@@ -35,3 +35,24 @@ class FieldName:
     OBSERVED_VALUES = "observed_values"
     IS_PAD = "is_pad"
     FORECAST_START = "forecast_start"
+
+    @staticmethod
+    def dataset_required_fields():
+        return [FieldName.START, FieldName.TARGET]
+
+    @staticmethod
+    def dataset_feature_fields():
+        return [
+            FieldName.FEAT_STATIC_CAT,
+            FieldName.FEAT_STATIC_REAL,
+            FieldName.FEAT_DYNAMIC_CAT,
+            FieldName.FEAT_DYNAMIC_REAL,
+        ]
+
+    @staticmethod
+    def dataset_fields():
+        return (
+            FieldName.dataset_feature_fields()
+            + FieldName.dataset_required_fields()
+            + [FieldName.ITEM_ID]
+        )

--- a/src/gluonts/dataset/stat.py
+++ b/src/gluonts/dataset/stat.py
@@ -123,6 +123,7 @@ class DatasetStatistics(NamedTuple):
     num_time_observations: int
     num_time_series: int
     scale_histogram: ScaleHistogram
+    unsupported_fields: Set[str]
 
     # DO NOT override the __str__ method, since we rely that we can load
     # DatasetStatistics again; i.e. stats == eval(str(stats))
@@ -167,6 +168,7 @@ def calculate_dataset_statistics(ts_dataset: Any) -> DatasetStatistics:
     num_feat_dynamic_real: Optional[int] = None
     num_feat_dynamic_cat: Optional[int] = None
     num_missing_values = 0
+    unsupported_fields = set()
 
     scale_histogram = ScaleHistogram()
 
@@ -340,11 +342,19 @@ def calculate_dataset_statistics(ts_dataset: Any) -> DatasetStatistics:
                     len(target),
                 )
 
+            # UNSUPPORTED FIELDS
+            unsupported_fields.update(
+                set(ts.keys()) - set(FieldName.dataset_fields())
+            )
+
     assert_data_error(num_time_series > 0, "Time series dataset is empty!")
     assert_data_error(
         num_time_observations > 0,
         "Only empty time series found in the dataset!",
     )
+
+    # remove 'source' from unsupported field
+    unsupported_fields.discard("source")
 
     # note this require the above assumption to avoid a division by zero
     # runtime error
@@ -378,4 +388,5 @@ def calculate_dataset_statistics(ts_dataset: Any) -> DatasetStatistics:
         num_time_observations=num_time_observations,
         num_time_series=num_time_series,
         scale_histogram=scale_histogram,
+        unsupported_fields=unsupported_fields,
     )

--- a/src/gluonts/model/estimator.py
+++ b/src/gluonts/model/estimator.py
@@ -253,16 +253,15 @@ class GluonEstimator(Estimator):
 
         return used_fields
 
-    def show_field_info(
-        self, estimator_fields: set, dataset_stats: NamedTuple
-    ):
+    @staticmethod
+    def show_field_info(estimator_fields: set, dataset_stats: NamedTuple):
         # In the dataset but not used
         if (
             dataset_stats.feat_static_cat
             and FieldName.FEAT_STATIC_CAT not in estimator_fields
         ):
             logging.info(
-                f"WARNING: The dataset contains the field {FieldName.FEAT_STATIC_CAT} but it is not "
+                f"WARNING: The dataset contains the field '{FieldName.FEAT_STATIC_CAT}' but it is not "
                 f"used by the estimator. The field is ignored."
             )
         if (
@@ -270,7 +269,7 @@ class GluonEstimator(Estimator):
             and FieldName.FEAT_STATIC_REAL not in estimator_fields
         ):
             logging.info(
-                f"WARNING: The dataset contains the field {FieldName.FEAT_STATIC_REAL} but it is not "
+                f"WARNING: The dataset contains the field '{FieldName.FEAT_STATIC_REAL}' but it is not "
                 f"used by the estimator. The field is ignored."
             )
         if (
@@ -278,7 +277,7 @@ class GluonEstimator(Estimator):
             and FieldName.FEAT_DYNAMIC_CAT not in estimator_fields
         ):
             logging.info(
-                f"WARNING: The dataset contains the field {FieldName.FEAT_DYNAMIC_CAT} but it is not "
+                f"WARNING: The dataset contains the field '{FieldName.FEAT_DYNAMIC_CAT}' but it is not "
                 f"used by the estimator. The field is ignored."
             )
         if (
@@ -286,7 +285,7 @@ class GluonEstimator(Estimator):
             and FieldName.FEAT_DYNAMIC_REAL not in estimator_fields
         ):
             logging.info(
-                f"WARNING: The dataset contains the field {FieldName.FEAT_DYNAMIC_REAL} but it is not "
+                f"WARNING: The dataset contains the field '{FieldName.FEAT_DYNAMIC_REAL}' but it is not "
                 f"used by the estimator. The field is ignored."
             )
 
@@ -294,5 +293,5 @@ class GluonEstimator(Estimator):
         if dataset_stats.unsupported_fields:
             for field in dataset_stats.unsupported_fields:
                 logging.info(
-                    f"WARNING: The dataset contains the field {field}. The field is not supported."
+                    f"WARNING: The dataset contains the field '{field}'. The field is not supported."
                 )

--- a/src/gluonts/transform.py
+++ b/src/gluonts/transform.py
@@ -226,10 +226,6 @@ class Transformation(metaclass=abc.ABCMeta):
     A Transformation processes works on a stream (iterator) of dictionaries.
     """
 
-    @validated()
-    def __init__(self) -> None:
-        self.estimator_fields = []
-
     @abc.abstractmethod
     def __call__(
         self, data_it: Iterator[DataEntry], is_train: bool
@@ -247,8 +243,6 @@ class Chain(Transformation):
 
     @validated()
     def __init__(self, trans: List[Transformation]) -> None:
-        super().__init__()
-
         self.trans = trans
 
     def __call__(
@@ -264,9 +258,6 @@ class Chain(Transformation):
 
 
 class Identity(Transformation):
-    def __init__(self) -> None:
-        super().__init__()
-
     def __call__(
         self, data_it: Iterator[DataEntry], is_train: bool
     ) -> Iterator[DataEntry]:
@@ -277,9 +268,6 @@ class MapTransformation(Transformation):
     """
     Base class for Transformations that returns exactly one result per input in the stream.
     """
-
-    def __init__(self) -> None:
-        super().__init__()
 
     def __call__(
         self, data_it: Iterator[DataEntry], is_train: bool
@@ -300,9 +288,6 @@ class SimpleTransformation(MapTransformation):
     Element wise transformations that are the same in train and test mode
     """
 
-    def __init__(self) -> None:
-        super().__init__()
-
     def map_transform(self, data: DataEntry, is_train: bool) -> DataEntry:
         return self.transform(data)
 
@@ -320,8 +305,6 @@ class AdhocTransform(SimpleTransformation):
     """
 
     def __init__(self, func: Callable[[DataEntry], DataEntry]) -> None:
-        super().__init__()
-
         self.func = func
 
     def transform(self, data: DataEntry) -> DataEntry:
@@ -333,9 +316,6 @@ class FlatMapTransformation(Transformation):
     Transformations that yield zero or more results per input, but do not combine
     elements from the input stream.
     """
-
-    def __init__(self) -> None:
-        super().__init__()
 
     def __call__(
         self, data_it: Iterator[DataEntry], is_train: bool
@@ -369,8 +349,6 @@ class FlatMapTransformation(Transformation):
 
 class FilterTransformation(FlatMapTransformation):
     def __init__(self, condition: Callable[[DataEntry], bool]) -> None:
-        super().__init__()
-
         self.condition = condition
 
     def flatmap_transform(
@@ -383,8 +361,6 @@ class FilterTransformation(FlatMapTransformation):
 class RemoveFields(SimpleTransformation):
     @validated()
     def __init__(self, field_names: List[str]) -> None:
-        super().__init__()
-
         self.field_names = field_names
 
     def transform(self, data: DataEntry) -> DataEntry:
@@ -430,8 +406,6 @@ class SetFieldIfNotPresent(SimpleTransformation):
 
     @validated()
     def __init__(self, field: str, value: Any) -> None:
-        super().__init__()
-
         self.output_field = field
         self.value = value
 
@@ -458,8 +432,6 @@ class AsNumpyArray(SimpleTransformation):
     def __init__(
         self, field: str, expected_ndim: int, dtype: DType = np.float32
     ) -> None:
-        super().__init__()
-
         self.field = field
         self.expected_ndim = expected_ndim
         self.dtype = dtype
@@ -503,8 +475,6 @@ class ExpandDimArray(SimpleTransformation):
 
     @validated()
     def __init__(self, field: str, axis: Optional[int] = None) -> None:
-        super().__init__()
-
         self.field = field
         self.axis = axis
 
@@ -537,8 +507,6 @@ class VstackFeatures(SimpleTransformation):
         input_fields: List[str],
         drop_inputs: bool = True,
     ) -> None:
-        super().__init__()
-
         self.output_field = output_field
         self.input_fields = input_fields
 
@@ -587,8 +555,6 @@ class ConcatFeatures(SimpleTransformation):
         input_fields: List[str],
         drop_inputs: bool = True,
     ) -> None:
-        super().__init__()
-
         self.output_field = output_field
         self.input_fields = input_fields
 
@@ -628,8 +594,6 @@ class SwapAxes(SimpleTransformation):
 
     @validated()
     def __init__(self, input_fields: List[str], axes: Tuple[int, int]) -> None:
-        super().__init__()
-
         self.input_fields = input_fields
         self.axis1, self.axis2 = axes
 
@@ -671,8 +635,6 @@ class ListFeatures(SimpleTransformation):
         input_fields: List[str],
         drop_inputs: bool = True,
     ) -> None:
-        super().__init__()
-
         self.output_field = output_field
         self.input_fields = input_fields
 
@@ -721,8 +683,6 @@ class AddObservedValuesIndicator(SimpleTransformation):
         dummy_value: int = 0,
         convert_nans: bool = True,
     ) -> None:
-        super().__init__()
-
         self.dummy_value = dummy_value
         self.target_field = target_field
         self.output_field = output_field
@@ -754,8 +714,6 @@ class RenameFields(SimpleTransformation):
 
     @validated()
     def __init__(self, mapping: Dict[str, str]) -> None:
-        super().__init__()
-
         self.mapping = mapping
         values_count = Counter(mapping.values())
         for new_key, count in values_count.items():
@@ -804,8 +762,6 @@ class AddConstFeature(MapTransformation):
         const: float = 1.0,
         dtype: DType = np.float32,
     ) -> None:
-        super().__init__()
-
         self.pred_length = pred_length
         self.const = const
         self.dtype = dtype
@@ -852,8 +808,6 @@ class AddTimeFeatures(MapTransformation):
         time_features: List[TimeFeature],
         pred_length: int,
     ) -> None:
-        super().__init__()
-
         self.date_features = time_features
         self.pred_length = pred_length
         self.start_field = start_field
@@ -931,8 +885,6 @@ class AddAgeFeature(MapTransformation):
         pred_length: int,
         log_scale: bool = True,
     ) -> None:
-        super().__init__()
-
         self.pred_length = pred_length
         self.target_field = target_field
         self.feature_name = output_field
@@ -1020,7 +972,6 @@ class InstanceSplitter(FlatMapTransformation):
         time_series_fields: Optional[List[str]] = None,
         pick_incomplete: bool = True,
     ) -> None:
-        super().__init__()
 
         assert future_length > 0
 
@@ -1185,12 +1136,12 @@ class CanonicalInstanceSplitter(FlatMapTransformation):
         use_prediction_features: bool = False,
         prediction_length: Optional[int] = None,
     ) -> None:
-        super().__init__()
-
         self.instance_sampler = instance_sampler
         self.instance_length = instance_length
         self.output_NTC = output_NTC
-        self.dynamic_feature_fields = time_series_fields
+        self.ts_fields = (
+            time_series_fields if time_series_fields is not None else []
+        )
         self.target_field = target_field
         self.allow_target_padding = allow_target_padding
         self.pad_value = pad_value
@@ -1214,7 +1165,7 @@ class CanonicalInstanceSplitter(FlatMapTransformation):
     def flatmap_transform(
         self, data: DataEntry, is_train: bool
     ) -> Iterator[DataEntry]:
-        ts_fields = self.dynamic_feature_fields + [self.target_field]
+        ts_fields = self.ts_fields + [self.target_field]
         ts_target = data[self.target_field]
 
         len_target = ts_target.shape[-1]
@@ -1299,8 +1250,6 @@ class SelectFields(MapTransformation):
 
     @validated()
     def __init__(self, input_fields: List[str]) -> None:
-        super().__init__()
-
         self.input_fields = input_fields
 
     def map_transform(self, data: DataEntry, is_train: bool) -> DataEntry:

--- a/test/dataset/test_stat.py
+++ b/test/dataset/test_stat.py
@@ -121,6 +121,7 @@ class DatasetStatisticsTest(unittest.TestCase):
             num_feat_dynamic_cat=2,
             num_missing_values=0,
             scale_histogram=scale_histogram,
+            unsupported_fields=set()
         )
 
         # FIXME: the cast below is a hack to make mypy happy

--- a/test/dataset/test_stat.py
+++ b/test/dataset/test_stat.py
@@ -121,7 +121,7 @@ class DatasetStatisticsTest(unittest.TestCase):
             num_feat_dynamic_cat=2,
             num_missing_values=0,
             scale_histogram=scale_histogram,
-            unsupported_fields=set()
+            unsupported_fields=set(),
         )
 
         # FIXME: the cast below is a hack to make mypy happy


### PR DESCRIPTION
This PR compares the fields in a dataset and the fields that an estimator uses and gives relevant messages to the user.

The fields of the dataset are given by its `calc_stats` method and the fields of an estimator by parsing as a string the `transformation`.

**One thing to consider:** to get the dataset fields we parse the whole dataset with `calc_stats` which also checks for inconsistencies (missing fields in time series, wrong shapes etc.). In theory, we can only check the first entry to get the fields and speed up the process but if the dataset is wrongly formatted the training will fail later. We need to decide what we prefer:
1) Check the whole dataset internally before training and throw error messages in case the dataset is wrongly formatted. This adds some overhead, especially for large datasets (maybe we can quantify this and see if it is an actual issue), and seems to be redundant for someone that uses a dataset that has been already checked. On the other hand it catches errors early before the training starts.
2) Assume that it is the user's responsibility to correctly format their datasets and to use the `calc_stats` method (maybe rename it to `checks_and_stats`?) to ensure that their dataset is compatible. If they use a wrongly formatted dataset the training will just fail. In this case we can check only the firs entry.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
