### PR TITLE
Fixes for serializing sets and numpy numbers in SerDe

### DIFF
--- a/src/gluonts/core/serde.py
+++ b/src/gluonts/core/serde.py
@@ -208,9 +208,13 @@ def dump_code(o: Any) -> str:
             return "(" + ", ".join(elems) + ",)"
         elif isinstance(x, str):
             return '"' + x + '"'  # TODO: escape comp characters
-        elif isinstance(x, float):
+        elif isinstance(x, float) or np.issubdtype(type(x), np.inexact):
             return str(x) if math.isfinite(x) else 'float("' + str(x) + '")'
-        elif isinstance(x, int) or x is None:
+        elif (
+            isinstance(x, int)
+            or np.issubdtype(type(x), np.integer)
+            or x is None
+        ):
             return str(x)
         else:
             x = fqname_for(x.__class__)
@@ -384,9 +388,9 @@ def encode(v: Any) -> Any:
     """
     if isinstance(v, type(None)):
         return None
-    elif isinstance(v, (float, int, str)):
+    elif isinstance(v, (float, int, str)) or np.issubdtype(type(v), np.number):
         return v
-    elif isinstance(v, list) or type(v) == tuple:
+    elif isinstance(v, (list, set)) or type(v) == tuple:
         return [encode(v) for v in v]
     elif isinstance(v, tuple) and not hasattr(v, "_asdict"):
         return tuple([encode(v) for v in v])


### PR DESCRIPTION
This PR fixes a several problems that happen when you're trying to use categorical features in Sagemaker with DeepAR. They happen for builtin set type and with numpy numbers — these types are missed in the SerDe code. Here is a traceback for one of them:

```python
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.7/site-packages/gluonts/shell/__main__.py", line 179, in <module>
    cli(prog_name=__package__)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/gluonts/shell/__main__.py", line 169, in train_command
    train.run_train_and_test(env, forecaster_type_by_name(forecaster))
  File "/usr/local/lib/python3.7/site-packages/gluonts/shell/train.py", line 61, in run_train_and_test
    predictor = run_train(forecaster, env.datasets["train"])
  File "/usr/local/lib/python3.7/site-packages/gluonts/shell/train.py", line 70, in run_train
    log.metric("train_dataset_stats", train_dataset.calc_stats())
  File "/usr/local/lib/python3.7/site-packages/gluonts/core/log.py", line 38, in metric
    logger.info(f"gluonts[{metric}]: {dump_code(value)}")
  File "/usr/local/lib/python3.7/site-packages/gluonts/core/serde.py", line 219, in dump_code
    return _dump_code(encode(o))
  File "/usr/local/lib/python3.7/site-packages/gluonts/core/serde.py", line 194, in _dump_code
    [f"{k}={_dump_code(v)}" for k, v in kwargs.items()],
  File "/usr/local/lib/python3.7/site-packages/gluonts/core/serde.py", line 194, in <listcomp>
    [f"{k}={_dump_code(v)}" for k, v in kwargs.items()],
  File "/usr/local/lib/python3.7/site-packages/gluonts/core/serde.py", line 204, in _dump_code
    elems = [dump_code(v) for v in x]
  File "/usr/local/lib/python3.7/site-packages/gluonts/core/serde.py", line 204, in <listcomp>
    elems = [dump_code(v) for v in x]
  File "/usr/local/lib/python3.7/site-packages/gluonts/core/serde.py", line 219, in dump_code
    return _dump_code(encode(o))
  File "/usr/local/lib/python3.7/site-packages/gluonts/core/serde.py", line 204, in _dump_code
    elems = [dump_code(v) for v in x]
  File "/usr/local/lib/python3.7/site-packages/gluonts/core/serde.py", line 204, in <listcomp>
    elems = [dump_code(v) for v in x]
  File "/usr/local/lib/python3.7/site-packages/gluonts/core/serde.py", line 219, in dump_code
    return _dump_code(encode(o))
  File "/usr/local/lib/python3.7/site-packages/gluonts/core/serde.py", line 217, in _dump_code
    raise RuntimeError(f"Unexpected element type {x}")
RuntimeError: Unexpected element type numpy.int32
```

This PR introduces a fix — the missing types are added in Encoding function.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
