### PR TITLE
Added operator to allow for easier chaining of transformations.

### DIFF
--- a/src/gluonts/transform/_base.py
+++ b/src/gluonts/transform/_base.py
@@ -41,6 +41,9 @@ class Transformation(metaclass=abc.ABCMeta):
     def chain(self, other: "Transformation") -> "Chain":
         return Chain(self, other)
 
+    def __add__(self, other: "Transformation") -> "Chain":
+        return self.chain(other)
+
 
 class Chain(Transformation):
     """


### PR DESCRIPTION
Makes it easier to use multiple transformations.

```python
chain = SetField("foo", 42) + SetField("bar", 99)
```

We could think about using a different operator than `+`, but `+` is probably most fitting.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
