### PR TITLE
Fix typos in documentation

### DIFF
--- a/src/gluonts/dataset/split/splitter.py
+++ b/src/gluonts/dataset/split/splitter.py
@@ -30,7 +30,7 @@ For all other datasets, the more flexible `DateSplitter` can be used::
         prediction_length=24,
         split_date=pd.Timestamp('2018-01-31', freq='D')
     )
-    train, test = splitter.split_dataset(whole_dataset)
+    train, test = splitter.split(whole_dataset)
 
 The module also supports rolling splits::
 
@@ -38,7 +38,7 @@ The module also supports rolling splits::
         prediction_length=24,
         split_date=pd.Timestamp('2018-01-31', freq='D')
     )
-    train, test = splitter.rolling_split_dataset(whole_dataset, windows=7)
+    train, test = splitter.rolling_split(whole_dataset, windows=7)
 """
 
 # Standard library imports


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Fix typos in the documentation in `splitter.py`. The `DateSplitter` class does not have methods `split_dataset` and `rolling_split_dataset`; they should be `split` and `rolling_split`, respectively.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
