### PR TITLE
Small fixes to box cox and `TransformedDistribution`

### DIFF
--- a/src/gluonts/distribution/__init__.py
+++ b/src/gluonts/distribution/__init__.py
@@ -35,6 +35,7 @@ from .piecewise_linear import (
 )
 from .student_t import StudentT, StudentTOutput
 from .transformed_distribution import TransformedDistribution
+from .transformed_distribution_output import TransformedDistributionOutput
 from .uniform import Uniform, UniformOutput
 
 __all__ = [
@@ -62,6 +63,7 @@ __all__ = [
     "PiecewiseLinearOutput",
     "TransformedPiecewiseLinear",
     "TransformedDistribution",
+    "TransformedDistributionOutput",
     "bijection",
 ]
 

--- a/src/gluonts/distribution/box_cox_tranform.py
+++ b/src/gluonts/distribution/box_cox_tranform.py
@@ -197,7 +197,7 @@ class BoxCoxTranform(Bijection):
         base = F.relu(y * lambda_1 + 1.0)
 
         return F.where(
-            condition=F.abs(lambda_1).__ge__(tol_lambda_1),
+            condition=(F.abs(lambda_1).__ge__(tol_lambda_1)).broadcast_like(y),
             x=_power(base, 1.0 / lambda_1) - lambda_2,
             y=F.exp(y) - lambda_2,
             name="Box_Cox_inverse_trans",
@@ -254,7 +254,7 @@ class BoxCoxTransformOutput(BijectionOutput):
     def domain_map(self, F, *args: Tensor) -> Tuple[Tensor, ...]:
         lambda_1, lambda_2 = args
         if self.fix_lambda_2:
-            lambda_2 = self.lb_obs * F.ones_like(lambda_2)
+            lambda_2 = -self.lb_obs * F.ones_like(lambda_2)
         else:
             # This makes sure that :math:`z +  \lambda_2 > 0`, where :math:`z > lb_obs`
             lambda_2 = softplus(F, lambda_2) - self.lb_obs * F.ones_like(

--- a/src/gluonts/distribution/transformed_distribution_output.py
+++ b/src/gluonts/distribution/transformed_distribution_output.py
@@ -126,7 +126,7 @@ class TransformedDistributionOutput(DistributionOutput):
             )
         ]
 
-        trans_distr = TransformedDistribution(distr, *transforms)
+        trans_distr = TransformedDistribution(distr, transforms)
 
         # Apply scaling as well at the end if scale is not None!
         if scale is None:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Some small fixes to boxcox:
- `lb_obs` was used with the wrong sign in boxcox. I.e. when the smallest observation is `-0.1` you had to set `lb_obs=0.1`
- fix broadcasting issue in the condition

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
