### PR TITLE
Fix use of numpy.histogram.

### DIFF
--- a/test/distribution/test_mixture.py
+++ b/test/distribution/test_mixture.py
@@ -48,7 +48,7 @@ BINS = np.linspace(-5, 5, 100)
 
 
 def histogram(samples: NPArrayLike) -> np.ndarray:
-    h, _ = np.histogram(samples, bins=BINS, normed=True)
+    h, _ = np.histogram(samples, bins=BINS, density=True)
     return h
 
 


### PR DESCRIPTION
`normed` is deprecated in favour of `density`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
