### PR TITLE
Add transform objects for temporal point processes (#294)

### DIFF
--- a/src/gluonts/transform.py
+++ b/src/gluonts/transform.py
@@ -25,6 +25,7 @@ import pandas as pd
 from gluonts.core.component import DType, validated
 from gluonts.core.exception import GluonTSDateBoundsError, assert_data_error
 from gluonts.dataset.common import DataEntry, Dataset
+from gluonts.dataset.field_names import FieldName
 from gluonts.dataset.stat import ScaleHistogram
 from gluonts.time_feature import TimeFeature
 from gluonts.runtime_params import GLUONTS_MAX_IDLE_TRANSFORMS
@@ -137,7 +138,9 @@ class UniformSplitSampler(InstanceSampler):
         self.lookup = np.arange(2 ** 13)
 
     def __call__(self, ts: np.ndarray, a: int, b: int) -> np.ndarray:
-        assert a <= b
+        assert (
+            a <= b
+        ), "First index must be less than or equal to the last index."
         while ts.shape[-1] >= len(self.lookup):
             self.lookup = np.arange(2 * len(self.lookup))
         mask = np.random.uniform(low=0.0, high=1.0, size=b - a + 1) < self.p
@@ -156,6 +159,42 @@ class TestSplitSampler(InstanceSampler):
 
     def __call__(self, ts: np.ndarray, a: int, b: int) -> np.ndarray:
         return np.array([b])
+
+
+class ContinuousTimePointSampler:
+    """
+    Abstract class for "continuous time" samplers, which, given a lower bound
+    and upper bound, sample "points" (events) in continuous time from a
+    specified interval.
+    """
+
+    def __init__(self, num_instances: int) -> None:
+        self.num_instances = num_instances
+
+    def __call__(self, a: float, b: float) -> np.ndarray:
+        """
+        Returns random points in the real interval between :code:`a` and
+        :code:`b`.
+
+        Parameters
+        ----------
+        a
+            The lower bound (minimum time value that a sampled point can take)
+        b
+            Upper bound. Must be greater than a.
+        """
+        raise NotImplementedError()
+
+
+class ContinuousTimeUniformSampler(ContinuousTimePointSampler):
+    """
+    Implements a simple random sampler to sample points in the continuous
+    interval between :code:`a` and :code:`b`.
+    """
+
+    def __call__(self, a: float, b: float) -> np.ndarray:
+        assert a <= b, "Interval start time must be before interval end time."
+        return np.random.rand(self.num_instances) * (b - a) + a
 
 
 class ExpectedNumInstanceSampler(InstanceSampler):
@@ -1308,6 +1347,170 @@ class CanonicalInstanceSplitter(FlatMapTransformation):
             )
 
             yield d
+
+
+class ContinuousTimeInstanceSplitter(FlatMapTransformation):
+    """
+    Selects training instances by slicing "intervals" from a continous-time
+    process instantiation. Concretely, the input data is expected to describe an
+    instantiation from a point (or jump) process, with the "target"
+    identifying inter-arrival times and other features (marks), as described
+    in detail below.
+
+    The splitter will then take random points in continuous time from each
+    given observation, and return a (variable-length) array of points in
+    the past (context) and the future (prediction) intervals.
+
+    The transformation is analogous to its discrete counterpart
+    `InstanceSplitter` except that
+
+    - It does not allow "incomplete" records. That is, the past and future
+      intervals sampled are always complete
+    - Outputs a (T, C) layout.
+    - Does not accept `time_series_fields` (i.e., only accepts target fields) as these
+      would typically not be available in TPP data.
+
+    The target arrays are expected to have (2, T) layout where the first axis
+    corresponds to the (i) interarrival times between consecutive points, in
+    order and (ii) integer identifiers of marks (from {0, 1, ..., :code:`num_marks`}).
+    The returned arrays will have (T, 2) layout.
+
+    For example, the array below corresponds to a target array where points with timestamps
+    0.5, 1.1, and 1.5 were observed belonging to categories (marks) 3, 1 and 0
+    respectively: :code:`[[0.5, 0.6, 0.4], [3, 1, 0]]`.
+
+    Parameters
+    ----------
+    past_interval_length
+        length of the interval seen before making prediction
+    future_interval_length
+        length of the interval that must be predicted
+    train_sampler
+        instance sampler that provides sampling indices given a time-series
+    target_field
+        field containing the target
+    start_field
+        field containing the start date of the of the point process observation
+    end_field
+        field containing the end date of the point process observation
+    forecast_start_field
+        output field that will contain the time point where the forecast starts
+    """
+
+    def __init__(
+        self,
+        past_interval_length: float,
+        future_interval_length: float,
+        train_sampler: ContinuousTimePointSampler,
+        target_field: str = FieldName.TARGET,
+        start_field: str = FieldName.START,
+        end_field: str = "end",
+        forecast_start_field: str = FieldName.FORECAST_START,
+    ) -> None:
+
+        assert (
+            future_interval_length > 0
+        ), "Prediction interval must have length greater than 0."
+
+        self.train_sampler = train_sampler
+        self.past_interval_length = past_interval_length
+        self.future_interval_length = future_interval_length
+        self.target_field = target_field
+        self.start_field = start_field
+        self.end_field = end_field
+        self.forecast_start_field = forecast_start_field
+
+    # noinspection PyMethodMayBeStatic
+    def _mask_sorted(self, a: np.ndarray, lb: float, ub: float):
+        start = np.searchsorted(a, lb)
+        end = np.searchsorted(a, ub)
+        return np.arange(start, end)
+
+    def flatmap_transform(
+        self, data: DataEntry, is_train: bool
+    ) -> Iterator[DataEntry]:
+
+        assert data[self.start_field].freq == data[self.end_field].freq
+
+        total_interval_length = (
+            data[self.end_field] - data[self.start_field]
+        ) / data[self.start_field].freq.delta
+
+        # sample forecast start times in continuous time
+        if is_train:
+            if total_interval_length < (
+                self.future_interval_length + self.past_interval_length
+            ):
+                sampling_times: np.ndarray = np.array([])
+            else:
+                sampling_times = self.train_sampler(
+                    self.past_interval_length,
+                    total_interval_length - self.future_interval_length,
+                )
+        else:
+            sampling_times = np.array([total_interval_length])
+
+        ia_times = data[self.target_field][0, :]
+        marks = data[self.target_field][1:, :]
+
+        ts = np.cumsum(ia_times)
+        assert ts[-1] < total_interval_length, (
+            "Target interarrival times provided are inconsistent with "
+            "start and end timestamps."
+        )
+
+        # select field names that will be included in outputs
+        keep_cols = {
+            k: v
+            for k, v in data.items()
+            if k not in [self.target_field, self.start_field, self.end_field]
+        }
+
+        for future_start in sampling_times:
+
+            r: DataEntry = dict()
+
+            past_start = future_start - self.past_interval_length
+            future_end = future_start + self.future_interval_length
+
+            assert past_start >= 0
+
+            past_mask = self._mask_sorted(ts, past_start, future_start)
+
+            past_ia_times = np.diff(np.r_[0, ts[past_mask] - past_start])[
+                np.newaxis
+            ]
+
+            r[f"past_{self.target_field}"] = np.concatenate(
+                [past_ia_times, marks[:, past_mask]], axis=0
+            ).transpose()
+
+            r["past_valid_length"] = np.array([len(past_mask)])
+
+            r[self.forecast_start_field] = (
+                data[self.start_field]
+                + data[self.start_field].freq.delta * future_start
+            )
+
+            if is_train:  # include the future only if is_train
+                assert future_end <= total_interval_length
+
+                future_mask = self._mask_sorted(ts, future_start, future_end)
+
+                future_ia_times = np.diff(
+                    np.r_[0, ts[future_mask] - future_start]
+                )[np.newaxis]
+
+                r[f"future_{self.target_field}"] = np.concatenate(
+                    [future_ia_times, marks[:, future_mask]], axis=0
+                ).transpose()
+
+                r["future_valid_length"] = np.array([len(future_mask)])
+
+            # include other fields
+            r.update(keep_cols.copy())
+
+            yield r
 
 
 class SelectFields(MapTransformation):

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -25,7 +25,7 @@ import gluonts
 from gluonts import time_feature, transform
 from gluonts.core import fqname_for
 from gluonts.core.serde import dump_code, dump_json, load_code, load_json
-from gluonts.dataset.common import ProcessStartField, DataEntry
+from gluonts.dataset.common import ProcessStartField, DataEntry, ListDataset
 from gluonts.dataset.field_names import FieldName
 from gluonts.dataset.stat import ScaleHistogram, calculate_dataset_statistics
 
@@ -687,6 +687,172 @@ def test_target_dim_indicator():
         assert (
             data_entry["target_dimensions"] == np.array([0, 1, 2, 3])
         ).all()
+
+
+@pytest.fixture
+def point_process_dataset():
+
+    ia_times = np.array([0.2, 0.7, 0.2, 0.5, 0.3, 0.3, 0.2, 0.1])
+    marks = np.array([0, 1, 2, 0, 1, 2, 2, 2])
+
+    lds = ListDataset(
+        [
+            {
+                "target": np.c_[ia_times, marks].T,
+                "start": pd.Timestamp("2011-01-01 00:00:00", freq="H"),
+                "end": pd.Timestamp("2011-01-01 03:00:00", freq="H"),
+            }
+        ],
+        freq="H",
+        one_dim_target=False,
+    )
+
+    return lds
+
+
+class MockContinuousTimeSampler(transform.ContinuousTimePointSampler):
+    # noinspection PyMissingConstructor,PyUnusedLocal
+    def __init__(self, ret_values, *args, **kwargs):
+        self._ret_values = ret_values
+
+    def __call__(self, *args, **kwargs):
+        return np.array(self._ret_values)
+
+
+def test_ctsplitter_mask_sorted(point_process_dataset):
+    d = next(iter(point_process_dataset))
+
+    ia_times = d["target"][0, :]
+
+    ts = np.cumsum(ia_times)
+
+    splitter = transform.ContinuousTimeInstanceSplitter(
+        2,
+        1,
+        train_sampler=transform.ContinuousTimeUniformSampler(num_instances=10),
+    )
+
+    # no boundary conditions
+    res = splitter._mask_sorted(ts, 1, 2)
+    assert all([a == b for a, b in zip([2, 3, 4], res)])
+
+    # lower bound equal, exclusive of upper bound
+    res = splitter._mask_sorted(np.array([1, 2, 3, 4, 5, 6]), 1, 2)
+    assert all([a == b for a, b in zip([0], res)])
+
+
+def test_ctsplitter_no_train_last_point(point_process_dataset):
+    splitter = transform.ContinuousTimeInstanceSplitter(
+        2,
+        1,
+        train_sampler=transform.ContinuousTimeUniformSampler(num_instances=10),
+    )
+
+    iter_de = splitter(point_process_dataset, is_train=False)
+
+    d_out = next(iter(iter_de))
+
+    assert "future_target" not in d_out
+    assert "future_valid_length" not in d_out
+    assert "past_target" in d_out
+    assert "past_valid_length" in d_out
+
+    assert d_out["past_valid_length"] == 6
+    assert np.allclose(
+        [0.1, 0.5, 0.3, 0.3, 0.2, 0.1], d_out["past_target"][..., 0], atol=0.01
+    )
+
+
+def test_ctsplitter_train_correct(point_process_dataset):
+    splitter = transform.ContinuousTimeInstanceSplitter(
+        1,
+        1,
+        train_sampler=MockContinuousTimeSampler(
+            ret_values=[1.01, 1.5, 1.99], num_instances=3
+        ),
+    )
+
+    iter_de = splitter(point_process_dataset, is_train=True)
+
+    outputs = list(iter_de)
+
+    assert outputs[0]["past_valid_length"] == 2
+    assert outputs[0]["future_valid_length"] == 3
+
+    assert np.allclose(
+        outputs[0]["past_target"], np.array([[0.19, 0.7], [0, 1]]).T
+    )
+    assert np.allclose(
+        outputs[0]["future_target"], np.array([[0.09, 0.5, 0.3], [2, 0, 1]]).T
+    )
+
+    assert outputs[1]["past_valid_length"] == 2
+    assert outputs[1]["future_valid_length"] == 4
+
+    assert outputs[2]["past_valid_length"] == 3
+    assert outputs[2]["future_valid_length"] == 3
+
+
+def test_ctsplitter_train_correct_out_count(point_process_dataset):
+
+    # produce new TPP data by shuffling existing TS instance
+    def shuffle_iterator(num_duplications=5):
+        for entry in point_process_dataset:
+            for i in range(num_duplications):
+                d = dict.copy(entry)
+                d["target"] = np.random.permutation(d["target"].T).T
+                yield d
+
+    splitter = transform.ContinuousTimeInstanceSplitter(
+        1,
+        1,
+        train_sampler=MockContinuousTimeSampler(
+            ret_values=[1.01, 1.5, 1.99], num_instances=3
+        ),
+    )
+
+    iter_de = splitter(shuffle_iterator(), is_train=True)
+
+    outputs = list(iter_de)
+
+    assert len(outputs) == 5 * 3
+
+
+def test_ctsplitter_train_samples_correct_times(point_process_dataset):
+
+    splitter = transform.ContinuousTimeInstanceSplitter(
+        1.25, 1.25, train_sampler=transform.ContinuousTimeUniformSampler(20)
+    )
+
+    iter_de = splitter(point_process_dataset, is_train=True)
+
+    assert all(
+        [
+            (
+                pd.Timestamp("2011-01-01 01:15:00")
+                <= d["forecast_start"]
+                <= pd.Timestamp("2011-01-01 01:45:00")
+            )
+            for d in iter_de
+        ]
+    )
+
+
+def test_ctsplitter_train_short_intervals(point_process_dataset):
+    splitter = transform.ContinuousTimeInstanceSplitter(
+        0.01,
+        0.01,
+        train_sampler=MockContinuousTimeSampler(
+            ret_values=[1.01, 1.5, 1.99], num_instances=3
+        ),
+    )
+
+    iter_de = splitter(point_process_dataset, is_train=True)
+
+    for d in iter_de:
+        assert d["future_valid_length"] == d["past_valid_length"] == 0
+        assert np.prod(np.shape(d["past_target"])) == 0
+        assert np.prod(np.shape(d["future_target"])) == 0
 
 
 def make_dataset(N, train_length):


### PR DESCRIPTION
*Issue #, if available:*

This is the first PR setting up the infrastructure for temporal point processes in GluonTS (#294). 

*Description of changes:*

Put simply it introduces the `ContinuousTimeInstanceSplitter` object, which somewhat replicates the logic of an `InstanceSplitter` for but for point processes in continuous time. I thought this was a good first PR for me, and a good place to start the process of bringing in TPPs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
