### PR TITLE
Fix scale in synthetic data generation tutorial

### DIFF
--- a/docs/examples/synthetic_data_generation_tutorial/tutorial.md
+++ b/docs/examples/synthetic_data_generation_tutorial/tutorial.md
@@ -232,7 +232,7 @@ As recipes are just lists of expressions that evaluated sequentially, recipes ca
 
 ```python
 scaling = [
-    ("scale", rcp.RandomUniform(0, 1000)),
+    ("scale", rcp.RandomUniform(low=0, high=1000, shape=1)),
     ("z", "scale" * rcp.Ref("unscaled"))
 ]
 


### PR DESCRIPTION
*Description of changes:* I believe the scale was being generated with the wrong shape in one of the examples, this fixes it by making it uniform in time


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
