### PR TITLE
Test on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 dist: xenial
 language: python
 python:
-- '3.7'
-install: true
-script: true
+  - 3.6
+  - 3.7
+  - 3.8
+cache: pip
+install:
+  - pip install mxnet==1.4.1
+  - pip install -e ".[shell]"
+script:
+  - python setup.py test
 deploy:
   provider: pypi
   user: gluonts

--- a/requirements/requirements-setup.txt
+++ b/requirements/requirements-setup.txt
@@ -1,4 +1,4 @@
 black==19.3b0
-mypy==0.630
+mypy>=0.740
 setuptools>=40.1.0
 setuptools_scm>=3.3.3


### PR DESCRIPTION
*Issue #:* #454

*Description of changes:* This adds running the tests on travis for python 3.6, 3.7 and 3.8.

It currently fails to build under 3.8 because of errors such as

```
AttributeError: type object 'pandas._libs.tslibs.conversion._TSObject' has no attribute '__reduce_cython__'
```

`mypy` was bumped to 0.740 in order to fix an issue where `typed-ast` 1.1.2 would be installed, and would build from source under python 3.8 (no wheels available) and it would fail the build.

Example of a build: https://travis-ci.org/TomzxForks/gluon-ts/builds/612933608


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
