### PR TITLE
Add slice_axis methods to Distribution

### DIFF
--- a/src/gluonts/distribution/binned.py
+++ b/src/gluonts/distribution/binned.py
@@ -174,6 +174,10 @@ class Binned(Distribution):
 
         return _sample_multiple(s, self.bin_probs, num_samples=num_samples)
 
+    @property
+    def args(self) -> List:
+        return [self.bin_probs, self.bin_centers]
+
 
 class BinnedArgs(gluon.HybridBlock):
     def __init__(

--- a/src/gluonts/distribution/distribution.py
+++ b/src/gluonts/distribution/distribution.py
@@ -253,6 +253,30 @@ class Distribution:
         """
         raise NotImplementedError()
 
+    def slice(self, begin: Tuple, end: Tuple) -> "Distribution":
+        """
+        Construct a new distribution by slicing all constructor arguments
+        as specified by the provided bounds. Relies on ``mx.nd.slice``.
+        """
+        sliced_distr = self.__class__(
+            *[a.slice(begin, end) for a in self.args]
+        )
+        assert isinstance(sliced_distr, type(self))
+        return sliced_distr
+
+    def slice_axis(
+        self, axis: int, begin: int, end: Optional[int]
+    ) -> "Distribution":
+        """
+        Construct a new distribution by slicing all constructor arguments
+        as specified by the provided bounds. Relies on ``mx.nd.slice_axis``.
+        """
+        sliced_distr = self.__class__(
+            *[a.slice_axis(axis, begin, end) for a in self.args]
+        )
+        assert isinstance(sliced_distr, type(self))
+        return sliced_distr
+
 
 def _expand_param(p: Tensor, num_samples: Optional[int] = None) -> Tensor:
     """

--- a/src/gluonts/distribution/distribution.py
+++ b/src/gluonts/distribution/distribution.py
@@ -261,7 +261,7 @@ class Distribution:
         as specified by the provided bounds. Relies on ``mx.nd.slice_axis``.
         """
         sliced_distr = self.__class__(
-            *[a.slice_axis(axis, begin, end) for a in self.args]
+            *[arg.slice_axis(axis, begin, end) for arg in self.args]
         )
         assert isinstance(sliced_distr, type(self))
         return sliced_distr

--- a/src/gluonts/distribution/distribution.py
+++ b/src/gluonts/distribution/distribution.py
@@ -253,17 +253,6 @@ class Distribution:
         """
         raise NotImplementedError()
 
-    def slice(self, begin: Tuple, end: Tuple) -> "Distribution":
-        """
-        Construct a new distribution by slicing all constructor arguments
-        as specified by the provided bounds. Relies on ``mx.nd.slice``.
-        """
-        sliced_distr = self.__class__(
-            *[a.slice(begin, end) for a in self.args]
-        )
-        assert isinstance(sliced_distr, type(self))
-        return sliced_distr
-
     def slice_axis(
         self, axis: int, begin: int, end: Optional[int]
     ) -> "Distribution":

--- a/src/gluonts/distribution/gaussian.py
+++ b/src/gluonts/distribution/gaussian.py
@@ -13,7 +13,7 @@
 
 # Standard library imports
 import math
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple, List
 
 # First-party imports
 from gluonts.model.common import Tensor
@@ -115,6 +115,10 @@ class Gaussian(Distribution):
                 self.sigma, math.sqrt(2.0) * erfinv(F, 2.0 * level - 1.0)
             ),
         )
+
+    @property
+    def args(self) -> List:
+        return [self.mu, self.sigma]
 
 
 class GaussianOutput(DistributionOutput):

--- a/src/gluonts/distribution/laplace.py
+++ b/src/gluonts/distribution/laplace.py
@@ -12,7 +12,7 @@
 # permissions and limitations under the License.
 
 # Standard library imports
-from typing import Dict, Tuple
+from typing import Dict, Tuple, List
 
 # First-party imports
 from gluonts.model.common import Tensor
@@ -99,6 +99,10 @@ class Laplace(Distribution):
         u = F.where(condition, F.log(2.0 * level), -F.log(2.0 - 2.0 * level))
 
         return F.broadcast_add(self.mu, F.broadcast_mul(self.b, u))
+
+    @property
+    def args(self) -> List:
+        return [self.mu, self.b]
 
 
 class LaplaceOutput(DistributionOutput):

--- a/src/gluonts/distribution/neg_binomial.py
+++ b/src/gluonts/distribution/neg_binomial.py
@@ -12,7 +12,7 @@
 # permissions and limitations under the License.
 
 # Standard library imports
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple, List
 
 # First-party imports
 from gluonts.model.common import Tensor
@@ -92,6 +92,10 @@ class NegativeBinomial(Distribution):
         return _sample_multiple(
             s, mu=self.mu, alpha=self.alpha, num_samples=num_samples
         )
+
+    @property
+    def args(self) -> List:
+        return [self.mu, self.alpha]
 
 
 class NegativeBinomialOutput(DistributionOutput):

--- a/src/gluonts/distribution/student_t.py
+++ b/src/gluonts/distribution/student_t.py
@@ -13,7 +13,7 @@
 
 # Standard library imports
 import math
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple, List
 
 # First-party imports
 from gluonts.model.common import Tensor
@@ -110,6 +110,10 @@ class StudentT(Distribution):
             nu=self.nu,
             num_samples=num_samples,
         )
+
+    @property
+    def args(self) -> List:
+        return [self.mu, self.sigma, self.nu]
 
 
 class StudentTOutput(DistributionOutput):

--- a/src/gluonts/distribution/uniform.py
+++ b/src/gluonts/distribution/uniform.py
@@ -12,7 +12,7 @@
 # permissions and limitations under the License.
 
 # Standard library imports
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple, List
 
 # First-party imports
 from gluonts.model.common import Tensor
@@ -99,6 +99,10 @@ class Uniform(Distribution):
         return F.broadcast_add(
             F.broadcast_mul(self.high - self.low, level), self.low
         )
+
+    @property
+    def args(self) -> List:
+        return [self.low, self.high]
 
 
 class UniformOutput(DistributionOutput):

--- a/test/distribution/test_distribution_slice.py
+++ b/test/distribution/test_distribution_slice.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
 import pytest
 
 import mxnet as mx

--- a/test/distribution/test_distribution_slice.py
+++ b/test/distribution/test_distribution_slice.py
@@ -13,21 +13,6 @@ DISTR_CASES = [
     )
 ]
 
-SLICE_CASES = [
-    [((None, None), (None, None)), DISTR_SHAPE],
-    [((1, None), (None, -1)), (2, 3)],
-]
-
-
-@pytest.mark.parametrize("slice_args, expected_shape", SLICE_CASES)
-@pytest.mark.parametrize("distr", DISTR_CASES)
-def test_distr_slice(distr, slice_args, expected_shape):
-    begin, end = slice_args
-    distr_sliced = distr.slice(begin, end)
-
-    assert distr_sliced.batch_shape == expected_shape
-
-
 SLICE_AXIS_CASES = [[(0, 0, None), 3], [(0, 1, 3), 2], [(1, -1, None), 1]]
 
 

--- a/test/distribution/test_distribution_slice.py
+++ b/test/distribution/test_distribution_slice.py
@@ -1,0 +1,42 @@
+import pytest
+
+import mxnet as mx
+
+from gluonts.distribution.gaussian import Gaussian
+
+DISTR_SHAPE = (3, 4)
+
+DISTR_CASES = [
+    Gaussian(
+        mu=mx.nd.random.normal(shape=DISTR_SHAPE),
+        sigma=mx.nd.random.uniform(shape=DISTR_SHAPE),
+    )
+]
+
+SLICE_CASES = [
+    [((None, None), (None, None)), DISTR_SHAPE],
+    [((1, None), (None, -1)), (2, 3)],
+]
+
+
+@pytest.mark.parametrize("slice_args, expected_shape", SLICE_CASES)
+@pytest.mark.parametrize("distr", DISTR_CASES)
+def test_distr_slice(distr, slice_args, expected_shape):
+    begin, end = slice_args
+    distr_sliced = distr.slice(begin, end)
+
+    assert distr_sliced.batch_shape == expected_shape
+
+
+SLICE_AXIS_CASES = [[(0, 0, None), 3], [(0, 1, 3), 2], [(1, -1, None), 1]]
+
+
+@pytest.mark.parametrize(
+    "slice_axis_args, expected_axis_length", SLICE_AXIS_CASES
+)
+@pytest.mark.parametrize("distr", DISTR_CASES)
+def test_distr_slice_axis(distr, slice_axis_args, expected_axis_length):
+    axis, begin, end = slice_axis_args
+    distr_sliced = distr.slice_axis(axis, begin, end)
+
+    assert distr_sliced.batch_shape[axis] == expected_axis_length


### PR DESCRIPTION
*Description of changes:* This allows to slice distributions across arbitrary axes, using the basically the same signatures as mx.nd.slice and mx.nd.slice_axis.

More tests/distributions to come, feedback wanted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
