### PR TITLE
Representing the Binned distribution directly through log probabilities

### DIFF
--- a/src/gluonts/distribution/binned.py
+++ b/src/gluonts/distribution/binned.py
@@ -35,8 +35,9 @@ class Binned(Distribution):
 
     Parameters
     ----------
-    bin_probs
-        Tensor containing the bin probabilities, of shape `(*batch_shape, num_bins)`.
+    bin_log_probs
+        Tensor containing log probabilities of the bins, of shape
+        `(*batch_shape, num_bins)`.
     bin_centers
         Tensor containing the bin centers, of shape `(*batch_shape, num_bins)`.
     F
@@ -45,10 +46,13 @@ class Binned(Distribution):
     is_reparameterizable = False
 
     @validated()
-    def __init__(self, bin_probs: Tensor, bin_centers: Tensor, F=None) -> None:
+    def __init__(
+        self, bin_log_probs: Tensor, bin_centers: Tensor, F=None
+    ) -> None:
         self.bin_centers = bin_centers
-        self.bin_probs = bin_probs
-        self.F = F if F else getF(bin_probs)
+        self.bin_log_probs = bin_log_probs
+        self._bin_probs = None
+        self.F = F if F else getF(bin_log_probs)
 
         self.bin_edges = Binned._compute_edges(self.F, bin_centers)
 
@@ -87,8 +91,14 @@ class Binned(Distribution):
         return F.concat(low, means, high, dim=-1)
 
     @property
+    def bin_probs(self):
+        if self._bin_probs is None:
+            self._bin_probs = self.bin_log_probs.exp()
+        return self._bin_probs
+
+    @property
     def batch_shape(self) -> Tuple:
-        return self.bin_probs.shape[:-1]
+        return self.bin_log_probs.shape[:-1]
 
     @property
     def event_shape(self) -> Tuple:
@@ -104,8 +114,8 @@ class Binned(Distribution):
 
     @property
     def stddev(self):
-        Ex2 = (self.bin_probs * self.bin_centers.square()).sum(axis=-1)
-        return (Ex2 - self.mean.square()).sqrt()
+        ex2 = (self.bin_probs * self.bin_centers.square()).sum(axis=-1)
+        return (ex2 - self.mean.square()).sqrt()
 
     def log_prob(self, x):
         F = self.F
@@ -116,7 +126,7 @@ class Binned(Distribution):
         mask = F.broadcast_lesser_equal(left_edges, x) * F.broadcast_lesser(
             x, right_edges
         )
-        return F.broadcast_mul(self.bin_probs.log(), mask).sum(axis=-1)
+        return F.broadcast_mul(self.bin_log_probs, mask).sum(axis=-1)
 
     def cdf(self, x: Tensor) -> Tensor:
         F = self.F
@@ -178,7 +188,7 @@ class Binned(Distribution):
 
     @property
     def args(self) -> List:
-        return [self.bin_probs, self.bin_centers]
+        return [self.bin_log_probs, self.bin_centers]
 
 
 class BinnedArgs(gluon.HybridBlock):
@@ -203,7 +213,7 @@ class BinnedArgs(gluon.HybridBlock):
                     weight_initializer=mx.init.Xavier(),
                 )
             )
-            self.proj.add(gluon.nn.HybridLambda("softmax"))
+            self.proj.add(gluon.nn.HybridLambda("log_softmax"))
 
     def hybrid_forward(
         self, F, x: Tensor, bin_centers: Tensor

--- a/test/distribution/test_distribution_methods.py
+++ b/test/distribution/test_distribution_methods.py
@@ -76,9 +76,11 @@ test_cases = [
     (
         Binned,
         {
-            "bin_probs": mx.nd.array(
-                [[0, 0.3, 0.1, 0.05, 0.2, 0.1, 0.25]]
-            ).repeat(axis=0, repeats=2),
+            "bin_log_probs": mx.nd.array(
+                [[1e-300, 0.3, 0.1, 0.05, 0.2, 0.1, 0.25]]
+            )
+            .log()
+            .repeat(axis=0, repeats=2),
             "bin_centers": mx.nd.array(
                 [[-5, -3, -1.2, -0.5, 0, 0.1, 0.2]]
             ).repeat(axis=0, repeats=2),

--- a/test/distribution/test_distribution_sampling.py
+++ b/test/distribution/test_distribution_sampling.py
@@ -81,9 +81,11 @@ test_cases = [
     (
         Binned,
         {
-            "bin_probs": mx.nd.array(
+            "bin_log_probs": mx.nd.array(
                 [[0.1, 0.2, 0.1, 0.05, 0.2, 0.1, 0.25]]
-            ).repeat(axis=0, repeats=2),
+            )
+            .log()
+            .repeat(axis=0, repeats=2),
             "bin_centers": mx.nd.array(
                 [[-5, -3, -1.2, -0.5, 0, 0.1, 0.2]]
             ).repeat(axis=0, repeats=2),


### PR DESCRIPTION
Co-authored with @canerturkmen 

*Description of changes:* The Binned distribution is not too robust in its `log_prob` method. The reason is the internal representation being based on the probabilities of the bins, rather than directly the log probabilities. This can be seen with the following MWE:

```python
import mxnet as mx

from gluonts.distribution import BinnedOutput

distr_out = BinnedOutput(bin_centers=mx.nd.array([1.0, 2.0, 3.0, 4.0, 5.0]))
args_proj = distr_out.get_args_proj()
args_proj.initialize()

network_out = 50*mx.nd.ones(shape=(10,))

args = args_proj(network_out)

distr = distr_out.distribution(args=args)

print(distr.log_prob(mx.nd.array([0.5, 1.5, 2.5, 3.5, 4.5, 5.5])))
```

Output **before** the fix:

```python
[nan nan nan nan nan nan]
<NDArray 6 @cpu(0)>
```

Output **after** the fix:

```python
[   0.       -113.20108   -54.23133   -65.08172   -16.988205  -16.988205]
<NDArray 6 @cpu(0)>
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
