### PR TITLE
Relax requirements constraints

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,11 +2,11 @@
 # see: https://github.com/boto/botocore/commit/e87e7a745fd972815b235a9ee685232745aa94f9
 python-dateutil==2.8.0
 
-boto3==1.*
-holidays==0.9.*
-matplotlib==3.*
-numpy==1.14.*
-pandas>=0.25.0
-pydantic==0.28.*
-tqdm>=4.23.0
-ujson>=1.35
+boto3>=1.0,<2
+holidays>=0.9,<0.10
+matplotlib>=3.0,<4
+numpy>=1.14,<2
+pandas>=0.25,<0.26
+pydantic>=0.28,<2
+tqdm>=4.23,<5
+ujson>=1.3,<2


### PR DESCRIPTION
This allows gluon-ts to be installed in a project that requires
similar dependencies. Because gluon-ts dependencies constraints
are too strict, it may prevent it from being installed side by
side with those other libraries if the constraints cannot resolve
to a common version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
