### PR TITLE
Made constant_dataset prediction length consistent

### DIFF
--- a/src/gluonts/dataset/artificial/_base.py
+++ b/src/gluonts/dataset/artificial/_base.py
@@ -842,7 +842,7 @@ def constant_dataset() -> Tuple[DatasetInfo, Dataset, Dataset]:
     info = DatasetInfo(
         name="constant_dataset",
         metadata=metadata,
-        prediction_length=2,
+        prediction_length=6,
         train_statistics=calculate_dataset_statistics(train_ds),
         test_statistics=calculate_dataset_statistics(test_ds),
     )


### PR DESCRIPTION
perhaps it doesn't matter but since the test_ds has target length of 30 it might be more consistent to make the prediction length match up?

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
