### PR TITLE
[Fix] Assure Learning Rate Scheduler does not increase the learning rate

### DIFF
--- a/src/gluonts/trainer/learning_rate_scheduler.py
+++ b/src/gluonts/trainer/learning_rate_scheduler.py
@@ -62,6 +62,10 @@ class MetricAttentiveScheduler(mx.lr_scheduler.LRScheduler):
         assert base_lr > 0, f"base_lr should be positive, got {base_lr}"
 
         assert (
+            base_lr > min_lr
+        ), f"base_lr should greater than min_lr, {base_lr} <= {min_lr}"
+
+        assert (
             0 < decay_factor < 1
         ), f"decay_factor factor should be between 0 and 1, got {decay_factor}"
 


### PR DESCRIPTION
When the base learning rate is smaller than the minimum learning rate, the following operation is applied:

> max(min_lr, factor*base_lr)

This effectively increases the learning rate once the patience epochs without improvement are reached.

Description of changes:

I included an assert statement to break in case min_lr > base_lr