### PR TITLE
Fix batch shape in Binned Distribution

### DIFF
--- a/src/gluonts/distribution/binned.py
+++ b/src/gluonts/distribution/binned.py
@@ -87,7 +87,7 @@ class Binned(Distribution):
 
     @property
     def batch_shape(self) -> Tuple:
-        return self.bin_centers.shape[:-1]
+        return self.bin_probs.shape[:-1]
 
     @property
     def event_shape(self) -> Tuple:


### PR DESCRIPTION
The Binned distribution does not return the right batch shape since `bin_centers` is just a one-dimensional list common for all examples in the batch. The shape information is available in `bin_probs`.