### PR TITLE
Use static categorical feature for evaluating m4 datasets

### DIFF
--- a/examples/benchmark_m4.py
+++ b/examples/benchmark_m4.py
@@ -74,6 +74,11 @@ def evaluate(dataset_name, estimator):
     estimator = estimator(
         prediction_length=dataset.metadata.prediction_length,
         freq=dataset.metadata.freq,
+        use_feat_static_cat=True,
+        cardinality=[
+            feat_static_cat.cardinality
+            for feat_static_cat in dataset.metadata.feat_static_cat
+        ],
     )
 
     print(f"evaluating {estimator} on {dataset}")


### PR DESCRIPTION
#376 

We currently do not use categorical feature in the evaluation of m4 datasets although this is present in the dataset. This often results in large error for `m4_hourly`. This PR adds cat feature  for the m4 evaluation. 

I ran deepar model with and without categorical feature. For `m4_hourly` there is a clear improvement. On other datasets using cat feature is slightly better for almost all datasets in terms of  `RMSE`, `mean_wQunatileLoss`, `MASE`. On the other metrics it is mixed although I think using cat in principle should always give better results; need to check the impact of `embedding_dim` on the performance.

**Without cat feature**

|dataset        |estimator         |RMSE  |mean_wQuantileLoss      |MASE|     sMAPE       |MSIS
| --- | --- | --- | ---  | --- | --- | --- | 
|     m4_hourly  |DeepAREstimator  |6287.739733            |0.106407  |1.783540  |0.131712  |26.874568
|      m4_daily  |DeepAREstimator   |669.159914            |0.025856  |4.120823  |0.038060  |54.246199
|     m4_weekly  |DeepAREstimator   |668.698652            |0.051018  |2.848970  |0.084453  |26.471953
|    m4_monthly  |DeepAREstimator  |1422.962951            |0.118168  |1.196579  |0.140440  |26.074230
|  m4_quarterly  |DeepAREstimator  |1397.590109            |0.086418  |1.299676  |0.106761  |16.885508
|     m4_yearly  |DeepAREstimator  |1802.114059            |0.121546  |3.638369  |0.145967  |59.942453


**With cat feature**

| dataset        | estimator         | RMSE  | mean_wQuantileLoss      | MASE     | sMAPE       | MSIS
| --- | --- | --- | ---  | --- | --- | --- | 
|     m4_hourly  |DeepAREstimator |  2224.828709           |  0.043838 |  1.388138 |  0.125006 |  23.352866
|      m4_daily  |DeepAREstimator  |  630.971563           | 0.024090  | 3.570393  | 0.033416  | 45.372105
|     m4_weekly  |DeepAREstimator  | 671.174265            | 0.050066  | 2.894249  | 0.085407  | 35.433631
|    m4_monthly  |DeepAREstimator  |1404.456407            | 0.113999  | 1.113356  | 0.140272  | 22.465503
|  m4_quarterly  |DeepAREstimator  | 1407.398593           | 0.086242  | 1.434469  | 0.111112  | 18.267942
|     m4_yearly  | DeepAREstimator | 1975.966961           | 0.136738  | 4.237890  | 0.165475  | 72.581687

