### PR TITLE
Adding gpu support to the cholesky jitter and eig tests.

### DIFF
--- a/src/gluonts/core/component.py
+++ b/src/gluonts/core/component.py
@@ -481,7 +481,7 @@ mx.Context.validate = MXContext.validate
 mx.Context.__get_validators__ = MXContext.__get_validators__
 
 
-def get_mxnet_context() -> mx.Context:
+def get_mxnet_context(gpu_number=0) -> mx.Context:
     """
     Returns either CPU or GPU context
     """
@@ -491,17 +491,17 @@ def get_mxnet_context() -> mx.Context:
         return mx.context.cpu()
     else:
         logging.info("Using GPU")
-        return mx.context.gpu(0)
+        return mx.context.gpu(gpu_number)
 
 
-def check_gpu_support() -> None:
+def check_gpu_support() -> bool:
     """
-    Emits a log line that indicates whether the currently installed MXNet
-    version has GPU support.
+    Emits a log line and returns a boolean that indicate whether
+    the currently installed MXNet version has GPU support.
     """
-    logger.info(
-        f'MXNet GPU support is {"ON" if mx.context.num_gpus() > 0 else "OFF"}'
-    )
+    n = mx.context.num_gpus()
+    logger.info(f'MXNet GPU support is {"ON" if n > 0 else "OFF"}')
+    return False if n == 0 else True
 
 
 class DType:

--- a/src/gluonts/support/linalg_util.py
+++ b/src/gluonts/support/linalg_util.py
@@ -213,11 +213,11 @@ def jitter_cholesky(
                     ),
                 )
             )
-            # gpu will not throw error but will store nans. If nan, L.sum() = nan
-            # so the error tolerance can be large.
+            # gpu will not throw error but will store nans. If nan, L.sum() = nan and 
+            # L.nansum() computes the sum treating nans as zeros so the error tolerance can be large.
+            # for axis = Null, nansum() and sum() will sum over all elements and return scalar array with shape (1,)
             # TODO: Add support for symbolic case: Cannot use <= operator with symbolic variables
-            # Need to add absolute value because numerical issues when the inner argument is nan can make the inner argument negative when taking the max on the gpu
-            assert F.abs(F.max(F.abs(L.nansum() - L.sum()))) <= 1e-1
+            assert F.abs(L.nansum() - L.sum()) <= 1e-1
             return L
         except:
             if num_iter == 0:

--- a/src/gluonts/support/linalg_util.py
+++ b/src/gluonts/support/linalg_util.py
@@ -213,7 +213,7 @@ def jitter_cholesky(
                     ),
                 )
             )
-            # gpu will not throw error but will store nans. If nan, L.sum() = nan and 
+            # gpu will not throw error but will store nans. If nan, L.sum() = nan and
             # L.nansum() computes the sum treating nans as zeros so the error tolerance can be large.
             # for axis = Null, nansum() and sum() will sum over all elements and return scalar array with shape (1,)
             # TODO: Add support for symbolic case: Cannot use <= operator with symbolic variables

--- a/src/gluonts/support/linalg_util.py
+++ b/src/gluonts/support/linalg_util.py
@@ -216,7 +216,8 @@ def jitter_cholesky(
             # gpu will not throw error but will store nans. If nan, L.sum() = nan
             # so the error tolerance can be large.
             # TODO: Add support for symbolic case: Cannot use <= operator with symbolic variables
-            assert F.max(F.abs(L.nansum() - L.sum()) <= 1e-1)
+            # Need to add absolute value because numerical issues when the inner argument is nan can make the inner argument negative when taking the max on the gpu
+            assert F.abs(F.max(F.abs(L.nansum() - L.sum()))) <= 1e-1
             return L
         except:
             if num_iter == 0:

--- a/test/support/test_jitter.py
+++ b/test/support/test_jitter.py
@@ -29,12 +29,10 @@ import pytest
 # This test verifies that both eigenvalue decomposition and iterative jitter method
 # make a non-positive definite matrix positive definite to be able to compute the cholesky.
 # Both gpu and cpu as well as single and double precision are tested.
-# FIXME: Add gpu support for the tests in brazil gets error Check failed: e == cudaSuccess || e ==
-# FIXME: cudaErrorCudartUnloading CUDA: CUDA driver version is insufficient for CUDA runtime version
-# FIXME: @pytest.mark.parametrize('ctx', [mx.Context('gpu'), mx.Context('cpu')])
+@pytest.mark.parametrize("ctx", [mx.Context("gpu"), mx.Context("cpu")])
 @pytest.mark.parametrize("jitter_method", ["iter", "eig"])
 @pytest.mark.parametrize("float_type", [np.float32, np.float64])
-def test_jitter_unit(jitter_method, float_type, ctx=mx.Context("cpu")):
+def test_jitter_unit(jitter_method, float_type, ctx):
     matrix = nd.array(
         [[[1, 2], [3, 4]], [[10, 100], [-21.5, 41]]], ctx=ctx, dtype=float_type
     )
@@ -51,14 +49,10 @@ def test_jitter_unit(jitter_method, float_type, ctx=mx.Context("cpu")):
 # Without the jitter method, NaNs occurs on the gpu for single and double precision and on the cpu for only single
 # precision.  This test verifies that applying the default jitter method fixes these numerical issues on both cpu
 # and gpu and for single and double precision.
-# FIXME: Add gpu support for the tests in braxil gets error Check failed: e == cudaSuccess || e ==
-# FIXME: cudaErrorCudartUnloading CUDA: CUDA driver version is insufficient for CUDA runtime version
-# FIXME: @pytest.mark.parametrize('ctx', [mx.Context('gpu'), mx.Context('cpu')])
+@pytest.mark.parametrize("ctx", [mx.Context("gpu"), mx.Context("cpu")])
 @pytest.mark.parametrize("jitter_method", ["iter", "eig"])
 @pytest.mark.parametrize("float_type", [np.float32, np.float64])
-def test_jitter_synthetic(
-    jitter_method, float_type, ctx=mx.Context("cpu")
-) -> None:
+def test_jitter_synthetic(jitter_method, float_type, ctx) -> None:
     # Initialize problem parameters
     batch_size = 1
     prediction_length = 50

--- a/test/support/test_jitter.py
+++ b/test/support/test_jitter.py
@@ -15,6 +15,7 @@
 import math
 
 # First-party imports
+from gluonts.core.component import check_gpu_support
 from gluonts.kernels import RBFKernel
 from gluonts.gp import GaussianProcess
 from gluonts.support.linalg_util import jitter_cholesky, jitter_cholesky_eig
@@ -25,14 +26,6 @@ import mxnet as mx
 import numpy as np
 import pytest
 
-# This function is used to see if the gpu is available.
-def gpu_device(gpu_number=0):
-    try:
-        _ = mx.nd.array([1, 2, 3], ctx=mx.gpu(gpu_number))
-    except mx.MXNetError:
-        return None
-    return mx.gpu(gpu_number)
-
 
 # This test verifies that both eigenvalue decomposition and iterative jitter method
 # make a non-positive definite matrix positive definite to be able to compute the cholesky.
@@ -42,7 +35,7 @@ def gpu_device(gpu_number=0):
 @pytest.mark.parametrize("float_type", [np.float32, np.float64])
 def test_jitter_unit(jitter_method, float_type, ctx) -> None:
     # TODO: Enable GPU tests on Jenkins
-    if ctx == mx.Context("gpu") and not gpu_device():
+    if ctx == mx.Context("gpu") and not check_gpu_support():
         return
     matrix = nd.array(
         [[[1, 2], [3, 4]], [[10, 100], [-21.5, 41]]], ctx=ctx, dtype=float_type
@@ -63,9 +56,9 @@ def test_jitter_unit(jitter_method, float_type, ctx) -> None:
 @pytest.mark.parametrize("ctx", [mx.Context("gpu"), mx.Context("cpu")])
 @pytest.mark.parametrize("jitter_method", ["iter", "eig"])
 @pytest.mark.parametrize("float_type", [np.float32, np.float64])
-def test_jitter_synthetic(jitter_method, float_type, ctx) -> None:
+def test_jitter_synthetic_gp(jitter_method, float_type, ctx) -> None:
     # TODO: Enable GPU tests on Jenkins
-    if ctx == mx.Context("gpu") and not gpu_device():
+    if ctx == mx.Context("gpu") and not check_gpu_support():
         return
     # Initialize problem parameters
     batch_size = 1

--- a/test/support/test_jitter.py
+++ b/test/support/test_jitter.py
@@ -25,6 +25,14 @@ import mxnet as mx
 import numpy as np
 import pytest
 
+# This function is used to see if the gpu is available.
+def gpu_device(gpu_number=0):
+    try:
+        _ = mx.nd.array([1, 2, 3], ctx=mx.gpu(gpu_number))
+    except mx.MXNetError:
+        return None
+    return mx.gpu(gpu_number)
+
 
 # This test verifies that both eigenvalue decomposition and iterative jitter method
 # make a non-positive definite matrix positive definite to be able to compute the cholesky.
@@ -32,7 +40,10 @@ import pytest
 @pytest.mark.parametrize("ctx", [mx.Context("gpu"), mx.Context("cpu")])
 @pytest.mark.parametrize("jitter_method", ["iter", "eig"])
 @pytest.mark.parametrize("float_type", [np.float32, np.float64])
-def test_jitter_unit(jitter_method, float_type, ctx):
+def test_jitter_unit(jitter_method, float_type, ctx) -> None:
+    # TODO: Enable GPU tests on Jenkins
+    if ctx == mx.Context("gpu") and not gpu_device():
+        return
     matrix = nd.array(
         [[[1, 2], [3, 4]], [[10, 100], [-21.5, 41]]], ctx=ctx, dtype=float_type
     )
@@ -53,6 +64,9 @@ def test_jitter_unit(jitter_method, float_type, ctx):
 @pytest.mark.parametrize("jitter_method", ["iter", "eig"])
 @pytest.mark.parametrize("float_type", [np.float32, np.float64])
 def test_jitter_synthetic(jitter_method, float_type, ctx) -> None:
+    # TODO: Enable GPU tests on Jenkins
+    if ctx == mx.Context("gpu") and not gpu_device():
+        return
     # Initialize problem parameters
     batch_size = 1
     prediction_length = 50


### PR DESCRIPTION
*Issue #, if available:*
- Results in the error with Deep State described here https://github.com/awslabs/gluon-ts/issues/336

*Description of changes:*
- Enabled gpu tests for the cholesky jitter iterative and eigenvalue methods for numerically non-positive definite matrices
- On the gpu, if the cholesky factor `L` is not positive definite, it stores `nan` in the entries rather than throwing an error like on the cpu
- Updated assert error on gpu that compares `L.nansum()` and `L.sum()` to remove incorrect end parenthesis and to add an additional absolute value due to numerical issues.
- Moved `test/gp/test_jitter.py` to `test/support/test_jitter.py` since the jitter methods are under `src/support/linalg_util.py`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.