### PR TITLE
Bump up numpy version

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,7 +5,7 @@ python-dateutil==2.8.0
 boto3~=1.0
 holidays>=0.9,<0.10
 matplotlib~=3.0
-numpy~=1.14
+numpy~=1.16
 pandas>=0.25,<0.26
 pydantic~=1.1
 tqdm~=4.23


### PR DESCRIPTION
*Issue #, if available:*
Related to #470 . Bumping up numpy because: 

1. Users ask for it. 
2. We will need the numpy `take_along_axis` operator for the marginal CDF transformation of the Gaussian Copula model that comes in numpy version `1.16)

*Description of changes:*
Bumping up numpy version. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
