### PR TITLE
Add `loc` argument to distribution output classes

### DIFF
--- a/src/gluonts/distribution/bijection.py
+++ b/src/gluonts/distribution/bijection.py
@@ -198,9 +198,9 @@ class AffineTransformation(Bijection):
     Parameters
     ----------
     loc
-        Translation parameter.
+        Translation parameter. If unspecified or `None`, this will be zero.
     scale
-        Scaling parameter.
+        Scaling parameter. If unspecified or `None`, this will be one.
     """
 
     @validated()

--- a/src/gluonts/distribution/bijection.py
+++ b/src/gluonts/distribution/bijection.py
@@ -229,8 +229,8 @@ class AffineTransformation(Bijection):
     def log_abs_det_jac(self, x: Tensor, y: Tensor) -> Tensor:
         if self.scale is not None:
             return self.scale.broadcast_like(x).abs().log()
-        else:
-            raise RuntimeError("scale is of type None in log_abs_det_jac")
+        F = getF(x)
+        return F.zeros_like(x)
 
     @property
     def sign(self):

--- a/src/gluonts/distribution/binned.py
+++ b/src/gluonts/distribution/binned.py
@@ -219,6 +219,7 @@ class BinnedOutput(DistributionOutput):
 
     @validated()
     def __init__(self, bin_centers: mx.nd.NDArray) -> None:
+        super().__init__(self)
         self.bin_centers = bin_centers
         self.num_bins = self.bin_centers.shape[0]
         assert len(self.bin_centers.shape) == 1
@@ -226,7 +227,7 @@ class BinnedOutput(DistributionOutput):
     def get_args_proj(self, *args, **kwargs) -> gluon.nn.HybridBlock:
         return BinnedArgs(self.num_bins, self.bin_centers)
 
-    def distribution(self, args, scale=None) -> Binned:
+    def distribution(self, args, loc=None, scale=None) -> Binned:
         probs = args[0]
         bin_centers = args[1]
         F = getF(probs)
@@ -236,6 +237,10 @@ class BinnedOutput(DistributionOutput):
         if scale is not None:
             bin_centers = F.broadcast_mul(
                 bin_centers, scale.expand_dims(axis=-1)
+            )
+        if loc is not None:
+            bin_centers = F.broadcast_add(
+                bin_centers, loc.expand_dims(axis=-1)
             )
 
         return Binned(probs, bin_centers)

--- a/src/gluonts/distribution/dirichlet.py
+++ b/src/gluonts/distribution/dirichlet.py
@@ -136,14 +136,15 @@ class Dirichlet(Distribution):
 class DirichletOutput(DistributionOutput):
     @validated()
     def __init__(self, dim: int) -> None:
+        super().__init__(self)
         assert dim > 1, "Dimension should be larger than one."
         self.args_dim = {"alpha": dim}
         self.distr_cls = Dirichlet
         self.dim = dim
         self.mask = None
 
-    def distribution(self, distr_args, scale=None, **kwargs) -> Distribution:
-        # todo deal with scaling
+    def distribution(self, distr_args, loc=None, scale=None) -> Distribution:
+        assert loc is None and scale is None
         distr = Dirichlet(distr_args)
         return distr
 

--- a/src/gluonts/distribution/dirichlet_multinomial.py
+++ b/src/gluonts/distribution/dirichlet_multinomial.py
@@ -171,6 +171,7 @@ class DirichletMultinomial(Distribution):
 class DirichletMultinomialOutput(DistributionOutput):
     @validated()
     def __init__(self, dim: int, n_trials: int) -> None:
+        super().__init__(self)
         assert dim > 1, "Dimension must be larger than one."
         self.dim = dim
         self.n_trials = n_trials
@@ -179,8 +180,8 @@ class DirichletMultinomialOutput(DistributionOutput):
         self.dim = dim
         self.mask = None
 
-    def distribution(self, distr_args, scale=None, **kwargs) -> Distribution:
-        # todo deal with scaling
+    def distribution(self, distr_args, loc=None, scale=None) -> Distribution:
+        assert loc is None and scale is None
         distr = DirichletMultinomial(self.dim, self.n_trials, distr_args)
         return distr
 

--- a/src/gluonts/distribution/distribution_output.py
+++ b/src/gluonts/distribution/distribution_output.py
@@ -117,7 +117,10 @@ class DistributionOutput(Output):
         pass
 
     def distribution(
-        self, distr_args, scale: Optional[Tensor] = None
+        self,
+        distr_args,
+        loc: Optional[Tensor] = None,
+        scale: Optional[Tensor] = None,
     ) -> Distribution:
         r"""
         Construct the associated distribution, given the collection of
@@ -127,16 +130,19 @@ class DistributionOutput(Output):
         ----------
         distr_args
             Constructor arguments for the underlying Distribution type.
+        loc
+            Optional tensor, of the same shape as the
+            batch_shape+event_shape of the resulting distribution.
         scale
             Optional tensor, of the same shape as the
             batch_shape+event_shape of the resulting distribution.
         """
-        if scale is None:
+        if loc is None and scale is None:
             return self.distr_cls(*distr_args)
         else:
             distr = self.distr_cls(*distr_args)
             return TransformedDistribution(
-                distr, [AffineTransformation(scale=scale)]
+                distr, [AffineTransformation(loc=loc, scale=scale)]
             )
 
     @property

--- a/src/gluonts/distribution/lowrank_gp.py
+++ b/src/gluonts/distribution/lowrank_gp.py
@@ -129,6 +129,7 @@ class LowrankGPOutput(DistributionOutput):
         mu_ratio: float = 1.0,
         dropout_rate: float = 0.0,
     ) -> None:
+        super().__init__(self)
         self.dist_cls = LowrankMultivariateGaussian
         self.dim = dim
         self.rank = rank
@@ -148,13 +149,13 @@ class LowrankGPOutput(DistributionOutput):
             prefix=prefix,
         )
 
-    def distribution(self, distr_args, scale=None, dim=None):
+    def distribution(self, distr_args, loc=None, scale=None, dim=None):
         dist = LowrankMultivariateGaussian(dim, self.rank, *distr_args)
-        if scale is None:
+        if loc is None and scale is None:
             return dist
         else:
             return TransformedDistribution(
-                dist, [bijection.AffineTransformation(scale=scale)]
+                dist, [bijection.AffineTransformation(loc=loc, scale=scale)]
             )
 
     @property

--- a/src/gluonts/distribution/lowrank_multivariate_gaussian.py
+++ b/src/gluonts/distribution/lowrank_multivariate_gaussian.py
@@ -311,6 +311,7 @@ class LowrankMultivariateGaussianOutput(DistributionOutput):
         sigma_init: float = 1.0,
         sigma_minimum: float = sigma_minimum,
     ) -> None:
+        super().__init__(self)
         self.distr_cls = LowrankMultivariateGaussian
         self.dim = dim
         self.rank = rank
@@ -326,13 +327,15 @@ class LowrankMultivariateGaussianOutput(DistributionOutput):
             prefix=prefix,
         )
 
-    def distribution(self, distr_args, scale=None, **kwargs) -> Distribution:
+    def distribution(
+        self, distr_args, loc=None, scale=None, **kwargs
+    ) -> Distribution:
         distr = LowrankMultivariateGaussian(self.dim, self.rank, *distr_args)
-        if scale is None:
+        if loc is None and scale is None:
             return distr
         else:
             return TransformedDistribution(
-                distr, [bijection.AffineTransformation(scale=scale)]
+                distr, [bijection.AffineTransformation(loc=loc, scale=scale)]
             )
 
     def domain_map(self, F, mu_vector, D_vector, W_vector):

--- a/src/gluonts/distribution/mixture.py
+++ b/src/gluonts/distribution/mixture.py
@@ -179,14 +179,18 @@ class MixtureDistributionOutput(DistributionOutput):
 
     # Overwrites the parent class method.
     def distribution(
-        self, distr_args, scale: Optional[Tensor] = None, **kwargs
+        self,
+        distr_args,
+        loc: Optional[Tensor] = None,
+        scale: Optional[Tensor] = None,
+        **kwargs,
     ) -> MixtureDistribution:
         mixture_probs = distr_args[0]
         component_args = distr_args[1:]
         return MixtureDistribution(
             mixture_probs=mixture_probs,
             components=[
-                do.distribution(args, scale=scale)
+                do.distribution(args, loc=loc, scale=scale)
                 for do, args in zip(self.distr_outputs, component_args)
             ],
         )

--- a/src/gluonts/distribution/neg_binomial.py
+++ b/src/gluonts/distribution/neg_binomial.py
@@ -118,7 +118,13 @@ class NegativeBinomialOutput(DistributionOutput):
     # Overwrites the parent class method.
     # We cannot scale using the affine transformation since negative binomial should return integers.
     # Instead we scale the parameters.
-    def distribution(self, distr_args, scale=None) -> NegativeBinomial:
+    def distribution(
+        self,
+        distr_args,
+        loc: Optional[Tensor] = None,
+        scale: Optional[Tensor] = None,
+    ) -> NegativeBinomial:
+        assert loc is None
         mu, alpha = distr_args
         if scale is None:
             return NegativeBinomial(mu, alpha)

--- a/src/gluonts/distribution/transformed_distribution_output.py
+++ b/src/gluonts/distribution/transformed_distribution_output.py
@@ -115,7 +115,10 @@ class TransformedDistributionOutput(DistributionOutput):
         return sum(tuple([distr_params] + transforms_params), ())
 
     def distribution(
-        self, distr_args, scale: Optional[Tensor] = None, **kwargs
+        self,
+        distr_args,
+        loc: Optional[Tensor] = None,
+        scale: Optional[Tensor] = None,
     ) -> Distribution:
         distr_args, transforms_args = self._split_args(distr_args)
         distr = self.base_distr_output.distr_cls(*distr_args)
@@ -129,11 +132,11 @@ class TransformedDistributionOutput(DistributionOutput):
         trans_distr = TransformedDistribution(distr, transforms)
 
         # Apply scaling as well at the end if scale is not None!
-        if scale is None:
+        if loc is None and scale is None:
             return trans_distr
         else:
             return TransformedDistribution(
-                trans_distr, [AffineTransformation(scale=scale)]
+                trans_distr, [AffineTransformation(loc=loc, scale=scale)]
             )
 
     @property


### PR DESCRIPTION
*Description of changes:* This PR adds the `loc` argument to the `distribution` method of `DistributionOutput` classes. Assertions are added in case the specific distributions don't support either `loc` or `scale`. A bug in the `TransformedPiecewiseLinear` distribution was also fixed: this went unnoticed since it only appears when the base distribution is composed with more than one affine transformation, which never happens when using `PiecewiseLinearOutput`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
