### PR TITLE
add poisson distribution

### DIFF
--- a/src/gluonts/distribution/__init__.py
+++ b/src/gluonts/distribution/__init__.py
@@ -49,6 +49,7 @@ from .transformed_distribution_output import TransformedDistributionOutput
 from .uniform import Uniform, UniformOutput
 
 from .gamma import Gamma, GammaOutput
+from .poisson import Poisson, PoissonOutput
 
 __all__ = [
     "Distribution",
@@ -77,6 +78,8 @@ __all__ = [
     "BinnedOutput",
     "PiecewiseLinear",
     "PiecewiseLinearOutput",
+    "Poisson",
+    "PoissonOutput",
     "TransformedPiecewiseLinear",
     "TransformedDistribution",
     "TransformedDistributionOutput",

--- a/src/gluonts/distribution/poisson.py
+++ b/src/gluonts/distribution/poisson.py
@@ -1,0 +1,115 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# Standard library imports
+from typing import Dict, Optional, Tuple, List
+
+# Third-party imports
+import numpy as np
+
+# First-party imports
+from gluonts.model.common import Tensor
+from gluonts.core.component import validated
+
+# Relative imports
+from .distribution import Distribution, _sample_multiple, getF, softplus
+from .distribution_output import DistributionOutput
+
+
+class Poisson(Distribution):
+    r"""
+    Poisson distribution, i.e. the distribution of the number of
+    successes in a specified region.
+
+    Parameters
+    ----------
+    rate
+        Tensor containing the means, of shape `(*batch_shape, *event_shape)`.
+    F
+    """
+
+    is_reparameterizable = False
+
+    @validated()
+    def __init__(self, rate: Tensor, F=None) -> None:
+        self.rate = rate
+        self.F = F if F else getF(rate)
+
+    @property
+    def batch_shape(self) -> Tuple:
+        return self.rate.shape
+
+    @property
+    def event_shape(self) -> Tuple:
+        return ()
+
+    @property
+    def event_dim(self) -> int:
+        return 0
+
+    def log_prob(self, x: Tensor) -> Tensor:
+        F = self.F
+        ll = x * F.log(self.rate) - F.gammaln(x + 1.0) - self.rate
+        return ll
+
+    @property
+    def mean(self) -> Tensor:
+        return self.rate
+
+    @property
+    def stddev(self) -> Tensor:
+        return self.F.sqrt(self.rate)
+
+    def sample(
+        self, num_samples: Optional[int] = None, dtype=np.float32
+    ) -> Tensor:
+        def s(rate: Tensor) -> Tensor:
+            return self.F.random.poisson(lam=rate, dtype=dtype)
+
+        return _sample_multiple(s, rate=self.rate, num_samples=num_samples)
+
+    @property
+    def args(self) -> List:
+        return [self.rate]
+
+
+class PoissonOutput(DistributionOutput):
+    args_dim: Dict[str, int] = {"rate": 1}
+    distr_cls: type = Poisson
+
+    @classmethod
+    def domain_map(cls, F, rate):
+        rate = softplus(F, rate) + 1e-8
+        return rate.squeeze(axis=-1)
+
+    # Overwrites the parent class method.
+    # We cannot scale using the affine transformation since Poisson should return integers.
+    # Instead we scale the parameters.
+    def distribution(
+        self,
+        distr_args,
+        loc: Optional[Tensor] = None,
+        scale: Optional[Tensor] = None,
+    ) -> Poisson:
+        rate = distr_args
+        assert loc is None
+        if scale is None:
+            return Poisson(rate)
+        else:
+            F = getF(rate)
+            rate = F.broadcast_mul(rate, scale)
+            return Poisson(rate, F)
+
+    @property
+    def event_shape(self) -> Tuple:
+        return ()

--- a/test/distribution/test_distribution_methods.py
+++ b/test/distribution/test_distribution_methods.py
@@ -27,6 +27,7 @@ from gluonts.distribution import (
     Beta,
     MultivariateGaussian,
     PiecewiseLinear,
+    Poisson,
     Binned,
     TransformedDistribution,
 )
@@ -83,6 +84,7 @@ test_cases = [
             ).repeat(axis=0, repeats=2),
         },
     ),
+    (Poisson, {"rate": mx.nd.array([1000.0, 1.0])}),
 ]
 
 test_output = {
@@ -126,6 +128,11 @@ test_output = {
         "stddev": mx.nd.array([1.377416, 1.377416]),
         "variance": mx.nd.array([1.8972749, 1.8972749]),
     },
+    "Poisson": {
+        "mean": mx.nd.array([1000.0, 1.0]),
+        "stddev": mx.nd.array([31.622776, 1.0]),
+        "variance": mx.nd.array([1000.0, 1.0]),
+    },
 }
 
 # TODO: implement stddev methods for MultivariateGaussian and LowrankMultivariateGaussian
@@ -137,6 +144,7 @@ DISTRIBUTIONS = [
     NegativeBinomial,
     Uniform,
     Binned,
+    Poisson,
 ]
 
 

--- a/test/distribution/test_distribution_output_shapes.py
+++ b/test/distribution/test_distribution_output_shapes.py
@@ -28,6 +28,7 @@ from gluonts.distribution import (
     LowrankMultivariateGaussianOutput,
     NegativeBinomialOutput,
     PiecewiseLinearOutput,
+    PoissonOutput,
     StudentTOutput,
     UniformOutput,
     DirichletOutput,
@@ -140,6 +141,14 @@ from gluonts.distribution import (
             [None, mx.nd.ones(shape=(3, 4, 5))],
             (3, 4),
             (5,),
+        ),
+        (
+            PoissonOutput(),
+            mx.nd.random.normal(shape=(3, 4, 5, 6)),
+            [None],
+            [None, mx.nd.ones(shape=(3, 4, 5))],
+            (3, 4, 5),
+            (),
         ),
     ],
 )

--- a/test/distribution/test_distribution_sampling.py
+++ b/test/distribution/test_distribution_sampling.py
@@ -27,6 +27,7 @@ from gluonts.distribution import (
     Gamma,
     Beta,
     MultivariateGaussian,
+    Poisson,
     PiecewiseLinear,
     Binned,
     TransformedDistribution,
@@ -88,6 +89,7 @@ test_cases = [
             ).repeat(axis=0, repeats=2),
         },
     ),
+    (Poisson, {"rate": mx.nd.array([1000.0, 0])}),
 ]
 
 

--- a/test/distribution/test_distribution_shapes.py
+++ b/test/distribution/test_distribution_shapes.py
@@ -27,6 +27,7 @@ from gluonts.distribution import (
     MultivariateGaussian,
     NegativeBinomial,
     PiecewiseLinear,
+    Poisson,
     StudentT,
     Uniform,
     TransformedDistribution,
@@ -104,6 +105,7 @@ from gluonts.distribution.box_cox_transform import BoxCoxTransform
             (3, 4, 5),
             (),
         ),
+        (Poisson(rate=mx.nd.ones(shape=(3, 4, 5))), (3, 4, 5), ()),
         (
             Uniform(
                 low=-mx.nd.ones(shape=(3, 4, 5)),


### PR DESCRIPTION
*Issue #, if available:* fixes #529

*Description of changes:*
Implement poisson distribution based on scipy.stats.poisson, Please correct me if there is any mistakes!
Also I can't seem to find a way to set all 0 to 1 in the x tensor for log_prob method, as the x seem to change to symbol object as training went on.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
