### PR TITLE
 DeepStateEstimator: Make cardinality argument compulsory 

### DIFF
--- a/src/gluonts/model/deepstate/_estimator.py
+++ b/src/gluonts/model/deepstate/_estimator.py
@@ -12,6 +12,7 @@
 # permissions and limitations under the License.
 
 # Standard library imports
+import numpy as np
 from typing import List, Optional
 
 # Third-party imports
@@ -82,6 +83,10 @@ class DeepStateEstimator(GluonEstimator):
         Frequency of the data to train on and predict
     prediction_length
         Length of the prediction horizon
+    cardinality
+        Number of values of each categorical feature.
+        This must be set by default unless ``use_feat_static_cat``
+        is set to `False` explicitly (which is NOT recommended).
     add_trend
         Flag to indicate whether to include trend component in the
         state space model
@@ -117,9 +122,6 @@ class DeepStateEstimator(GluonEstimator):
     use_feat_static_cat
         Whether to use the ``feat_static_cat`` field from the data
         (default: False)
-    cardinality
-        Number of values of each categorical feature.
-        This must be set if ``use_feat_static_cat == True`` (default: None)
     embedding_dimension
         Dimension of the embeddings for categorical features
         (default: [min(50, (cat+1)//2) for cat in cardinality])
@@ -135,6 +137,7 @@ class DeepStateEstimator(GluonEstimator):
         self,
         freq: str,
         prediction_length: int,
+        cardinality: List[int],
         add_trend: bool = False,
         past_length: Optional[int] = None,
         num_periods_to_train: int = 4,
@@ -145,8 +148,7 @@ class DeepStateEstimator(GluonEstimator):
         num_eval_samples: int = 100,
         dropout_rate: float = 0.1,
         use_feat_dynamic_real: bool = False,
-        use_feat_static_cat: bool = False,
-        cardinality: Optional[List[int]] = None,
+        use_feat_static_cat: bool = True,
         embedding_dimension: Optional[List[int]] = None,
         issm: Optional[ISSM] = None,
         scaling: bool = True,
@@ -166,15 +168,13 @@ class DeepStateEstimator(GluonEstimator):
             num_eval_samples > 0
         ), "The value of `num_eval_samples` should be > 0"
         assert dropout_rate >= 0, "The value of `dropout_rate` should be >= 0"
-        assert (cardinality is not None and use_feat_static_cat) or (
-            cardinality is None and not use_feat_static_cat
-        ), "You should set `cardinality` if and only if `use_feat_static_cat=True`"
-        assert cardinality is None or [
-            c > 0 for c in cardinality
-        ], "Elements of `cardinality` should be > 0"
-        assert embedding_dimension is None or [
-            e > 0 for e in embedding_dimension
-        ], "Elements of `embedding_dimension` should be > 0"
+        assert not use_feat_static_cat or np.prod(cardinality) > 1, (
+            f"Number of distinct values across static categorical features (i.e., prod(`cardinality`)) "
+            f"must be larger than 1 if `use_feat_static_cat=True`. But cardinality provided is: {cardinality}"
+        )
+        assert embedding_dimension is None or all(
+            [e > 0 for e in embedding_dimension]
+        ), "Elements of `embedding_dimension` should be > 0"
 
         self.freq = freq
         self.past_length = (

--- a/src/gluonts/model/deepstate/_estimator.py
+++ b/src/gluonts/model/deepstate/_estimator.py
@@ -12,7 +12,6 @@
 # permissions and limitations under the License.
 
 # Standard library imports
-import numpy as np
 from typing import List, Optional
 
 # Third-party imports
@@ -168,12 +167,12 @@ class DeepStateEstimator(GluonEstimator):
             num_eval_samples > 0
         ), "The value of `num_eval_samples` should be > 0"
         assert dropout_rate >= 0, "The value of `dropout_rate` should be >= 0"
-        assert not use_feat_static_cat or np.prod(cardinality) > 1, (
-            f"Number of distinct values across static categorical features (i.e., prod(`cardinality`)) "
-            f"must be larger than 1 if `use_feat_static_cat=True`. But cardinality provided is: {cardinality}"
+        assert not use_feat_static_cat or any(c > 1 for c in cardinality), (
+            f"Cardinality of at least one static categorical feature must be larger than 1 "
+            f"if `use_feat_static_cat=True`. But cardinality provided is: {cardinality}"
         )
         assert embedding_dimension is None or all(
-            [e > 0 for e in embedding_dimension]
+            e > 0 for e in embedding_dimension
         ), "Elements of `embedding_dimension` should be > 0"
 
         self.freq = freq

--- a/src/gluonts/testutil/dummy_datasets.py
+++ b/src/gluonts/testutil/dummy_datasets.py
@@ -1,0 +1,68 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# Standard library imports
+from functools import partial
+from random import randint
+from typing import List, Tuple
+
+# Third-party imports
+import numpy as np
+import pytest
+
+# First-party imports
+from gluonts.dataset.common import ListDataset
+from gluonts.dataset.field_names import FieldName
+
+
+def make_dummy_datasets_with_features(
+    num_ts: int = 5,
+    start: str = "2018-01-01",
+    freq: str = "D",
+    min_length: int = 5,
+    max_length: int = 10,
+    prediction_length: int = 3,
+    cardinality: List[int] = [],
+    num_feat_dynamic_real: int = 0,
+) -> Tuple[ListDataset, ListDataset]:
+
+    data_iter_train = []
+    data_iter_test = []
+
+    for k in range(num_ts):
+        ts_length = randint(min_length, max_length)
+        data_entry_train = {
+            FieldName.START: start,
+            FieldName.TARGET: [0.0] * ts_length,
+        }
+        if len(cardinality) > 0:
+            data_entry_train[FieldName.FEAT_STATIC_CAT] = [
+                randint(0, c) for c in cardinality
+            ]
+        data_entry_test = data_entry_train.copy()
+        if num_feat_dynamic_real > 0:
+            data_entry_train[FieldName.FEAT_DYNAMIC_REAL] = [
+                [float(1 + k)] * ts_length
+                for k in range(num_feat_dynamic_real)
+            ]
+            data_entry_test[FieldName.FEAT_DYNAMIC_REAL] = [
+                [float(1 + k)] * (ts_length + prediction_length)
+                for k in range(num_feat_dynamic_real)
+            ]
+        data_iter_train.append(data_entry_train)
+        data_iter_test.append(data_entry_test)
+
+    return (
+        ListDataset(data_iter=data_iter_train, freq=freq),
+        ListDataset(data_iter=data_iter_test, freq=freq),
+    )

--- a/test/model/test_deepstate_smoke.py
+++ b/test/model/test_deepstate_smoke.py
@@ -15,19 +15,19 @@
 from functools import partial
 
 # Third-party imports
-import numpy as np
 import pytest
 
 # First-party imports
+from gluonts.model.deepstate import DeepStateEstimator
 from gluonts.testutil.dummy_datasets import make_dummy_datasets_with_features
-from gluonts.model.deepar import DeepAREstimator
 from gluonts.trainer import Trainer
 
 
 common_estimator_hps = dict(
     freq="D",
     prediction_length=3,
-    trainer=Trainer(epochs=3, num_batches_per_epoch=2, batch_size=4),
+    trainer=Trainer(epochs=3, num_batches_per_epoch=2, batch_size=1),
+    past_length=10,
 )
 
 
@@ -36,39 +36,45 @@ common_estimator_hps = dict(
     [
         # No features
         (
-            partial(DeepAREstimator, **common_estimator_hps),
+            partial(
+                DeepStateEstimator,
+                **common_estimator_hps,
+                cardinality=[1],
+                use_feat_static_cat=False,
+            ),
             make_dummy_datasets_with_features(),
         ),
         # Single static categorical feature
         (
             partial(
-                DeepAREstimator,
-                **common_estimator_hps,
-                use_feat_static_cat=True,
-                cardinality=[5],
+                DeepStateEstimator, **common_estimator_hps, cardinality=[5]
             ),
             make_dummy_datasets_with_features(cardinality=[5]),
         ),
         # Multiple static categorical features
         (
             partial(
-                DeepAREstimator,
+                DeepStateEstimator,
                 **common_estimator_hps,
-                use_feat_static_cat=True,
                 cardinality=[3, 10, 42],
             ),
             make_dummy_datasets_with_features(cardinality=[3, 10, 42]),
         ),
-        # Multiple static categorical features (ignored)
-        (
-            partial(DeepAREstimator, **common_estimator_hps),
-            make_dummy_datasets_with_features(cardinality=[3, 10, 42]),
-        ),
-        # Single dynamic real feature
+        # Multiple static categorical features for one of which cardinality = 1
         (
             partial(
-                DeepAREstimator,
+                DeepStateEstimator,
                 **common_estimator_hps,
+                cardinality=[3, 1, 42],
+            ),
+            make_dummy_datasets_with_features(cardinality=[3, 1, 42]),
+        ),
+        (
+            partial(
+                DeepStateEstimator,
+                **common_estimator_hps,
+                cardinality=[1],
+                use_feat_static_cat=False,
                 use_feat_dynamic_real=True,
             ),
             make_dummy_datasets_with_features(num_feat_dynamic_real=1),
@@ -76,21 +82,28 @@ common_estimator_hps = dict(
         # Multiple dynamic real feature
         (
             partial(
-                DeepAREstimator,
+                DeepStateEstimator,
                 **common_estimator_hps,
+                cardinality=[1],
+                use_feat_static_cat=False,
                 use_feat_dynamic_real=True,
             ),
             make_dummy_datasets_with_features(num_feat_dynamic_real=3),
         ),
         # Multiple dynamic real feature (ignored)
         (
-            partial(DeepAREstimator, **common_estimator_hps),
+            partial(
+                DeepStateEstimator,
+                **common_estimator_hps,
+                cardinality=[1],
+                use_feat_static_cat=False,
+            ),
             make_dummy_datasets_with_features(num_feat_dynamic_real=3),
         ),
         # Both static categorical and dynamic real features
         (
             partial(
-                DeepAREstimator,
+                DeepStateEstimator,
                 **common_estimator_hps,
                 use_feat_dynamic_real=True,
                 use_feat_static_cat=True,
@@ -100,20 +113,39 @@ common_estimator_hps = dict(
                 cardinality=[3, 10, 42], num_feat_dynamic_real=3
             ),
         ),
-        # Both static categorical and dynamic real features (ignored)
-        (
-            partial(DeepAREstimator, **common_estimator_hps),
-            make_dummy_datasets_with_features(
-                cardinality=[3, 10, 42], num_feat_dynamic_real=3
-            ),
-        ),
     ],
 )
-@pytest.mark.parametrize("dtype", [np.float32, np.float64])
-def test_deepar_smoke(estimator, datasets, dtype):
-    estimator = estimator(dtype=dtype)
+def test_deepstate_smoke(estimator, datasets):
+    # TODO: pass `dtype` below once you add `dtype` support to `DeepStateEstimator`
+    estimator = estimator()
     dataset_train, dataset_test = datasets
     predictor = estimator.train(dataset_train)
     forecasts = list(predictor.predict(dataset_test))
-    assert all([forecast.samples.dtype == dtype for forecast in forecasts])
     assert len(forecasts) == len(dataset_test)
+
+
+# This test makes sure that `DeepStateEstimator` raises exception when it is misused.
+#   * cardinality is not passed explicitly
+#   * product of cardinalities is not greater than 1 even though `use_feat_static_cat == True`
+@pytest.mark.parametrize(
+    "estimator, datasets",
+    [
+        # Static categorical feature ignored
+        (
+            partial(DeepStateEstimator, **common_estimator_hps),
+            make_dummy_datasets_with_features(cardinality=[3]),
+        ),
+        # Static categorical features are ignored by wrongly setting cardinality = [1, 1, 1]
+        (
+            partial(
+                DeepStateEstimator,
+                **common_estimator_hps,
+                cardinality=[1, 1, 1],
+            ),
+            make_dummy_datasets_with_features(cardinality=[3, 10, 42]),
+        ),
+    ],
+)
+def test_deepstate_static_feat(estimator, datasets):
+    with pytest.raises(Exception):
+        estimator()

--- a/test/model/test_deepstate_smoke.py
+++ b/test/model/test_deepstate_smoke.py
@@ -146,6 +146,6 @@ def test_deepstate_smoke(estimator, datasets):
         ),
     ],
 )
-def test_deepstate_static_feat(estimator, datasets):
+def test_deepstate_exceptions_with_feat_static_cat(estimator, datasets):
     with pytest.raises(Exception):
         estimator()


### PR DESCRIPTION
*Description of changes:*

This PR tries to make sure that `DeepStateEstimator` is not misused :) The assumption is that `DeepStateEstimator` is usually applied to dataset of multiple time series that have at least one categorical feature (e.g., an *id* for each time series). This way comparison against classical state space models that fit a separate model to each time series in the dataset makes sense.

* Added missing smoke test for `DeepStateEstimator`.
* Added test to make sure that invalid settings with respect static categorical features raise exceptions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
