### PR TITLE
fix validation error in transformed distribution output

### DIFF
--- a/src/gluonts/distribution/transformed_distribution_output.py
+++ b/src/gluonts/distribution/transformed_distribution_output.py
@@ -133,7 +133,7 @@ class TransformedDistributionOutput(DistributionOutput):
             return trans_distr
         else:
             return TransformedDistribution(
-                trans_distr, AffineTransformation(scale=scale)
+                trans_distr, [AffineTransformation(scale=scale)]
             )
 
     @property


### PR DESCRIPTION
*Issue #, if available:*
#463 
*Description of changes:*
While testing Box Cox transformation I found that there is a validation error that needs a fi.x

I was able to train a `DeepAR` model after fixing this by specifying the distribution output as
```
distr_output=distribution.TransformedDistributionOutput(
                distribution.GaussianOutput(), [distribution.InverseBoxCoxTransformOutput(lb_obs=-1.0E-5)]
            )
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
