### PR TITLE
Fix item_id field in provided datasets

### DIFF
--- a/src/gluonts/dataset/repository/_gp_copula_2019.py
+++ b/src/gluonts/dataset/repository/_gp_copula_2019.py
@@ -147,6 +147,7 @@ def save_dataset(dataset_path: Path, ds_info: GPCopulaDataset):
                 # Handles adding categorical features of rolling
                 # evaluation dates
                 cat=[cat - ds_info.num_series * (cat // ds_info.num_series)],
+                item_id=cat,
             )
             for cat, data_entry in enumerate(dataset)
         ],

--- a/src/gluonts/dataset/repository/_lstnet.py
+++ b/src/gluonts/dataset/repository/_lstnet.py
@@ -166,6 +166,7 @@ def generate_lstnet_dataset(dataset_path: Path, dataset_name: str):
                     target_values=sliced_ts.values,
                     start=sliced_ts.index[0],
                     cat=[cat],
+                    item_id=cat,
                 )
             )
 
@@ -192,6 +193,7 @@ def generate_lstnet_dataset(dataset_path: Path, dataset_name: str):
                     target_values=sliced_ts.values,
                     start=sliced_ts.index[0],
                     cat=[cat],
+                    item_id=cat,
                 )
             )
 

--- a/src/gluonts/dataset/repository/_m4.py
+++ b/src/gluonts/dataset/repository/_m4.py
@@ -72,7 +72,12 @@ def generate_m4_dataset(
     save_to_file(
         train_file,
         [
-            to_dict(target_values=target, start=mock_start_dataset, cat=[cat])
+            to_dict(
+                target_values=target,
+                start=mock_start_dataset,
+                cat=[cat],
+                item_id=cat,
+            )
             for cat, target in enumerate(train_target_values)
         ],
     )
@@ -80,7 +85,12 @@ def generate_m4_dataset(
     save_to_file(
         test_file,
         [
-            to_dict(target_values=target, start=mock_start_dataset, cat=[cat])
+            to_dict(
+                target_values=target,
+                start=mock_start_dataset,
+                cat=[cat],
+                item_id=cat,
+            )
             for cat, target in enumerate(test_target_values)
         ],
     )

--- a/src/gluonts/dataset/repository/_util.py
+++ b/src/gluonts/dataset/repository/_util.py
@@ -14,13 +14,16 @@
 import json
 import os
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Any
 
 import numpy as np
 
 
 def to_dict(
-    target_values: np.ndarray, start: str, cat: Optional[List[int]] = None
+    target_values: np.ndarray,
+    start: str,
+    cat: Optional[List[int]] = None,
+    item_id: Optional[Any] = None,
 ):
     def serialize(x):
         if np.isnan(x):
@@ -36,6 +39,9 @@ def to_dict(
 
     if cat is not None:
         res["feat_static_cat"] = cat
+
+    if item_id is not None:
+        res["item_id"] = item_id
 
     return res
 


### PR DESCRIPTION
*Issue #, if available:* #291 

*Description of changes:* This adds an `"item_id"` field in the provided dataset recipes. Getting the datases with `regenerate=True` should then fix #291. I set the `"item_id"` field to be the same incremental integer as the `"cat"` field, but we could decide of using something slightly different there for clarity (like the `"item<N>"` string or something like that).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
