### PR TITLE
Introduce ForecastGenerator to wrap mxnet output into forecast object

### DIFF
--- a/src/gluonts/model/forecast_generator.py
+++ b/src/gluonts/model/forecast_generator.py
@@ -71,7 +71,7 @@ def _extract_instances(x: Any) -> Any:
         assert False
 
 
-class ForecastWrapper:
+class ForecastGenerator:
     """
     Classes used to bring the output of a network into a class.
     """
@@ -89,7 +89,7 @@ class ForecastWrapper:
         raise NotImplementedError()
 
 
-class DistributionForecastWrapper(ForecastWrapper):
+class DistributionForecastGenerator(ForecastGenerator):
     @validated()
     def __init__(self, distr_output: DistributionOutput) -> None:
         self.distr_output = distr_output
@@ -133,7 +133,7 @@ class DistributionForecastWrapper(ForecastWrapper):
             assert i + 1 == len(batch["forecast_start"])
 
 
-class QuantileForecastWrapper(ForecastWrapper):
+class QuantileForecastGenerator(ForecastGenerator):
     @validated()
     def __init__(self, quantiles: List[str]) -> None:
         self.quantiles = quantiles
@@ -174,7 +174,7 @@ class QuantileForecastWrapper(ForecastWrapper):
             assert i + 1 == len(batch["forecast_start"])
 
 
-class SampleForecastWrapper(ForecastWrapper):
+class SampleForecastGenerator(ForecastGenerator):
     @validated()
     def __init__(self):
         pass

--- a/src/gluonts/model/forecast_wrapper.py
+++ b/src/gluonts/model/forecast_wrapper.py
@@ -1,0 +1,222 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import logging
+from typing import Any, Callable, Iterator, List, Optional
+
+# Third-party imports
+import mxnet as mx
+import numpy as np
+
+# First-party imports
+from gluonts.distribution import Distribution, DistributionOutput
+from gluonts.core.component import validated
+from gluonts.dataset.common import DataEntry
+from gluonts.dataset.field_names import FieldName
+from gluonts.dataset.loader import InferenceDataLoader
+from gluonts.model.forecast import (
+    Forecast,
+    SampleForecast,
+    QuantileForecast,
+    DistributionForecast,
+)
+
+
+OutputTransform = Callable[[DataEntry, np.ndarray], np.ndarray]
+BlockType = mx.gluon.Block
+
+
+LOG_CACHE = set([])
+
+
+def log_once(msg):
+    global LOG_CACHE
+    if msg not in LOG_CACHE:
+        logging.info(msg)
+        LOG_CACHE.add(msg)
+
+
+def _extract_instances(x: Any) -> Any:
+    """
+    Helper function to extract individual instances from batched
+    mxnet results.
+
+    For a tensor `a`
+      _extract_instances(a) -> [a[0], a[1], ...]
+
+    For (nested) tuples of tensors `(a, (b, c))`
+      _extract_instances((a, (b, c)) -> [(a[0], (b[0], c[0])), (a[1], (b[1], c[1])), ...]
+    """
+    if isinstance(x, (np.ndarray, mx.nd.NDArray)):
+        for i in range(x.shape[0]):
+            # yield x[i: i + 1]
+            yield x[i]
+    elif isinstance(x, tuple):
+        for m in zip(*[_extract_instances(y) for y in x]):
+            yield tuple([r for r in m])
+    elif x is None:
+        while True:
+            yield None
+    else:
+        assert False
+
+
+class ForecastWrapper:
+    """
+    Classes used to bring the output of a network into a class.
+    """
+
+    def __call__(
+        self,
+        inference_data_loader: InferenceDataLoader,
+        prediction_net: BlockType,
+        input_names: List[str],
+        freq: str,
+        output_transform: Optional[OutputTransform],
+        num_eval_samples: Optional[int],
+        **kwargs
+    ) -> Iterator[Forecast]:
+        raise NotImplementedError()
+
+
+class DistributionForecastWrapper(ForecastWrapper):
+    @validated()
+    def __init__(self, distr_output: DistributionOutput) -> None:
+        self.distr_output = distr_output
+
+    def __call__(
+        self,
+        inference_data_loader: InferenceDataLoader,
+        prediction_net: BlockType,
+        input_names: List[str],
+        freq: str,
+        output_transform: Optional[OutputTransform],
+        num_eval_samples: Optional[int],
+        **kwargs
+    ) -> Iterator[DistributionForecast]:
+        for batch in inference_data_loader:
+            inputs = [batch[k] for k in input_names]
+            outputs = prediction_net(*inputs)
+            if output_transform is not None:
+                outputs = output_transform(batch, outputs)
+            if num_eval_samples:
+                log_once(
+                    "Forecast is not sample based. Ignoring parameter `num_eval_samples` from predict method."
+                )
+
+            distributions = [
+                self.distr_output.distribution(*u)
+                for u in _extract_instances(outputs)
+            ]
+
+            i = -1
+            for i, distr in enumerate(distributions):
+                yield DistributionForecast(
+                    distr,
+                    start_date=batch["forecast_start"][i],
+                    freq=freq,
+                    item_id=batch[FieldName.ITEM_ID][i]
+                    if FieldName.ITEM_ID in batch
+                    else None,
+                    info=batch["info"][i] if "info" in batch else None,
+                )
+            assert i + 1 == len(batch["forecast_start"])
+
+
+class QuantileForecastWrapper(ForecastWrapper):
+    @validated()
+    def __init__(self, quantiles: List[str]) -> None:
+        self.quantiles = quantiles
+
+    def __call__(
+        self,
+        inference_data_loader: InferenceDataLoader,
+        prediction_net: BlockType,
+        input_names: List[str],
+        freq: str,
+        output_transform: Optional[OutputTransform],
+        num_eval_samples: Optional[int],
+        **kwargs
+    ) -> Iterator[Forecast]:
+        for batch in inference_data_loader:
+            inputs = [batch[k] for k in input_names]
+            outputs = prediction_net(*inputs).asnumpy()
+            if output_transform is not None:
+                outputs = output_transform(batch, outputs)
+
+            if num_eval_samples:
+                log_once(
+                    "Forecast is not sample based. Ignoring parameter `num_eval_samples` from predict method."
+                )
+
+            i = -1
+            for i, output in enumerate(outputs):
+                yield QuantileForecast(
+                    output,
+                    start_date=batch["forecast_start"][i],
+                    freq=freq,
+                    item_id=batch[FieldName.ITEM_ID][i]
+                    if FieldName.ITEM_ID in batch
+                    else None,
+                    info=batch["info"][i] if "info" in batch else None,
+                    forecast_keys=self.quantiles,
+                )
+            assert i + 1 == len(batch["forecast_start"])
+
+
+class SampleForecastWrapper(ForecastWrapper):
+    @validated()
+    def __init__(self):
+        pass
+
+    def __call__(
+        self,
+        inference_data_loader: InferenceDataLoader,
+        prediction_net: BlockType,
+        input_names: List[str],
+        freq: str,
+        output_transform: Optional[OutputTransform],
+        num_eval_samples: Optional[int],
+        **kwargs
+    ) -> Iterator[Forecast]:
+        for batch in inference_data_loader:
+            inputs = [batch[k] for k in input_names]
+            outputs = prediction_net(*inputs).asnumpy()
+            if output_transform is not None:
+                outputs = output_transform(batch, outputs)
+            if num_eval_samples:
+                num_collected_samples = outputs[0].shape[0]
+                collected_samples = [outputs]
+                while num_collected_samples < num_eval_samples:
+                    outputs = prediction_net(*inputs).asnumpy()
+                    if output_transform is not None:
+                        outputs = output_transform(batch, outputs)
+                    collected_samples.append(outputs)
+                    num_collected_samples += outputs[0].shape[0]
+                outputs = [
+                    np.concatenate(s)[:num_eval_samples]
+                    for s in zip(*collected_samples)
+                ]
+                assert len(outputs[0]) == num_eval_samples
+            i = -1
+            for i, output in enumerate(outputs):
+                yield SampleForecast(
+                    output,
+                    start_date=batch["forecast_start"][i],
+                    freq=freq,
+                    item_id=batch[FieldName.ITEM_ID][i]
+                    if FieldName.ITEM_ID in batch
+                    else None,
+                    info=batch["info"][i] if "info" in batch else None,
+                )
+            assert i + 1 == len(batch["forecast_start"])

--- a/src/gluonts/model/predictor.py
+++ b/src/gluonts/model/predictor.py
@@ -23,6 +23,9 @@ from pydoc import locate
 from tempfile import TemporaryDirectory
 from typing import (
     TYPE_CHECKING,
+    Tuple,
+    Union,
+    Any,
     Callable,
     Dict,
     Iterator,
@@ -37,6 +40,7 @@ import numpy as np
 
 # First-party imports
 import gluonts
+from gluonts.distribution import Distribution, DistributionOutput
 from gluonts.core.component import (
     DType,
     equals,
@@ -47,9 +51,10 @@ from gluonts.core.component import (
 from gluonts.core.exception import GluonTSException
 from gluonts.core.serde import dump_json, fqname_for, load_json
 from gluonts.dataset.common import DataEntry, Dataset, ListDataset
-from gluonts.dataset.field_names import FieldName
+from .forecast_wrapper import ForecastWrapper, SampleForecastWrapper
 from gluonts.dataset.loader import DataBatch, InferenceDataLoader
-from gluonts.model.forecast import Forecast, SampleForecast
+from gluonts.model.forecast import Forecast
+
 from gluonts.support.util import (
     export_repr_block,
     export_symb_block,
@@ -62,6 +67,9 @@ from gluonts.transform import Transformation
 
 if TYPE_CHECKING:  # avoid circular import
     from gluonts.model.estimator import Estimator  # noqa
+
+
+OutputTransform = Callable[[DataEntry, np.ndarray], np.ndarray]
 
 
 class Predictor:
@@ -231,28 +239,22 @@ class GluonPredictor(Predictor):
         freq: str,
         ctx: mx.Context,
         input_transform: Transformation,
-        output_transform: Optional[
-            Callable[[DataEntry, np.ndarray], np.ndarray]
-        ] = None,
-        float_type: DType = np.float32,
-        forecast_cls_name: str = "SampleForecast",
+        forecast_wrapper: ForecastWrapper = SampleForecastWrapper(),
         forecast_kwargs: Optional[Dict] = None,
+        output_transform: Optional[OutputTransform] = None,
+        float_type: DType = np.float32,
     ) -> None:
         super().__init__(prediction_length, freq)
-
-        forecast_dict = {c.__name__: c for c in Forecast.__subclasses__()}
-        assert forecast_cls_name in forecast_dict
 
         self.input_names = input_names
         self.prediction_net = prediction_net
         self.batch_size = batch_size
         self.input_transform = input_transform
+        self.forecast_wrapper = forecast_wrapper
+        self.forecast_kwargs = forecast_kwargs if forecast_kwargs else {}
         self.output_transform = output_transform
         self.ctx = ctx
         self.float_type = float_type
-        self.forecast_cls_name = forecast_cls_name
-        self._forecast_cls = forecast_dict[forecast_cls_name]
-        self.forecast_kwargs = forecast_kwargs if forecast_kwargs else {}
 
     def hybridize(self, batch: DataBatch) -> None:
         """
@@ -298,41 +300,15 @@ class GluonPredictor(Predictor):
             ctx=self.ctx,
             float_type=self.float_type,
         )
-        for batch in inference_data_loader:
-            inputs = [batch[k] for k in self.input_names]
-            outputs = self.prediction_net(*inputs).asnumpy()
-            if self.output_transform is not None:
-                outputs = self.output_transform(batch, outputs)
-            if num_eval_samples and not self._forecast_cls == SampleForecast:
-                logging.info(
-                    "Forecast is not sample based. Ignoring parameter `num_eval_samples` from predict method."
-                )
-            if num_eval_samples and self._forecast_cls == SampleForecast:
-                num_collected_samples = outputs[0].shape[0]
-                collected_samples = [outputs]
-                while num_collected_samples < num_eval_samples:
-                    outputs = self.prediction_net(*inputs).asnumpy()
-                    if self.output_transform is not None:
-                        outputs = self.output_transform(batch, outputs)
-                    collected_samples.append(outputs)
-                    num_collected_samples += outputs[0].shape[0]
-                outputs = [
-                    np.concatenate(s)[:num_eval_samples]
-                    for s in zip(*collected_samples)
-                ]
-                assert len(outputs[0]) == num_eval_samples
-            assert len(batch["forecast_start"]) == len(outputs)
-            for i, output in enumerate(outputs):
-                yield self._forecast_cls(
-                    output,
-                    start_date=batch["forecast_start"][i],
-                    freq=self.freq,
-                    item_id=batch[FieldName.ITEM_ID][i]
-                    if FieldName.ITEM_ID in batch
-                    else None,
-                    info=batch["info"][i] if "info" in batch else None,
-                    **self.forecast_kwargs,
-                )
+        yield from self.forecast_wrapper(
+            inference_data_loader=inference_data_loader,
+            prediction_net=self.prediction_net,
+            input_names=self.input_names,
+            freq=self.freq,
+            output_transform=self.output_transform,
+            num_eval_samples=num_eval_samples,
+            **self.forecast_kwargs,
+        )
 
     def __eq__(self, that):
         if type(self) != type(that):
@@ -369,7 +345,7 @@ class GluonPredictor(Predictor):
                 freq=self.freq,
                 ctx=self.ctx,
                 float_type=self.float_type,
-                forecast_cls_name=self.forecast_cls_name,
+                forecast_wrapper=self.forecast_wrapper,
                 forecast_kwargs=self.forecast_kwargs,
                 input_names=self.input_names,
             )
@@ -464,12 +440,12 @@ class RepresentableBlockPredictor(GluonPredictor):
         freq: str,
         ctx: mx.Context,
         input_transform: Transformation,
+        forecast_wrapper: ForecastWrapper = SampleForecastWrapper(),
+        forecast_kwargs: Optional[Dict] = None,
         output_transform: Optional[
             Callable[[DataEntry, np.ndarray], np.ndarray]
         ] = None,
         float_type: DType = np.float32,
-        forecast_cls_name: str = "SampleForecast",
-        forecast_kwargs: Optional[Dict] = None,
     ) -> None:
         super().__init__(
             input_names=get_hybrid_forward_input_names(prediction_net),
@@ -479,10 +455,10 @@ class RepresentableBlockPredictor(GluonPredictor):
             freq=freq,
             ctx=ctx,
             input_transform=input_transform,
+            forecast_wrapper=forecast_wrapper,
+            forecast_kwargs=forecast_kwargs,
             output_transform=output_transform,
             float_type=float_type,
-            forecast_cls_name=forecast_cls_name,
-            forecast_kwargs=forecast_kwargs,
         )
 
     def as_symbol_block_predictor(
@@ -501,10 +477,9 @@ class RepresentableBlockPredictor(GluonPredictor):
             freq=self.freq,
             ctx=self.ctx,
             input_transform=self.input_transform,
+            forecast_wrapper=self.forecast_wrapper,
             output_transform=self.output_transform,
             float_type=self.float_type,
-            forecast_cls_name=self.forecast_cls_name,
-            forecast_kwargs=self.forecast_kwargs,
         )
 
     def serialize_prediction_net(self, path: Path) -> None:

--- a/src/gluonts/model/seq2seq/_forking_estimator.py
+++ b/src/gluonts/model/seq2seq/_forking_estimator.py
@@ -22,8 +22,9 @@ from gluonts.block.quantile_output import QuantileOutput
 from gluonts.core.component import validated
 from gluonts.dataset.field_names import FieldName
 from gluonts.model.estimator import GluonEstimator
-from gluonts.model.forecast import QuantileForecast, Quantile
+from gluonts.model.forecast import Quantile
 from gluonts.model.predictor import Predictor, RepresentableBlockPredictor
+from gluonts.model.forecast_wrapper import QuantileForecastWrapper
 from gluonts.support.util import copy_parameters
 from gluonts.trainer import Trainer
 from gluonts.transform import (
@@ -158,6 +159,5 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
             freq=self.freq,
             prediction_length=self.prediction_length,
             ctx=self.trainer.ctx,
-            forecast_cls_name=QuantileForecast.__name__,
-            forecast_kwargs=dict(forecast_keys=quantile_strs),
+            forecast_wrapper=QuantileForecastWrapper(quantile_strs),
         )

--- a/src/gluonts/model/seq2seq/_forking_estimator.py
+++ b/src/gluonts/model/seq2seq/_forking_estimator.py
@@ -24,7 +24,7 @@ from gluonts.dataset.field_names import FieldName
 from gluonts.model.estimator import GluonEstimator
 from gluonts.model.forecast import Quantile
 from gluonts.model.predictor import Predictor, RepresentableBlockPredictor
-from gluonts.model.forecast_wrapper import QuantileForecastWrapper
+from gluonts.model.forecast_generator import QuantileForecastGenerator
 from gluonts.support.util import copy_parameters
 from gluonts.trainer import Trainer
 from gluonts.transform import (
@@ -159,5 +159,5 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
             freq=self.freq,
             prediction_length=self.prediction_length,
             ctx=self.trainer.ctx,
-            forecast_wrapper=QuantileForecastWrapper(quantile_strs),
+            forecast_generator=QuantileForecastGenerator(quantile_strs),
         )

--- a/src/gluonts/model/seq2seq/_seq2seq_estimator.py
+++ b/src/gluonts/model/seq2seq/_seq2seq_estimator.py
@@ -39,6 +39,7 @@ from gluonts.support.util import copy_parameters
 from gluonts.time_feature import time_features_from_frequency_str
 from gluonts.trainer import Trainer
 from gluonts.transform import ExpectedNumInstanceSampler
+from gluonts.model.forecast_wrapper import QuantileForecastWrapper
 
 # Relative imports
 from ._seq2seq_network import Seq2SeqPredictionNetwork, Seq2SeqTrainingNetwork
@@ -176,8 +177,7 @@ class Seq2SeqEstimator(GluonEstimator):
             freq=self.freq,
             prediction_length=self.prediction_length,
             ctx=self.trainer.ctx,
-            forecast_cls_name=QuantileForecast.__name__,
-            forecast_kwargs=dict(forecast_keys=quantile_strs),
+            forecast_wrapper=QuantileForecastWrapper(quantile_strs),
         )
 
 

--- a/src/gluonts/model/seq2seq/_seq2seq_estimator.py
+++ b/src/gluonts/model/seq2seq/_seq2seq_estimator.py
@@ -39,7 +39,7 @@ from gluonts.support.util import copy_parameters
 from gluonts.time_feature import time_features_from_frequency_str
 from gluonts.trainer import Trainer
 from gluonts.transform import ExpectedNumInstanceSampler
-from gluonts.model.forecast_wrapper import QuantileForecastWrapper
+from gluonts.model.forecast_generator import QuantileForecastGenerator
 
 # Relative imports
 from ._seq2seq_network import Seq2SeqPredictionNetwork, Seq2SeqTrainingNetwork
@@ -177,7 +177,7 @@ class Seq2SeqEstimator(GluonEstimator):
             freq=self.freq,
             prediction_length=self.prediction_length,
             ctx=self.trainer.ctx,
-            forecast_wrapper=QuantileForecastWrapper(quantile_strs),
+            forecast_generator=QuantileForecastGenerator(quantile_strs),
         )
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Make predictors and outputs more modular by introducing a `ForecastGenerator` that is used to bring the output of an mxnet block into a forecast.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
