### PR TITLE
Change causal conv1d default activation to match the doc

### DIFF
--- a/src/gluonts/block/cnn.py
+++ b/src/gluonts/block/cnn.py
@@ -58,7 +58,7 @@ class CausalConv1D(gluon.HybridBlock):
         channels: int,
         kernel_size: int,
         dilation: int = 1,
-        activation: Optional[str] = "relu",
+        activation: Optional[str] = None,
         **kwargs,
     ):
         super(CausalConv1D, self).__init__(**kwargs)


### PR DESCRIPTION
*Description of changes:*

Default activation used in [CausalConv1d](https://gluon-ts.mxnet.io/api/gluonts/gluonts.block.cnn.html#) doesn't match the code. Changing it to`None` from `"relu"`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
