### PR TITLE
Fix sample reshaping in DeepAR

### DIFF
--- a/src/gluonts/model/deepar/_network.py
+++ b/src/gluonts/model/deepar/_network.py
@@ -530,12 +530,12 @@ class DeepARPredictionNetwork(DeepARNetwork):
         # (batch_size * num_samples, prediction_length, *target_shape)
         samples = F.concat(*future_samples, dim=1)
 
-        # (batch_size, num_samples, *target_shape, prediction_length)
+        # (batch_size, num_samples, prediction_length, *target_shape)
         return samples.reshape(
             shape=(
                 (-1, self.num_parallel_samples)
-                + self.target_shape
                 + (self.prediction_length,)
+                + self.target_shape
             )
         )
 


### PR DESCRIPTION
*Issue #, if available:* #303 

*Description of changes:* This fixes some bad reshaping of the samples generated in DeepAR. The issue does not affect the univariate case, but in the multivariate case it confuses the sample dimensions which result in the weird behaviour highlighted in #303.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
