### PR TITLE
Remove Dataset class in favor of type alias

### DIFF
--- a/src/gluonts/dataset/common.py
+++ b/src/gluonts/dataset/common.py
@@ -17,6 +17,7 @@ from enum import Enum
 from functools import lru_cache
 from pathlib import Path
 from typing import (
+    cast,
     Any,
     Callable,
     Dict,
@@ -25,8 +26,6 @@ from typing import (
     List,
     NamedTuple,
     Optional,
-    Sized,
-    cast,
     Union,
 )
 
@@ -35,20 +34,17 @@ import numpy as np
 import pandas as pd
 import pydantic
 import ujson as json
-from pandas.tseries.frequencies import to_offset
 from pandas.tseries.offsets import Tick
 
 # First-party imports
 from gluonts.core.exception import GluonTSDataError
 from gluonts.dataset import jsonl, util
-from gluonts.dataset.stat import (
-    DatasetStatistics,
-    calculate_dataset_statistics,
-)
 
 # Dictionary used for data flowing through the transformations.
-# A Dataset is an iterable over such dictionaries.
 DataEntry = Dict[str, Any]
+
+# A Dataset is an iterable of DataEntry.
+Dataset = Iterable[DataEntry]
 
 
 class Timestamp(pd.Timestamp):
@@ -150,21 +146,6 @@ class MetaData(pydantic.BaseModel):
 class SourceContext(NamedTuple):
     source: str
     row: int
-
-
-class Dataset(Sized, Iterable[DataEntry]):
-    """
-    An abstract class for datasets, i.e., iterable collection of DataEntry.
-    """
-
-    def __iter__(self) -> Iterator[DataEntry]:
-        raise NotImplementedError
-
-    def __len__(self):
-        raise NotImplementedError
-
-    def calc_stats(self) -> DatasetStatistics:
-        return calculate_dataset_statistics(self)
 
 
 class Channel(pydantic.BaseModel):

--- a/src/gluonts/evaluation/backtest.py
+++ b/src/gluonts/evaluation/backtest.py
@@ -33,6 +33,7 @@ from gluonts.evaluation import Evaluator
 from gluonts.model.estimator import Estimator, GluonEstimator
 from gluonts.model.forecast import Forecast
 from gluonts.model.predictor import GluonPredictor, Predictor
+from gluonts.support.util import maybe_len
 from gluonts.transform import TransformedDataset
 
 
@@ -201,7 +202,7 @@ def backtest_metrics(
     )
 
     agg_metrics, item_metrics = evaluator(
-        ts_it, forecast_it, num_series=len(test_dataset)
+        ts_it, forecast_it, num_series=maybe_len(test_dataset)
     )
 
     # we only log aggregate metrics for now as item metrics may be very large

--- a/src/gluonts/model/trivial/mean.py
+++ b/src/gluonts/model/trivial/mean.py
@@ -112,12 +112,11 @@ class MeanEstimator(Estimator):
         training_data: Dataset,
         validation_dataset: Optional[Dataset] = None,
     ) -> ConstantPredictor:
-        contexts = np.broadcast_to(
-            array=[
+        contexts = np.array(
+            [
                 item["target"][-self.prediction_length :]
                 for item in training_data
-            ],
-            shape=(len(training_data), self.prediction_length),
+            ]
         )
 
         samples = np.broadcast_to(

--- a/src/gluonts/support/util.py
+++ b/src/gluonts/support/util.py
@@ -18,7 +18,17 @@ import signal
 import tempfile
 import time
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, cast, Union, Tuple
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    cast,
+    Union,
+    Tuple,
+    Iterable,
+)
 
 # Third-party imports
 import mxnet as mx
@@ -112,6 +122,13 @@ class HybridContext:
 
     def __exit__(self, *args):
         self.net.hybridize(active=self.original_mode, **self.kwargs)
+
+
+def maybe_len(obj) -> Optional[int]:
+    try:
+        return len(obj)
+    except NotImplementedError:
+        return None
 
 
 def copy_parameters(


### PR DESCRIPTION
*Description of changes:* This removes the `Dataset` class in favor of a type alias, allowing e.g. to just use a list with the appropriate fields as dataset.

```python
train_data = [
    "start": pd.Timestamp(...),
    "target": np.array([...])
]
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
