### PR TITLE
Added strategies for timezone information.

### DIFF
--- a/src/gluonts/dataset/common.py
+++ b/src/gluonts/dataset/common.py
@@ -316,7 +316,7 @@ class ProcessStartField(pydantic.BaseModel):
                     "Timezone information is not supported, "
                     f'but provided in the "{self.name}" field.'
                 )
-            elif tz_strategy == TimeZoneStrategy.utc:
+            elif self.tz_strategy == TimeZoneStrategy.utc:
                 # align timestamp to utc timezone
                 timestamp = timestamp.tz_convert("UTC")
 

--- a/src/gluonts/dataset/common.py
+++ b/src/gluonts/dataset/common.py
@@ -27,7 +27,7 @@ from typing import (
     Optional,
     Sized,
     cast,
-    Union
+    Union,
 )
 
 # Third-party imports
@@ -294,6 +294,7 @@ class ProcessStartField(pydantic.BaseModel):
     freq
         Frequency to use. This must be a valid Pandas frequency string.
     """
+
     class Config:
         arbitrary_types_allowed = True
 
@@ -312,7 +313,7 @@ class ProcessStartField(pydantic.BaseModel):
         if timestamp.tz is not None:
             if self.tz_strategy == TimeZoneStrategy.error:
                 raise GluonTSDataError(
-                    'Timezone information is not supported, '
+                    "Timezone information is not supported, "
                     f'but provided in the "{self.name}" field.'
                 )
             elif tz_strategy == TimeZoneStrategy.utc:


### PR DESCRIPTION
Currently, we throw an error if we encounter tz-information in a start-field.

The idea is to have different strategies dealing with such time-information:

* error -- current behaviour
* utc -- get time in UTC, e.g. if time zone is eastern time, we add 5 hours to the time and then remove the tz information
* ignore -- removes the timezone information

Maybe we could use `global` for `utc` and `local` for `ignore` instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
