### PR TITLE
Datatype

### DIFF
--- a/evaluations/generate_evaluations.py
+++ b/evaluations/generate_evaluations.py
@@ -24,14 +24,15 @@ from typing import Dict
 from gluonts.dataset.repository.datasets import get_dataset, dataset_names
 from gluonts.evaluation.backtest import backtest_metrics
 from gluonts.model.seasonal_naive import SeasonalNaivePredictor
+from gluonts.model.deepar import DeepAREstimator
 
 metrics_persisted = ["mean_wQuantileLoss", "ND", "RMSE"]
 datasets = dataset_names
 
 Estimators = [
-    SeasonalNaivePredictor,
+    # SeasonalNaivePredictor,
     # model.simple_feedforward.SimpleFeedForwardEstimator,
-    # model.deepar.DeepAREstimator,
+    DeepAREstimator,
     # model.NPTSPredictor,
     # model.seq2seq.MQCNNEstimator,
     # TransformerEstimator,

--- a/evaluations/generate_evaluations.py
+++ b/evaluations/generate_evaluations.py
@@ -24,15 +24,14 @@ from typing import Dict
 from gluonts.dataset.repository.datasets import get_dataset, dataset_names
 from gluonts.evaluation.backtest import backtest_metrics
 from gluonts.model.seasonal_naive import SeasonalNaivePredictor
-from gluonts.model.deepar import DeepAREstimator
 
 metrics_persisted = ["mean_wQuantileLoss", "ND", "RMSE"]
 datasets = dataset_names
 
 Estimators = [
-    # SeasonalNaivePredictor,
+    SeasonalNaivePredictor,
     # model.simple_feedforward.SimpleFeedForwardEstimator,
-    DeepAREstimator,
+    # model.deepar.DeepAREstimator,
     # model.NPTSPredictor,
     # model.seq2seq.MQCNNEstimator,
     # TransformerEstimator,

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 boto3==1.*
 holidays==0.9.*
 matplotlib==3.*
-mxnet>=1.3.1,<1.5.*
+mxnet>=1.4.1,<1.5.*
 numpy==1.14.*
 pandas>=0.25.0
 pydantic==0.28.*

--- a/src/gluonts/block/feature.py
+++ b/src/gluonts/block/feature.py
@@ -38,7 +38,11 @@ class FeatureEmbedder(nn.HybridBlock):
 
     @validated()
     def __init__(
-        self, cardinalities: List[int], embedding_dims: List[int], **kwargs
+        self,
+        cardinalities: List[int],
+        embedding_dims: List[int],
+        dtype=np.float32,
+        **kwargs,
     ) -> None:
         super().__init__(**kwargs)
 
@@ -56,9 +60,12 @@ class FeatureEmbedder(nn.HybridBlock):
         ), "Elements of `embedding_dims` should be > 0"
 
         self.__num_features = len(cardinalities)
+        self.dtype = dtype
 
         def create_embedding(i: int, c: int, d: int) -> nn.Embedding:
-            embedding = nn.Embedding(c, d, prefix=f"cat_{i}_embedding_")
+            embedding = nn.Embedding(
+                c, d, prefix=f"cat_{i}_embedding_", dtype=self.dtype
+            )
             self.register_child(embedding)
             return embedding
 

--- a/src/gluonts/block/feature.py
+++ b/src/gluonts/block/feature.py
@@ -34,6 +34,9 @@ class FeatureEmbedder(nn.HybridBlock):
 
     embedding_dims
         number of dimensions to embed each categorical feature.
+
+    dtype
+        Data type of the embedded features.
     """
 
     @validated()
@@ -41,7 +44,7 @@ class FeatureEmbedder(nn.HybridBlock):
         self,
         cardinalities: List[int],
         embedding_dims: List[int],
-        dtype=np.float32,
+        dtype: DType = np.float32,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)

--- a/src/gluonts/distribution/binned.py
+++ b/src/gluonts/distribution/binned.py
@@ -17,6 +17,7 @@ from typing import Tuple, List
 # Third-party imports
 import mxnet as mx
 from mxnet import gluon
+import numpy as np
 
 # First-party imports
 from gluonts.core.component import validated
@@ -157,7 +158,7 @@ class Binned(Distribution):
         a = centers_expanded.pick(idx, axis=-1)
         return a.swapaxes(0, 1)
 
-    def sample(self, num_samples=None):
+    def sample(self, num_samples=None, dtype=np.float32):
         def s(bin_probs):
             F = self.F
             indices = F.sample_multinomial(bin_probs)

--- a/src/gluonts/distribution/distribution.py
+++ b/src/gluonts/distribution/distribution.py
@@ -17,6 +17,7 @@ from typing import List, Optional, Tuple
 # Third-party imports
 import mxnet as mx
 from mxnet import autograd
+import numpy as np
 
 # First-party imports
 from gluonts.model.common import Tensor
@@ -177,12 +178,21 @@ class Distribution:
         """
         return self.batch_dim + self.event_dim
 
-    def sample(self, num_samples: Optional[int] = None) -> Tensor:
+    def sample(
+        self, num_samples: Optional[int] = None, dtype=np.float32
+    ) -> Tensor:
         r"""
         Draw samples from the distribution.
 
         If num_samples is given the first dimension of the output will be
         num_samples.
+
+        Parameters
+        ----------
+        num_samples
+            Number of samples to to be drawn.
+        dtype
+            Data-type of the samples.
 
         Returns
         -------
@@ -192,11 +202,13 @@ class Distribution:
             and  `(num_samples, *batch_shape, *eval_shape)` otherwise.
         """
         with autograd.pause():
-            var = self.sample_rep(num_samples=num_samples)
+            var = self.sample_rep(num_samples=num_samples, dtype=dtype)
             F = getF(var)
             return F.BlockGrad(var)
 
-    def sample_rep(self, num_samples: Optional[int] = None) -> Tensor:
+    def sample_rep(
+        self, num_samples: Optional[int] = None, dtype=np.float32
+    ) -> Tensor:
         raise NotImplementedError()
 
     @property

--- a/src/gluonts/distribution/distribution_output.py
+++ b/src/gluonts/distribution/distribution_output.py
@@ -50,18 +50,18 @@ class ArgProj(gluon.HybridBlock):
         self,
         args_dim: Dict[str, int],
         domain_map: Callable[..., Tuple[Tensor]],
-        float_type: DType = np.float32,
+        dtype: DType = np.float32,
         prefix: Optional[str] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.args_dim = args_dim
-        self.float_type = float_type
+        self.dtype = dtype
         self.proj = [
             gluon.nn.Dense(
                 dim,
                 flatten=False,
-                dtype=self.float_type,
+                dtype=self.dtype,
                 prefix=f"{prefix}_distr_{name}_",
             )
             for name, dim in args_dim.items()
@@ -83,22 +83,22 @@ class Output:
     """
 
     args_dim: Dict[str, int]
-    _float_type: DType = np.float32
+    _dtype: DType = np.float32
 
     @property
-    def float_type(self):
-        return self._float_type
+    def dtype(self):
+        return self._dtype
 
-    @float_type.setter
-    def float_type(self, float_type: DType):
-        self._float_type = float_type
+    @dtype.setter
+    def dtype(self, dtype: DType):
+        self._dtype = dtype
 
     def get_args_proj(self, prefix: Optional[str] = None) -> ArgProj:
         return ArgProj(
             args_dim=self.args_dim,
             domain_map=gluon.nn.HybridLambda(self.domain_map),
             prefix=prefix,
-            float_type=self._float_type,
+            dtype=self.dtype,
         )
 
     def domain_map(self, F, *args: Tensor):

--- a/src/gluonts/distribution/distribution_output.py
+++ b/src/gluonts/distribution/distribution_output.py
@@ -83,12 +83,22 @@ class Output:
     """
 
     args_dim: Dict[str, int]
+    _float_type: DType = np.float32
+
+    @property
+    def float_type(self):
+        return self._float_type
+
+    @float_type.setter
+    def float_type(self, float_type: DType):
+        self._float_type = float_type
 
     def get_args_proj(self, prefix: Optional[str] = None) -> ArgProj:
         return ArgProj(
             args_dim=self.args_dim,
             domain_map=gluon.nn.HybridLambda(self.domain_map),
             prefix=prefix,
+            float_type=self._float_type,
         )
 
     def domain_map(self, F, *args: Tensor):

--- a/src/gluonts/distribution/gaussian.py
+++ b/src/gluonts/distribution/gaussian.py
@@ -16,6 +16,9 @@ import math
 from functools import partial
 from typing import Dict, Optional, Tuple, List
 
+# Third-party imports
+import numpy as np
+
 # First-party imports
 from gluonts.model.common import Tensor
 from gluonts.support.util import erf, erfinv
@@ -84,18 +87,22 @@ class Gaussian(Distribution):
         )
         return (erf(F, u) + 1.0) / 2.0
 
-    def sample(self, num_samples: Optional[int] = None) -> Tensor:
+    def sample(
+        self, num_samples: Optional[int] = None, dtype=np.float32
+    ) -> Tensor:
         return _sample_multiple(
-            partial(self.F.sample_normal, dtype=self.mu.dtype),
+            partial(self.F.sample_normal, dtype=dtype),
             mu=self.mu,
             sigma=self.sigma,
             num_samples=num_samples,
         )
 
-    def sample_rep(self, num_samples: Optional[int] = None) -> Tensor:
+    def sample_rep(
+        self, num_samples: Optional[int] = None, dtype=np.float32
+    ) -> Tensor:
         def s(mu: Tensor, sigma: Tensor) -> Tensor:
             raw_samples = self.F.sample_normal(
-                mu=mu.zeros_like(), sigma=sigma.ones_like(), dtype=mu.dtype
+                mu=mu.zeros_like(), sigma=sigma.ones_like(), dtype=dtype
             )
             return sigma * raw_samples + mu
 

--- a/src/gluonts/distribution/gaussian.py
+++ b/src/gluonts/distribution/gaussian.py
@@ -13,6 +13,7 @@
 
 # Standard library imports
 import math
+from functools import partial
 from typing import Dict, Optional, Tuple, List
 
 # First-party imports
@@ -85,7 +86,7 @@ class Gaussian(Distribution):
 
     def sample(self, num_samples: Optional[int] = None) -> Tensor:
         return _sample_multiple(
-            self.F.sample_normal,
+            partial(self.F.sample_normal, dtype=self.mu.dtype),
             mu=self.mu,
             sigma=self.sigma,
             num_samples=num_samples,
@@ -94,7 +95,7 @@ class Gaussian(Distribution):
     def sample_rep(self, num_samples: Optional[int] = None) -> Tensor:
         def s(mu: Tensor, sigma: Tensor) -> Tensor:
             raw_samples = self.F.sample_normal(
-                mu=mu.zeros_like(), sigma=sigma.ones_like()
+                mu=mu.zeros_like(), sigma=sigma.ones_like(), dtype=mu.dtype
             )
             return sigma * raw_samples + mu
 

--- a/src/gluonts/distribution/laplace.py
+++ b/src/gluonts/distribution/laplace.py
@@ -14,6 +14,9 @@
 # Standard library imports
 from typing import Dict, Tuple, List
 
+# Third-party imports
+import numpy as np
+
 # First-party imports
 from gluonts.model.common import Tensor
 from gluonts.core.component import validated
@@ -74,12 +77,12 @@ class Laplace(Distribution):
         y = (x - self.mu) / self.b
         return 0.5 + 0.5 * y.sign() * (1.0 - self.F.exp(-y.abs()))
 
-    def sample_rep(self, num_samples=None) -> Tensor:
+    def sample_rep(self, num_samples=None, dtype=np.float32) -> Tensor:
         F = self.F
 
         def s(mu: Tensor, b: Tensor) -> Tensor:
             ones = mu.ones_like()
-            x = F.random.uniform(-0.5 * ones, 0.5 * ones, dtype=ones.dtype)
+            x = F.random.uniform(-0.5 * ones, 0.5 * ones, dtype=dtype)
             laplace_samples = mu - b * F.sign(x) * F.log(
                 (1.0 - 2.0 * F.abs(x)).clip(1.0e-30, 1.0e30)
                 # 1.0 - 2.0 * F.abs(x)

--- a/src/gluonts/distribution/laplace.py
+++ b/src/gluonts/distribution/laplace.py
@@ -79,7 +79,7 @@ class Laplace(Distribution):
 
         def s(mu: Tensor, b: Tensor) -> Tensor:
             ones = mu.ones_like()
-            x = F.random.uniform(-0.5 * ones, 0.5 * ones)
+            x = F.random.uniform(-0.5 * ones, 0.5 * ones, dtype=ones.dtype)
             laplace_samples = mu - b * F.sign(x) * F.log(
                 (1.0 - 2.0 * F.abs(x)).clip(1.0e-30, 1.0e30)
                 # 1.0 - 2.0 * F.abs(x)

--- a/src/gluonts/distribution/lowrank_multivariate_gaussian.py
+++ b/src/gluonts/distribution/lowrank_multivariate_gaussian.py
@@ -237,7 +237,7 @@ class LowrankMultivariateGaussian(Distribution):
 
         return self.Cov
 
-    def sample_rep(self, num_samples: int = None) -> Tensor:
+    def sample_rep(self, num_samples: int = None, dtype=np.float32) -> Tensor:
         r"""
         Draw samples from the multivariate Gaussian distribution:
 
@@ -250,6 +250,8 @@ class LowrankMultivariateGaussian(Distribution):
         ----------
         num_samples
             number of samples to be drawn.
+        dtype
+            Data-type of the samples.
 
         Returns
         -------
@@ -260,7 +262,7 @@ class LowrankMultivariateGaussian(Distribution):
             F = getF(mu)
 
             samples_D = F.sample_normal(
-                mu=F.zeros_like(mu), sigma=F.ones_like(mu), dtype=mu.dtype
+                mu=F.zeros_like(mu), sigma=F.ones_like(mu), dtype=dtype
             )
             cov_D = D.sqrt() * samples_D
 
@@ -272,7 +274,7 @@ class LowrankMultivariateGaussian(Distribution):
             samples_W = F.sample_normal(
                 mu=F.zeros_like(dummy_tensor),
                 sigma=F.ones_like(dummy_tensor),
-                dtype=mu.dtype,
+                dtype=dtype,
             )
 
             cov_W = F.linalg_gemm2(W, samples_W.expand_dims(axis=-1)).squeeze(

--- a/src/gluonts/distribution/lowrank_multivariate_gaussian.py
+++ b/src/gluonts/distribution/lowrank_multivariate_gaussian.py
@@ -260,7 +260,7 @@ class LowrankMultivariateGaussian(Distribution):
             F = getF(mu)
 
             samples_D = F.sample_normal(
-                mu=F.zeros_like(mu), sigma=F.ones_like(mu)
+                mu=F.zeros_like(mu), sigma=F.ones_like(mu), dtype=mu.dtype
             )
             cov_D = D.sqrt() * samples_D
 
@@ -270,7 +270,9 @@ class LowrankMultivariateGaussian(Distribution):
             ).squeeze(axis=-1)
 
             samples_W = F.sample_normal(
-                mu=F.zeros_like(dummy_tensor), sigma=F.ones_like(dummy_tensor)
+                mu=F.zeros_like(dummy_tensor),
+                sigma=F.ones_like(dummy_tensor),
+                dtype=mu.dtype,
             )
 
             cov_W = F.linalg_gemm2(W, samples_W.expand_dims(axis=-1)).squeeze(

--- a/src/gluonts/distribution/mixture.py
+++ b/src/gluonts/distribution/mixture.py
@@ -16,6 +16,7 @@ from typing import List, Optional, Tuple
 
 # Third-party imports
 from mxnet import gluon
+import numpy as np
 
 # First-party imports
 from gluonts.core.component import validated
@@ -118,8 +119,10 @@ class MixtureDistribution(Distribution):
             axis=-1,
         )
 
-    def sample(self, num_samples: Optional[int] = None) -> Tensor:
-        samples_list = [c.sample(num_samples) for c in self.components]
+    def sample(
+        self, num_samples: Optional[int] = None, dtype=np.float32
+    ) -> Tensor:
+        samples_list = [c.sample(num_samples, dtype) for c in self.components]
         samples = self.F.stack(*samples_list, axis=-1)
 
         mixture_probs = _expand_param(self.mixture_probs, num_samples)

--- a/src/gluonts/distribution/multivariate_gaussian.py
+++ b/src/gluonts/distribution/multivariate_gaussian.py
@@ -50,13 +50,10 @@ class MultivariateGaussian(Distribution):
     is_reparameterizable = True
 
     @validated()
-    def __init__(
-        self, mu: Tensor, L: Tensor, F=None, dtype: DType = np.float32
-    ) -> None:
+    def __init__(self, mu: Tensor, L: Tensor, F=None) -> None:
         self.mu = mu
         self.F = F if F else getF(mu)
         self.L = L
-        self.dtype = dtype
 
     @property
     def batch_shape(self) -> Tuple:
@@ -101,7 +98,9 @@ class MultivariateGaussian(Distribution):
     def variance(self) -> Tensor:
         return self.F.linalg_gemm2(self.L, self.L, transpose_b=True)
 
-    def sample_rep(self, num_samples: Optional[int] = None) -> Tensor:
+    def sample_rep(
+        self, num_samples: Optional[int] = None, dtype=np.float32
+    ) -> Tensor:
         r"""
         Draw samples from the multivariate Gaussian distributions.
         Internally, Cholesky factorization of the covariance matrix is used:
@@ -114,6 +113,8 @@ class MultivariateGaussian(Distribution):
         ----------
         num_samples
             Number of samples to be drawn.
+        dtype
+            Data-type of the samples.
         Returns
         -------
         Tensor
@@ -124,7 +125,7 @@ class MultivariateGaussian(Distribution):
             samples_std_normal = self.F.sample_normal(
                 mu=self.F.zeros_like(mu),
                 sigma=self.F.ones_like(mu),
-                dtype=self.dtype,
+                dtype=dtype,
             ).expand_dims(axis=-1)
             samples = (
                 self.F.linalg_gemm2(L, samples_std_normal).squeeze(axis=-1)

--- a/src/gluonts/distribution/multivariate_gaussian.py
+++ b/src/gluonts/distribution/multivariate_gaussian.py
@@ -51,12 +51,12 @@ class MultivariateGaussian(Distribution):
 
     @validated()
     def __init__(
-        self, mu: Tensor, L: Tensor, F=None, float_type: DType = np.float32
+        self, mu: Tensor, L: Tensor, F=None, dtype: DType = np.float32
     ) -> None:
         self.mu = mu
         self.F = F if F else getF(mu)
         self.L = L
-        self.float_type = float_type
+        self.dtype = dtype
 
     @property
     def batch_shape(self) -> Tuple:
@@ -124,7 +124,7 @@ class MultivariateGaussian(Distribution):
             samples_std_normal = self.F.sample_normal(
                 mu=self.F.zeros_like(mu),
                 sigma=self.F.ones_like(mu),
-                dtype=self.float_type,
+                dtype=self.dtype,
             ).expand_dims(axis=-1)
             samples = (
                 self.F.linalg_gemm2(L, samples_std_normal).squeeze(axis=-1)

--- a/src/gluonts/distribution/neg_binomial.py
+++ b/src/gluonts/distribution/neg_binomial.py
@@ -87,7 +87,7 @@ class NegativeBinomial(Distribution):
             r = F.minimum(F.maximum(tol, r), 1e10)
             theta = F.minimum(F.maximum(tol, theta), 1e10)
             x = F.minimum(F.random.gamma(r, theta), 1e6)
-            return F.random.poisson(lam=x)
+            return F.random.poisson(lam=x, dtype=x.dtype)
 
         return _sample_multiple(
             s, mu=self.mu, alpha=self.alpha, num_samples=num_samples

--- a/src/gluonts/distribution/neg_binomial.py
+++ b/src/gluonts/distribution/neg_binomial.py
@@ -14,6 +14,9 @@
 # Standard library imports
 from typing import Dict, Optional, Tuple, List
 
+# Third-party imports
+import numpy as np
+
 # First-party imports
 from gluonts.model.common import Tensor
 from gluonts.core.component import validated
@@ -78,7 +81,9 @@ class NegativeBinomial(Distribution):
     def stddev(self) -> Tensor:
         return self.F.sqrt(self.mu * (1.0 + self.mu * self.alpha))
 
-    def sample(self, num_samples: Optional[int] = None) -> Tensor:
+    def sample(
+        self, num_samples: Optional[int] = None, dtype=np.float32
+    ) -> Tensor:
         def s(mu: Tensor, alpha: Tensor) -> Tensor:
             F = self.F
             tol = 1e-5
@@ -87,7 +92,7 @@ class NegativeBinomial(Distribution):
             r = F.minimum(F.maximum(tol, r), 1e10)
             theta = F.minimum(F.maximum(tol, theta), 1e10)
             x = F.minimum(F.random.gamma(r, theta), 1e6)
-            return F.random.poisson(lam=x, dtype=x.dtype)
+            return F.random.poisson(lam=x, dtype=dtype)
 
         return _sample_multiple(
             s, mu=self.mu, alpha=self.alpha, num_samples=num_samples

--- a/src/gluonts/distribution/piecewise_linear.py
+++ b/src/gluonts/distribution/piecewise_linear.py
@@ -14,6 +14,9 @@
 # Standard library imports
 from typing import Dict, Optional, Tuple, cast, List
 
+# Third-party imports
+import numpy as np
+
 # First-party imports
 from gluonts.core.component import validated
 from gluonts.distribution.bijection import AffineTransformation, Bijection
@@ -116,12 +119,15 @@ class PiecewiseLinear(Distribution):
 
         return b, knot_positions
 
-    def sample(self, num_samples: Optional[int] = None) -> Tensor:
+    def sample(
+        self, num_samples: Optional[int] = None, dtype=np.float32
+    ) -> Tensor:
         F = self.F
 
         # if num_samples=None then u should have the same shape as gamma, i.e., (dim,)
         # else u should be (num_samples, dim)
         # Note: there is no need to extend the parameters to (num_samples, dim, ...)
+        # Thankfully samples returned by `uniform_like` have the expected datatype.
         u = F.random.uniform_like(
             data=(
                 self.gamma

--- a/src/gluonts/distribution/student_t.py
+++ b/src/gluonts/distribution/student_t.py
@@ -15,6 +15,9 @@
 import math
 from typing import Dict, Optional, Tuple, List
 
+# Third-party imports
+import numpy as np
+
 # First-party imports
 from gluonts.model.common import Tensor
 from gluonts.core.component import validated
@@ -94,16 +97,16 @@ class StudentT(Distribution):
         ll = Z - nup1_half * F.log1p(part1)
         return ll
 
-    def sample(self, num_samples: Optional[int] = None) -> Tensor:
+    def sample(
+        self, num_samples: Optional[int] = None, dtype=np.float32
+    ) -> Tensor:
         def s(mu: Tensor, sigma: Tensor, nu: Tensor) -> Tensor:
             F = self.F
             gammas = F.sample_gamma(
-                alpha=nu / 2.0,
-                beta=2.0 / (nu * F.square(sigma)),
-                dtype=nu.dtype,
+                alpha=nu / 2.0, beta=2.0 / (nu * F.square(sigma)), dtype=dtype
             )
             normal = F.sample_normal(
-                mu=mu, sigma=1.0 / F.sqrt(gammas), dtype=mu.dtype
+                mu=mu, sigma=1.0 / F.sqrt(gammas), dtype=dtype
             )
             return normal
 

--- a/src/gluonts/distribution/student_t.py
+++ b/src/gluonts/distribution/student_t.py
@@ -100,7 +100,7 @@ class StudentT(Distribution):
             gammas = F.sample_gamma(
                 alpha=nu / 2.0,
                 beta=2.0 / (nu * F.square(sigma)),
-                dtype=mu.dtype,
+                dtype=nu.dtype,
             )
             normal = F.sample_normal(
                 mu=mu, sigma=1.0 / F.sqrt(gammas), dtype=mu.dtype

--- a/src/gluonts/distribution/student_t.py
+++ b/src/gluonts/distribution/student_t.py
@@ -98,9 +98,13 @@ class StudentT(Distribution):
         def s(mu: Tensor, sigma: Tensor, nu: Tensor) -> Tensor:
             F = self.F
             gammas = F.sample_gamma(
-                alpha=nu / 2.0, beta=2.0 / (nu * F.square(sigma))
+                alpha=nu / 2.0,
+                beta=2.0 / (nu * F.square(sigma)),
+                dtype=mu.dtype,
             )
-            normal = F.sample_normal(mu=mu, sigma=1.0 / F.sqrt(gammas))
+            normal = F.sample_normal(
+                mu=mu, sigma=1.0 / F.sqrt(gammas), dtype=mu.dtype
+            )
             return normal
 
         return _sample_multiple(

--- a/src/gluonts/distribution/transformed_distribution.py
+++ b/src/gluonts/distribution/transformed_distribution.py
@@ -17,6 +17,7 @@ from typing import Optional, Tuple, List
 # Third-party imports
 from mxnet import autograd
 import mxnet as mx
+import numpy as np
 
 # First-party imports
 from gluonts.model.common import Tensor
@@ -80,15 +81,21 @@ class TransformedDistribution(Distribution):
         assert isinstance(self._event_shape, tuple)
         return self._event_shape
 
-    def sample(self, num_samples: Optional[int] = None) -> Tensor:
+    def sample(
+        self, num_samples: Optional[int] = None, dtype=np.float32
+    ) -> Tensor:
         with autograd.pause():
-            s = self.base_distribution.sample(num_samples=num_samples)
+            s = self.base_distribution.sample(
+                num_samples=num_samples, dtype=dtype
+            )
             for t in self.transforms:
                 s = t.f(s)
             return s
 
-    def sample_rep(self, num_samples: Optional[int] = None) -> Tensor:
-        s = self.base_distribution.sample_rep()
+    def sample_rep(
+        self, num_samples: Optional[int] = None, dtype=np.float
+    ) -> Tensor:
+        s = self.base_distribution.sample_rep(dtype=dtype)
         for t in self.transforms:
             s = t.f(s)
         return s

--- a/src/gluonts/distribution/uniform.py
+++ b/src/gluonts/distribution/uniform.py
@@ -15,6 +15,9 @@
 from functools import partial
 from typing import Dict, Optional, Tuple, List
 
+# Third-party imports
+import numpy as np
+
 # First-party imports
 from gluonts.model.common import Tensor
 from gluonts.core.component import validated
@@ -71,18 +74,22 @@ class Uniform(Distribution):
     def stddev(self) -> Tensor:
         return (self.high - self.low) / (12 ** 0.5)
 
-    def sample(self, num_samples: Optional[int] = None) -> Tensor:
+    def sample(
+        self, num_samples: Optional[int] = None, dtype=np.float32
+    ) -> Tensor:
         return _sample_multiple(
-            partial(self.F.sample_uniform, dtype=self.low.dtype),
+            partial(self.F.sample_uniform, dtype=dtype),
             low=self.low,
             high=self.high,
             num_samples=num_samples,
         )
 
-    def sample_rep(self, num_samples: Optional[int] = None) -> Tensor:
+    def sample_rep(
+        self, num_samples: Optional[int] = None, dtype=np.float32
+    ) -> Tensor:
         def s(low: Tensor, high: Tensor) -> Tensor:
             raw_samples = self.F.sample_uniform(
-                low=low.zeros_like(), high=high.ones_like(), dtype=low.dtype
+                low=low.zeros_like(), high=high.ones_like(), dtype=dtype
             )
             return low + raw_samples * (high - low)
 

--- a/src/gluonts/distribution/uniform.py
+++ b/src/gluonts/distribution/uniform.py
@@ -12,6 +12,7 @@
 # permissions and limitations under the License.
 
 # Standard library imports
+from functools import partial
 from typing import Dict, Optional, Tuple, List
 
 # First-party imports
@@ -72,7 +73,7 @@ class Uniform(Distribution):
 
     def sample(self, num_samples: Optional[int] = None) -> Tensor:
         return _sample_multiple(
-            self.F.sample_uniform,
+            partial(self.F.sample_uniform, dtype=self.low.dtype),
             low=self.low,
             high=self.high,
             num_samples=num_samples,
@@ -81,7 +82,7 @@ class Uniform(Distribution):
     def sample_rep(self, num_samples: Optional[int] = None) -> Tensor:
         def s(low: Tensor, high: Tensor) -> Tensor:
             raw_samples = self.F.sample_uniform(
-                low=low.zeros_like(), high=high.ones_like()
+                low=low.zeros_like(), high=high.ones_like(), dtype=low.dtype
             )
             return low + raw_samples * (high - low)
 

--- a/src/gluonts/evaluation/backtest.py
+++ b/src/gluonts/evaluation/backtest.py
@@ -180,7 +180,7 @@ def backtest_metrics(
                 transform=predictor.input_transform,
                 batch_size=forecaster.trainer.batch_size,
                 ctx=forecaster.trainer.ctx,
-                float_type=forecaster.float_type,
+                float_type=forecaster.dtype,
             )
 
             if forecaster.trainer.hybridize:

--- a/src/gluonts/evaluation/backtest.py
+++ b/src/gluonts/evaluation/backtest.py
@@ -180,7 +180,7 @@ def backtest_metrics(
                 transform=predictor.input_transform,
                 batch_size=forecaster.trainer.batch_size,
                 ctx=forecaster.trainer.ctx,
-                float_type=forecaster.dtype,
+                dtype=forecaster.dtype,
             )
 
             if forecaster.trainer.hybridize:

--- a/src/gluonts/gp/gaussian_process.py
+++ b/src/gluonts/gp/gaussian_process.py
@@ -250,7 +250,7 @@ class GaussianProcess:
             self._compute_cholesky_gp(
                 covariance, self.prediction_length, self.sample_noise
             ),
-            float_type=self.float_type,
+            dtype=self.float_type,
         ).sample_rep(
             self.num_samples
         )  # Shape (num_samples, batch_size, prediction_length)

--- a/src/gluonts/gp/gaussian_process.py
+++ b/src/gluonts/gp/gaussian_process.py
@@ -250,9 +250,8 @@ class GaussianProcess:
             self._compute_cholesky_gp(
                 covariance, self.prediction_length, self.sample_noise
             ),
-            dtype=self.float_type,
         ).sample_rep(
-            self.num_samples
+            self.num_samples, dtype=self.float_type
         )  # Shape (num_samples, batch_size, prediction_length)
         return self.F.transpose(samples, axes=(1, 2, 0))
 

--- a/src/gluonts/kernels/_kernel_output.py
+++ b/src/gluonts/kernels/_kernel_output.py
@@ -97,7 +97,7 @@ class KernelOutputDict(KernelOutput):
         return ArgProj(
             args_dim=self.args_dim,
             domain_map=gluon.nn.HybridLambda(self.domain_map),
-            float_type=float_type,
+            dtype=float_type,
         )
 
     # noinspection PyMethodOverriding,PyPep8Naming

--- a/src/gluonts/model/deepar/_estimator.py
+++ b/src/gluonts/model/deepar/_estimator.py
@@ -21,11 +21,7 @@ from mxnet.gluon import HybridBlock
 # First-party imports
 from gluonts.core.component import DType, validated
 from gluonts.dataset.field_names import FieldName
-from gluonts.distribution import (
-    DistributionOutput,
-    StudentTOutput,
-    GaussianOutput,
-)
+from gluonts.distribution import DistributionOutput, StudentTOutput
 from gluonts.model.estimator import GluonEstimator
 from gluonts.model.predictor import Predictor, RepresentableBlockPredictor
 from gluonts.support.util import copy_parameters

--- a/src/gluonts/model/deepar/_estimator.py
+++ b/src/gluonts/model/deepar/_estimator.py
@@ -117,9 +117,7 @@ class DeepAREstimator(GluonEstimator):
         self,
         freq: str,
         prediction_length: int,
-        trainer: Trainer = Trainer(
-            hybridize=True, num_batches_per_epoch=1, epochs=1
-        ),
+        trainer: Trainer = Trainer(),
         context_length: Optional[int] = None,
         num_layers: int = 2,
         num_cells: int = 40,
@@ -297,7 +295,6 @@ class DeepAREstimator(GluonEstimator):
             embedding_dimension=self.embedding_dimension,
             lags_seq=self.lags_seq,
             scaling=self.scaling,
-            batch_size=self.trainer.batch_size,
             dtype=self.dtype,
         )
 

--- a/src/gluonts/model/deepar/_estimator.py
+++ b/src/gluonts/model/deepar/_estimator.py
@@ -139,9 +139,9 @@ class DeepAREstimator(GluonEstimator):
         lags_seq: Optional[List[int]] = None,
         time_features: Optional[List[TimeFeature]] = None,
         num_parallel_samples: int = 100,
-        float_type: DType = np.float32,
+        dtype: DType = np.float32,
     ) -> None:
-        super().__init__(trainer=trainer, float_type=float_type)
+        super().__init__(trainer=trainer, dtype=dtype)
 
         assert (
             prediction_length > 0
@@ -171,7 +171,7 @@ class DeepAREstimator(GluonEstimator):
         )
         self.prediction_length = prediction_length
         self.distr_output = distr_output
-        self.distr_output.float_type = float_type
+        self.distr_output.dtype = dtype
         self.num_layers = num_layers
         self.num_cells = num_cells
         self.cell_type = cell_type
@@ -230,23 +230,23 @@ class DeepAREstimator(GluonEstimator):
                 AsNumpyArray(
                     field=FieldName.FEAT_STATIC_CAT,
                     expected_ndim=1,
-                    dtype=self.float_type,
+                    dtype=self.dtype,
                 ),
                 AsNumpyArray(
                     field=FieldName.FEAT_STATIC_REAL,
                     expected_ndim=1,
-                    dtype=self.float_type,
+                    dtype=self.dtype,
                 ),
                 AsNumpyArray(
                     field=FieldName.TARGET,
                     # in the following line, we add 1 for the time dimension
                     expected_ndim=1 + len(self.distr_output.event_shape),
-                    dtype=self.float_type,
+                    dtype=self.dtype,
                 ),
                 AddObservedValuesIndicator(
                     target_field=FieldName.TARGET,
                     output_field=FieldName.OBSERVED_VALUES,
-                    dtype=self.float_type,
+                    dtype=self.dtype,
                 ),
                 AddTimeFeatures(
                     start_field=FieldName.START,
@@ -260,7 +260,7 @@ class DeepAREstimator(GluonEstimator):
                     output_field=FieldName.FEAT_AGE,
                     pred_length=self.prediction_length,
                     log_scale=True,
-                    dtype=self.float_type,
+                    dtype=self.dtype,
                 ),
                 VstackFeatures(
                     output_field=FieldName.FEAT_TIME,
@@ -302,7 +302,7 @@ class DeepAREstimator(GluonEstimator):
             lags_seq=self.lags_seq,
             scaling=self.scaling,
             batch_size=self.trainer.batch_size,
-            dtype=self.float_type,
+            dtype=self.dtype,
         )
 
     def create_predictor(
@@ -322,7 +322,7 @@ class DeepAREstimator(GluonEstimator):
             embedding_dimension=self.embedding_dimension,
             lags_seq=self.lags_seq,
             scaling=self.scaling,
-            dtype=self.float_type,
+            dtype=self.dtype,
         )
 
         copy_parameters(trained_network, prediction_network)
@@ -334,5 +334,5 @@ class DeepAREstimator(GluonEstimator):
             freq=self.freq,
             prediction_length=self.prediction_length,
             ctx=self.trainer.ctx,
-            float_type=self.float_type,
+            dtype=self.dtype,
         )

--- a/src/gluonts/model/deepar/_network.py
+++ b/src/gluonts/model/deepar/_network.py
@@ -51,7 +51,6 @@ class DeepARNetwork(mx.gluon.HybridBlock):
         embedding_dimension: List[int],
         lags_seq: List[int],
         scaling: bool = True,
-        batch_size: int = 32,
         dtype: DType = np.float32,
         **kwargs,
     ) -> None:
@@ -67,7 +66,6 @@ class DeepARNetwork(mx.gluon.HybridBlock):
         self.embedding_dimension = embedding_dimension
         self.num_cat = len(cardinality)
         self.scaling = scaling
-        self.batch_size = batch_size
         self.dtype = dtype
 
         assert len(cardinality) == len(

--- a/src/gluonts/model/deepar/_network.py
+++ b/src/gluonts/model/deepar/_network.py
@@ -105,7 +105,9 @@ class DeepARNetwork(mx.gluon.HybridBlock):
                 self.rnn.add(cell)
             self.rnn.cast(dtype=dtype)
             self.embedder = FeatureEmbedder(
-                cardinalities=cardinality, embedding_dims=embedding_dimension, dtype=self.dtype,
+                cardinalities=cardinality,
+                embedding_dims=embedding_dimension,
+                dtype=self.dtype,
             )
             if scaling:
                 self.scaler = MeanScaler(keepdims=True)
@@ -544,7 +546,7 @@ class DeepARPredictionNetwork(DeepARNetwork):
             )
 
             # (batch_size * num_samples, 1, *target_shape)
-            new_samples = distr.sample()
+            new_samples = distr.sample(dtype=self.dtype)
 
             # (batch_size * num_samples, seq_len, *target_shape)
             repeated_past_target = F.concat(

--- a/src/gluonts/model/deepar/_network.py
+++ b/src/gluonts/model/deepar/_network.py
@@ -12,6 +12,7 @@
 # permissions and limitations under the License.
 
 # Standard library imports
+import numpy as np
 from typing import List, Optional, Tuple
 
 # Third-party imports
@@ -20,7 +21,7 @@ import mxnet as mx
 # First-party imports
 from gluonts.block.feature import FeatureEmbedder
 from gluonts.block.scaler import MeanScaler, NOPScaler
-from gluonts.core.component import validated
+from gluonts.core.component import DType, validated
 from gluonts.distribution import DistributionOutput, Distribution
 from gluonts.distribution.distribution import getF
 from gluonts.model.common import Tensor
@@ -50,6 +51,8 @@ class DeepARNetwork(mx.gluon.HybridBlock):
         embedding_dimension: List[int],
         lags_seq: List[int],
         scaling: bool = True,
+        batch_size: int = 32,
+        dtype: DType = np.float32,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -64,6 +67,8 @@ class DeepARNetwork(mx.gluon.HybridBlock):
         self.embedding_dimension = embedding_dimension
         self.num_cat = len(cardinality)
         self.scaling = scaling
+        self.batch_size = batch_size
+        self.dtype = dtype
 
         assert len(cardinality) == len(
             embedding_dimension
@@ -100,8 +105,9 @@ class DeepARNetwork(mx.gluon.HybridBlock):
                     else cell
                 )
                 self.rnn.add(cell)
+            self.rnn.cast(dtype=dtype)
             self.embedder = FeatureEmbedder(
-                cardinalities=cardinality, embedding_dims=embedding_dimension
+                cardinalities=cardinality, embedding_dims=embedding_dimension, dtype=self.dtype,
             )
             if scaling:
                 self.scaler = MeanScaler(keepdims=True)
@@ -277,6 +283,13 @@ class DeepARNetwork(mx.gluon.HybridBlock):
             length=subsequences_length,
             layout="NTC",
             merge_outputs=True,
+            begin_state=self.rnn.begin_state(
+                func=F.zeros,
+                dtype=self.dtype,
+                batch_size=inputs.shape[0]
+                if isinstance(inputs, mx.nd.NDArray)
+                else 0,
+            ),
         )
 
         # outputs: (batch_size, seq_len, num_cells)

--- a/src/gluonts/model/estimator.py
+++ b/src/gluonts/model/estimator.py
@@ -102,11 +102,9 @@ class GluonEstimator(Estimator):
     """
 
     @validated()
-    def __init__(
-        self, trainer: Trainer, float_type: DType = np.float32
-    ) -> None:
+    def __init__(self, trainer: Trainer, dtype: DType = np.float32) -> None:
         self.trainer = trainer
-        self.float_type = float_type
+        self.dtype = dtype
 
     @classmethod
     def from_hyperparameters(cls, **hyperparameters) -> "GluonEstimator":
@@ -175,7 +173,7 @@ class GluonEstimator(Estimator):
             batch_size=self.trainer.batch_size,
             num_batches_per_epoch=self.trainer.num_batches_per_epoch,
             ctx=self.trainer.ctx,
-            float_type=self.float_type,
+            dtype=self.dtype,
         )
 
         # ensure that the training network is created within the same MXNet

--- a/src/gluonts/model/gp_forecaster/_estimator.py
+++ b/src/gluonts/model/gp_forecaster/_estimator.py
@@ -104,15 +104,15 @@ class GaussianProcessEstimator(GluonEstimator):
         context_length: Optional[int] = None,
         kernel_output: KernelOutput = RBFKernelOutput(),
         params_scaling: bool = True,
-        float_type: DType = np.float64,
+        dtype: DType = np.float64,
         max_iter_jitter: int = 10,
         jitter_method: str = "iter",
         sample_noise: bool = True,
         time_features: Optional[List[TimeFeature]] = None,
         num_parallel_samples: int = 100,
     ) -> None:
-        self.float_type = float_type
-        super().__init__(trainer=trainer, float_type=self.float_type)
+        self.float_type = dtype
+        super().__init__(trainer=trainer, dtype=self.float_type)
 
         assert (
             prediction_length > 0
@@ -214,5 +214,5 @@ class GaussianProcessEstimator(GluonEstimator):
             freq=self.freq,
             prediction_length=self.prediction_length,
             ctx=self.trainer.ctx,
-            float_type=self.float_type,
+            dtype=self.float_type,
         )

--- a/src/gluonts/model/predictor.py
+++ b/src/gluonts/model/predictor.py
@@ -243,7 +243,7 @@ class GluonPredictor(Predictor):
         input_transform: Transformation,
         forecast_generator: ForecastGenerator = SampleForecastGenerator(),
         output_transform: Optional[OutputTransform] = None,
-        float_type: DType = np.float32,
+        dtype: DType = np.float32,
     ) -> None:
         super().__init__(prediction_length, freq)
 
@@ -254,7 +254,7 @@ class GluonPredictor(Predictor):
         self.forecast_generator = forecast_generator
         self.output_transform = output_transform
         self.ctx = ctx
-        self.float_type = float_type
+        self.dtype = dtype
 
     def hybridize(self, batch: DataBatch) -> None:
         """
@@ -298,7 +298,7 @@ class GluonPredictor(Predictor):
             self.input_transform,
             self.batch_size,
             ctx=self.ctx,
-            float_type=self.float_type,
+            dtype=self.dtype,
         )
         yield from self.forecast_generator(
             inference_data_loader=inference_data_loader,
@@ -343,7 +343,7 @@ class GluonPredictor(Predictor):
                 prediction_length=self.prediction_length,
                 freq=self.freq,
                 ctx=self.ctx,
-                float_type=self.float_type,
+                dtype=self.dtype,
                 forecast_generator=self.forecast_generator,
                 input_names=self.input_names,
             )
@@ -442,7 +442,7 @@ class RepresentableBlockPredictor(GluonPredictor):
         output_transform: Optional[
             Callable[[DataEntry, np.ndarray], np.ndarray]
         ] = None,
-        float_type: DType = np.float32,
+        dtype: DType = np.float32,
     ) -> None:
         super().__init__(
             input_names=get_hybrid_forward_input_names(prediction_net),
@@ -454,7 +454,7 @@ class RepresentableBlockPredictor(GluonPredictor):
             input_transform=input_transform,
             forecast_generator=forecast_generator,
             output_transform=output_transform,
-            float_type=float_type,
+            dtype=dtype,
         )
 
     def as_symbol_block_predictor(
@@ -475,7 +475,7 @@ class RepresentableBlockPredictor(GluonPredictor):
             input_transform=self.input_transform,
             forecast_generator=self.forecast_generator,
             output_transform=self.output_transform,
-            float_type=self.float_type,
+            dtype=self.dtype,
         )
 
     def serialize_prediction_net(self, path: Path) -> None:

--- a/src/gluonts/transform.py
+++ b/src/gluonts/transform.py
@@ -676,11 +676,13 @@ class AddObservedValuesIndicator(SimpleTransformation):
         output_field: str,
         dummy_value: int = 0,
         convert_nans: bool = True,
+        dtype: DType = np.float32,
     ) -> None:
         self.dummy_value = dummy_value
         self.target_field = target_field
         self.output_field = output_field
         self.convert_nans = convert_nans
+        self.dtype = dtype
 
     def transform(self, data: DataEntry) -> DataEntry:
         value = data[self.target_field]
@@ -692,7 +694,7 @@ class AddObservedValuesIndicator(SimpleTransformation):
 
         data[self.target_field] = value
         # Invert bool array so that missing values are zeros and store as float
-        data[self.output_field] = np.invert(nan_entries).astype(np.float32)
+        data[self.output_field] = np.invert(nan_entries).astype(self.dtype)
         return data
 
 
@@ -886,12 +888,14 @@ class AddAgeFeature(MapTransformation):
         output_field: str,
         pred_length: int,
         log_scale: bool = True,
+        dtype: DType = np.float32,
     ) -> None:
         self.pred_length = pred_length
         self.target_field = target_field
         self.feature_name = output_field
         self.log_scale = log_scale
         self._age_feature = np.zeros(0)
+        self.dtype = dtype
 
     def map_transform(self, data: DataEntry, is_train: bool) -> DataEntry:
         length = target_transformation_length(
@@ -899,9 +903,9 @@ class AddAgeFeature(MapTransformation):
         )
 
         if self.log_scale:
-            age = np.log10(2.0 + np.arange(length, dtype=np.float32))
+            age = np.log10(2.0 + np.arange(length, dtype=self.dtype))
         else:
-            age = np.arange(length, dtype=np.float32)
+            age = np.arange(length, dtype=self.dtype)
 
         data[self.feature_name] = age.reshape((1, length))
 


### PR DESCRIPTION
*Description of changes:*

This PR adds support for changing precision for gluon estimators. This is useful for example to speedup models by switching to lower precision or make the them (e.g., `gp_forecaster`) more robust by using double precision.

The changes are done only for `DeepAREstimator` on the computation side i.e., only changing estimator, network and distribution output. Changes on the dataset loading part as well as for other estimators will be sent separately to make the PR manageable. 
 
* Need new mxnet version; in older versions backward fails in symbolic mode if you use `np.float64`: one of the inputs of `grad_sum` is not `np.float32`. It maybe because  `float32` is hardcoded somewhere.
* sampling operators always return `np.float32` values, so had to set `dtype` explicitly here. 
* Also made the terminology consistent across by replacing `float_type` to `dtype`.
