### PR TITLE
Fix instance splitter issue with short time series

### DIFF
--- a/src/gluonts/transform/sampler.py
+++ b/src/gluonts/transform/sampler.py
@@ -104,6 +104,9 @@ class ExpectedNumInstanceSampler(InstanceSampler):
         self.lookup = np.arange(2 ** 13)
 
     def __call__(self, ts: np.ndarray, a: int, b: int) -> np.ndarray:
+        assert (
+            a <= b
+        ), "First index must be less than or equal to the last index."
         while ts.shape[-1] >= len(self.lookup):
             self.lookup = np.arange(2 * len(self.lookup))
 

--- a/src/gluonts/transform/split.py
+++ b/src/gluonts/transform/split.py
@@ -179,7 +179,7 @@ class InstanceSplitter(FlatMapTransformation):
                 else self.train_sampler(target, *sampling_bounds)
             )
         else:
-            assert self.pick_incomplete or len_target >= minimum_length
+            assert self.pick_incomplete or len_target >= self.past_length
             sampled_indices = np.array([len_target], dtype=int)
         for i in sampled_indices:
             pad_length = max(self.past_length - i, 0)

--- a/src/gluonts/transform/split.py
+++ b/src/gluonts/transform/split.py
@@ -156,33 +156,37 @@ class InstanceSplitter(FlatMapTransformation):
 
         len_target = target.shape[-1]
 
+        minimum_length = (
+            self.future_length
+            if self.pick_incomplete
+            else self.past_length + self.future_length
+        )
+
         if is_train:
-            if self.pick_incomplete:
-                if len_target < self.future_length:
-                    # We currently cannot handle time series that are
-                    # shorter than the prediction length during training,
-                    # so we just skip these. If we want to include them we
-                    # would need to pad and to mask the loss.
-                    sampling_indices = np.array([], dtype=int)
-                else:
-                    sampling_indices = self.train_sampler(
-                        target, 0, len_target - self.future_length
-                    )
-            else:
-                if len_target < self.past_length + self.future_length:
-                    sampling_indices = np.array([], dtype=int)
-                else:
-                    sampling_indices = self.train_sampler(
-                        target,
-                        self.past_length,
-                        len_target - self.future_length,
-                    )
+            sampling_bounds = (
+                (0, len_target - self.future_length)
+                if self.pick_incomplete
+                else (self.past_length, len_target - self.future_length)
+            )
+
+            # We currently cannot handle time series that are
+            # too short during training, so we just skip these.
+            # If we want to include them we would need to pad and to
+            # mask the loss.
+            sampled_indices = (
+                np.array([], dtype=int)
+                if len_target < minimum_length
+                else self.train_sampler(target, *sampling_bounds)
+            )
         else:
-            sampling_indices = np.array([len_target], dtype=int)
-        for i in sampling_indices:
+            assert self.pick_incomplete or len_target >= minimum_length
+            sampled_indices = np.array([len_target], dtype=int)
+        for i in sampled_indices:
             pad_length = max(self.past_length - i, 0)
             if not self.pick_incomplete:
-                assert pad_length == 0
+                assert (
+                    pad_length == 0
+                ), f"pad_length should be zero, got {pad_length}"
             d = data.copy()
             for ts_field in slice_cols:
                 if i > self.past_length:

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -209,11 +209,7 @@ def test_InstanceSplitter(
         "some_other_col": "ABC",
     }
 
-    if (
-        not is_train
-        and not pick_incomplete
-        and len(target) < train_length + pred_length
-    ):
+    if not is_train and not pick_incomplete and len(target) < train_length:
         with pytest.raises(AssertionError):
             out = list(t.flatmap_transform(data, is_train=is_train))
         return

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -106,7 +106,7 @@ def test_align_timestamp():
 @pytest.mark.parametrize("is_train", TEST_VALUES["is_train"])
 @pytest.mark.parametrize("target", TEST_VALUES["target"])
 @pytest.mark.parametrize("start", TEST_VALUES["start"])
-def test_AddTimeFeatures(start, target, is_train):
+def test_AddTimeFeatures(start, target, is_train: bool):
     pred_length = 13
     t = transform.AddTimeFeatures(
         start_field=FieldName.START,
@@ -133,7 +133,7 @@ def test_AddTimeFeatures(start, target, is_train):
 @pytest.mark.parametrize("is_train", TEST_VALUES["is_train"])
 @pytest.mark.parametrize("target", TEST_VALUES["target"])
 @pytest.mark.parametrize("start", TEST_VALUES["start"])
-def test_AddTimeFeatures_empty_time_features(start, target, is_train):
+def test_AddTimeFeatures_empty_time_features(start, target, is_train: bool):
     pred_length = 13
     t = transform.AddTimeFeatures(
         start_field=FieldName.START,
@@ -153,7 +153,7 @@ def test_AddTimeFeatures_empty_time_features(start, target, is_train):
 @pytest.mark.parametrize("is_train", TEST_VALUES["is_train"])
 @pytest.mark.parametrize("target", TEST_VALUES["target"])
 @pytest.mark.parametrize("start", TEST_VALUES["start"])
-def test_AddAgeFeatures(start, target, is_train):
+def test_AddAgeFeatures(start, target, is_train: bool):
     pred_length = 13
     t = transform.AddAgeFeature(
         pred_length=pred_length,
@@ -176,10 +176,15 @@ def test_AddAgeFeatures(start, target, is_train):
     )
 
 
+@pytest.mark.parametrize(
+    "pick_incomplete", TEST_VALUES["allow_target_padding"]
+)
 @pytest.mark.parametrize("is_train", TEST_VALUES["is_train"])
 @pytest.mark.parametrize("target", TEST_VALUES["target"])
 @pytest.mark.parametrize("start", TEST_VALUES["start"])
-def test_InstanceSplitter(start, target, is_train):
+def test_InstanceSplitter(
+    start, target, is_train: bool, pick_incomplete: bool
+):
     train_length = 100
     pred_length = 13
     t = transform.InstanceSplitter(
@@ -191,7 +196,7 @@ def test_InstanceSplitter(start, target, is_train):
         past_length=train_length,
         future_length=pred_length,
         time_series_fields=["some_time_feature"],
-        pick_incomplete=True,
+        pick_incomplete=pick_incomplete,
     )
 
     assert_serializable(t)
@@ -204,10 +209,25 @@ def test_InstanceSplitter(start, target, is_train):
         "some_other_col": "ABC",
     }
 
-    out = list(t.flatmap_transform(data, is_train=is_train))
+    if (
+        not is_train
+        and not pick_incomplete
+        and len(target) < train_length + pred_length
+    ):
+        with pytest.raises(AssertionError):
+            out = list(t.flatmap_transform(data, is_train=is_train))
+        return
+    else:
+        out = list(t.flatmap_transform(data, is_train=is_train))
 
     if is_train:
-        assert len(out) == max(0, len(target) - pred_length + 1)
+        assert len(out) == max(
+            0,
+            len(target)
+            - pred_length
+            + 1
+            - (0 if pick_incomplete else train_length),
+        )
     else:
         assert len(out) == 1
 
@@ -241,7 +261,11 @@ def test_InstanceSplitter(start, target, is_train):
     "allow_target_padding", TEST_VALUES["allow_target_padding"]
 )
 def test_CanonicalInstanceSplitter(
-    start, target, is_train, use_prediction_features, allow_target_padding
+    start,
+    target,
+    is_train: bool,
+    use_prediction_features: bool,
+    allow_target_padding: bool,
 ):
     train_length = 100
     pred_length = 13
@@ -351,10 +375,10 @@ def test_Transformation():
 def test_multi_dim_transformation(is_train):
     train_length = 10
 
-    first_dim = np.arange(1, 11, 1).tolist()
+    first_dim: list = list(np.arange(1, 11, 1))
     first_dim[-1] = "NaN"
 
-    second_dim = np.arange(11, 21, 1).tolist()
+    second_dim: list = list(np.arange(11, 21, 1))
     second_dim[0] = "NaN"
 
     ds = gluonts.dataset.common.ListDataset(


### PR DESCRIPTION
*Description of changes:* Some checks are added in the `InstanceSplitter` class for the case where `pick_incomplete=False`. This would otherwise cause problems downstream, when the sampler would to sample from an interval that has inverted bounds.

Further checks and typing cleanup are added.

Opening for feedback, trying to include a small test for this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
