### PR TITLE
Fix #535: quantile of Binned distribution

### DIFF
--- a/src/gluonts/distribution/binned.py
+++ b/src/gluonts/distribution/binned.py
@@ -129,9 +129,10 @@ class Binned(Distribution):
         F = self.F
 
         probs = self.bin_probs.swapaxes(0, 1)  # (num_bins, batch)
-        zeros_batch_size = F.slice_axis(probs, axis=0, begin=0, end=1).squeeze(
-            axis=0
-        )  # (batch_size,)
+        # (batch_size,)
+        zeros_batch_size = F.zeros_like(
+            F.slice_axis(probs, axis=0, begin=0, end=1).squeeze(axis=0)
+        )
 
         level = level.expand_dims(axis=0)
         # cdf shape (batch_size, levels)

--- a/test/distribution/test_distribution_sampling.py
+++ b/test/distribution/test_distribution_sampling.py
@@ -81,7 +81,7 @@ test_cases = [
         Binned,
         {
             "bin_probs": mx.nd.array(
-                [[0, 0.3, 0.1, 0.05, 0.2, 0.1, 0.25]]
+                [[0.1, 0.2, 0.1, 0.05, 0.2, 0.1, 0.25]]
             ).repeat(axis=0, repeats=2),
             "bin_centers": mx.nd.array(
                 [[-5, -3, -1.2, -0.5, 0, 0.1, 0.2]]


### PR DESCRIPTION
*Issue #535:*

*Description of changes:*

Looks like `zeros_batch_size` is also mainly to get the shape right. It is used [here](https://github.com/awslabs/gluon-ts/blob/a9cde7bf92178b4cf8010a4c8600940b595f2ae3/src/gluonts/distribution/binned.py#L147) just as a placeholder. Made this zero and `zeros_cdf` also becomes zero with that.

Updated tests as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
