### PR TITLE
address issue #278

### DIFF
--- a/src/gluonts/model/predictor.py
+++ b/src/gluonts/model/predictor.py
@@ -119,7 +119,9 @@ class Predictor:
         with (path / "type.txt").open("w") as fp:
             fp.write(fqname_for(self.__class__))
         with (path / "version.json").open("w") as fp:
-            json.dump({"model": self.__version__, "gluonts": gluonts.__version__}, fp)
+            json.dump(
+                {"model": self.__version__, "gluonts": gluonts.__version__}, fp
+            )
 
     @classmethod
     def deserialize(

--- a/src/gluonts/model/predictor.py
+++ b/src/gluonts/model/predictor.py
@@ -21,6 +21,7 @@ import traceback
 from pathlib import Path
 from pydoc import locate
 from tempfile import TemporaryDirectory
+import json
 from typing import (
     TYPE_CHECKING,
     Tuple,
@@ -117,7 +118,8 @@ class Predictor:
         # serialize Predictor type
         with (path / "type.txt").open("w") as fp:
             fp.write(fqname_for(self.__class__))
-            fp.write("\ngluonts version: " + self.__version__ + "\n")
+        with (path / "version.json").open("w") as fp:
+            json.dump({"model": self.__version__, "gluonts": gluonts.__version__}, fp)
 
     @classmethod
     def deserialize(

--- a/src/gluonts/model/predictor.py
+++ b/src/gluonts/model/predictor.py
@@ -117,6 +117,7 @@ class Predictor:
         # serialize Predictor type
         with (path / "type.txt").open("w") as fp:
             fp.write(fqname_for(self.__class__))
+            fp.write("\ngluonts version: " + self.__version__ + "\n")
 
     @classmethod
     def deserialize(


### PR DESCRIPTION
*Issue #, if available:*
#278
*Description of changes:*
This adds the version number of gluonts to the type.txt file during serialization, but doesn't do anything with this during deserialization. I tested this locally, but didn't add any unit tests. If I should, please point me to where I'd best do this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
