### PR TITLE
Update the docstring of RForecastPredictor

### DIFF
--- a/src/gluonts/model/r_forecast/_predictor.py
+++ b/src/gluonts/model/r_forecast/_predictor.py
@@ -30,7 +30,7 @@ USAGE_MESSAGE = """
 The RForecastPredictor is a thin wrapper for calling the R forecast package.
 In order to use it you need to install R and run
 
-pip install rpy2
+pip install 'rpy2>=2.9.*,<3.*'
 
 R -e 'install.packages(c("forecast", "nnfor"), repos="https://cloud.r-project.org")'
 """
@@ -44,7 +44,7 @@ class RForecastPredictor(RepresentablePredictor):
     The `RForecastPredictor` is a thin wrapper for calling the R forecast
     package.  In order to use it you need to install R and run::
 
-        pip install rpy2
+        pip install 'rpy2>=2.9.*,<3.*'
         R -e 'install.packages(c("forecast", "nnfor"), repos="https://cloud.r-project.org")'
 
     Parameters


### PR DESCRIPTION
*Issue #, if available: None*

*Description of changes:*
Changed the pip command from `pip install rpy2` to `pip install 'rpy2>=2.9.*,<3.*'`, which is consistent with [requirements-extras-r.txt](https://github.com/awslabs/gluon-ts/blob/master/requirements/requirements-extras-r.txt). The original command will install `rpy2` v3.2.1, which is not compatible with the `RForecastPredictor` class. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
