### PR TITLE
Fix bug in cdf method of piecewise linear distributions

### DIFF
--- a/src/gluonts/distribution/piecewise_linear.py
+++ b/src/gluonts/distribution/piecewise_linear.py
@@ -336,15 +336,7 @@ class PiecewiseLinearOutput(DistributionOutput):
     @classmethod
     def domain_map(cls, F, gamma, slopes, knot_spacings):
         # slopes of the pieces are non-negative
-        thresh = F.zeros_like(slopes) + 20.0
-        I_grt_thresh = F.broadcast_greater_equal(slopes, thresh)
-        I_sml_thresh = F.broadcast_lesser(slopes, thresh)
-        slopes_proj = (
-            I_sml_thresh
-            * F.Activation(data=(I_sml_thresh * slopes), act_type="softrelu")
-            + I_grt_thresh * slopes
-        )
-        # slopes = F.Activation(slopes, 'softrelu')
+        slopes_proj = F.Activation(data=slopes, act_type="softrelu") + 1e-4
 
         # the spacing between the knots should be in [0, 1] and sum to 1
         knot_spacings_proj = F.softmax(knot_spacings)

--- a/src/gluonts/distribution/piecewise_linear.py
+++ b/src/gluonts/distribution/piecewise_linear.py
@@ -236,7 +236,7 @@ class PiecewiseLinear(Distribution):
             / slope_l0_nz,
         )
 
-        return a_tilde
+        return F.broadcast_minimum(F.ones_like(a_tilde), a_tilde)
 
     def quantile(self, level: Tensor) -> Tensor:
         return self.quantile_internal(level, axis=0)

--- a/test/distribution/test_piecewise_linear.py
+++ b/test/distribution/test_piecewise_linear.py
@@ -136,3 +136,21 @@ def test_shapes(
         num_samples,
         *batch_shape,
     )
+
+
+def test_simple_symmetric():
+    gamma = mx.nd.array([-1.0])
+    slopes = mx.nd.array([[2.0, 2.0]])
+    knot_spacings = mx.nd.array([[0.5, 0.5]])
+
+    distr = PiecewiseLinear(
+        gamma=gamma, slopes=slopes, knot_spacings=knot_spacings
+    )
+
+    assert distr.cdf(mx.nd.array([-2.0])).asnumpy().item() == 0.0
+    assert distr.cdf(mx.nd.array([+2.0])).asnumpy().item() == 1.0
+
+    assert np.all(
+        distr.crps(mx.nd.array([-2.0])).asnumpy()
+        == distr.crps(mx.nd.array([+2.0])).asnumpy()
+    )

--- a/test/distribution/test_piecewise_linear.py
+++ b/test/distribution/test_piecewise_linear.py
@@ -150,7 +150,10 @@ def test_simple_symmetric():
     assert distr.cdf(mx.nd.array([-2.0])).asnumpy().item() == 0.0
     assert distr.cdf(mx.nd.array([+2.0])).asnumpy().item() == 1.0
 
-    assert np.all(
-        distr.crps(mx.nd.array([-2.0])).asnumpy()
-        == distr.crps(mx.nd.array([+2.0])).asnumpy()
+    expected_crps = np.array([1.0 + 2.0 / 3.0])
+
+    assert np.allclose(
+        distr.crps(mx.nd.array([-2.0])).asnumpy(), expected_crps
     )
+
+    assert np.allclose(distr.crps(mx.nd.array([2.0])).asnumpy(), expected_crps)

--- a/test/distribution/test_piecewise_linear.py
+++ b/test/distribution/test_piecewise_linear.py
@@ -17,7 +17,7 @@ import pytest
 import mxnet as mx
 import numpy as np
 
-from gluonts.distribution import PiecewiseLinear
+from gluonts.distribution import PiecewiseLinear, PiecewiseLinearOutput
 from gluonts.testutil import empirical_cdf
 from gluonts.core.serde import dump_json, load_json
 
@@ -157,3 +157,32 @@ def test_simple_symmetric():
     )
 
     assert np.allclose(distr.crps(mx.nd.array([2.0])).asnumpy(), expected_crps)
+
+
+def test_robustness():
+    distr_out = PiecewiseLinearOutput(num_pieces=10)
+    args_proj = distr_out.get_args_proj()
+    args_proj.initialize()
+
+    net_out = mx.nd.random.normal(shape=(1000, 30), scale=1e2)
+    gamma, slopes, knot_spacings = args_proj(net_out)
+    distr = distr_out.distribution((gamma, slopes, knot_spacings))
+
+    # compute the 1-quantile (the 0-quantile is gamma)
+    sup_support = gamma + mx.nd.sum(slopes * knot_spacings, axis=-1)
+
+    assert mx.nd.broadcast_lesser_equal(gamma, sup_support).asnumpy().all()
+
+    width = sup_support - gamma
+    x = mx.random.uniform(low=gamma - width, high=sup_support + width)
+
+    # check that 0 < cdf < 1
+    cdf_x = distr.cdf(x)
+    assert (
+        mx.nd.min(cdf_x).asscalar() >= 0.0
+        and mx.nd.max(cdf_x).asscalar() <= 1.0
+    )
+
+    # check that 0 <= crps
+    crps_x = distr.crps(x)
+    assert mx.nd.min(crps_x).asscalar() >= 0.0


### PR DESCRIPTION
*Issue #, if available:* partially addressing #563 

*Description of changes:* This fixes a bug in the cdf method of PiecewiseLinear, which was returning values larger than 1.0: this addresses the simpler example in #563. The more complex example there has to do with numerical problems, which make the cdf evaluation fail there, and crps as well as a consequence I believe. That problem will need more care.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
