### PR TITLE
Fix empty time_features issue

### DIFF
--- a/src/gluonts/transform.py
+++ b/src/gluonts/transform.py
@@ -831,7 +831,7 @@ class AddTimeFeatures(MapTransformation):
         )
         self._full_range_date_features = np.vstack(
             [feat(self.full_date_range) for feat in self.date_features]
-        )
+        ) if self.date_features else None
         self._date_index = pd.Series(
             index=self.full_date_range,
             data=np.arange(len(self.full_date_range)),
@@ -844,7 +844,11 @@ class AddTimeFeatures(MapTransformation):
         )
         self._update_cache(start, length)
         i0 = self._date_index[start]
-        features = self._full_range_date_features[..., i0 : i0 + length]
+        features = (
+            self._full_range_date_features[..., i0 : i0 + length]
+            if self.date_features 
+            else None
+        )
         data[self.output_field] = features
         return data
 

--- a/src/gluonts/transform.py
+++ b/src/gluonts/transform.py
@@ -829,9 +829,13 @@ class AddTimeFeatures(MapTransformation):
         self.full_date_range = pd.date_range(
             self._min_time_point, self._max_time_point, freq=start.freq
         )
-        self._full_range_date_features = np.vstack(
-            [feat(self.full_date_range) for feat in self.date_features]
-        ) if self.date_features else None
+        self._full_range_date_features = (
+            np.vstack(
+                [feat(self.full_date_range) for feat in self.date_features]
+            )
+            if self.date_features
+            else None
+        )
         self._date_index = pd.Series(
             index=self.full_date_range,
             data=np.arange(len(self.full_date_range)),
@@ -846,7 +850,7 @@ class AddTimeFeatures(MapTransformation):
         i0 = self._date_index[start]
         features = (
             self._full_range_date_features[..., i0 : i0 + length]
-            if self.date_features 
+            if self.date_features
             else None
         )
         data[self.output_field] = features

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -132,6 +132,26 @@ def test_AddTimeFeatures(start, target, is_train):
 @pytest.mark.parametrize("is_train", TEST_VALUES["is_train"])
 @pytest.mark.parametrize("target", TEST_VALUES["target"])
 @pytest.mark.parametrize("start", TEST_VALUES["start"])
+def test_AddTimeFeatures_empty_time_features(start, target, is_train):
+    pred_length = 13
+    t = transform.AddTimeFeatures(
+        start_field=FieldName.START,
+        target_field=FieldName.TARGET,
+        output_field="myout",
+        pred_length=pred_length,
+        time_features=[],
+    )
+
+    assert_serializable(t)
+
+    data = {"start": start, "target": target}
+    res = t.map_transform(data, is_train=is_train)
+    assert not res["myout"]
+
+
+@pytest.mark.parametrize("is_train", TEST_VALUES["is_train"])
+@pytest.mark.parametrize("target", TEST_VALUES["target"])
+@pytest.mark.parametrize("start", TEST_VALUES["start"])
 def test_AddAgeFeatures(start, target, is_train):
     pred_length = 13
     t = transform.AddAgeFeature(

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -146,7 +146,7 @@ def test_AddTimeFeatures_empty_time_features(start, target, is_train):
 
     data = {"start": start, "target": target}
     res = t.map_transform(data, is_train=is_train)
-    assert not res["myout"]
+    assert res["myout"] is None
 
 
 @pytest.mark.parametrize("is_train", TEST_VALUES["is_train"])


### PR DESCRIPTION
*Issue #367*

*Description of changes:*

* Cause of issue #367: In `AddTimeFeatures`, when `time_features` or `self. date_features` is an empty list, the following snippet would throw an error.
```
        self._full_range_date_features = np.vstack(
            [feat(self.full_date_range) for feat in self.date_features]
        )
```

* After this fix, if `time_features` is empty, `self._full_range_date_features` and `data[self.output_field]` will be set to `None`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
