### PR TITLE
Updated N-Beats defaults.

### DIFF
--- a/src/gluonts/model/n_beats/_ensemble.py
+++ b/src/gluonts/model/n_beats/_ensemble.py
@@ -296,7 +296,7 @@ class NBEATSEnsembleEstimator(Estimator):
         If type is "T" (trend), then it corresponds to the degree of the polynomial.
         If the type is "S" (seasonal) then its not used.
         A list of ints of length 1 or 'num_stacks'.
-        Default and recommended value for generic mode: [32]
+        Default value for generic mode: [32]
         Recommended value for interpretable mode: [3]
     stack_types
         One of the following values: "G" (generic), "S" (seasonal) or "T" (trend).

--- a/src/gluonts/model/n_beats/_ensemble.py
+++ b/src/gluonts/model/n_beats/_ensemble.py
@@ -296,8 +296,8 @@ class NBEATSEnsembleEstimator(Estimator):
         If type is "T" (trend), then it corresponds to the degree of the polynomial.
         If the type is "S" (seasonal) then its not used.
         A list of ints of length 1 or 'num_stacks'.
-        Default and recommended value for generic mode: [2]
-        Recommended value for interpretable mode: [2]
+        Default and recommended value for generic mode: [32]
+        Recommended value for interpretable mode: [3]
     stack_types
         One of the following values: "G" (generic), "S" (seasonal) or "T" (trend).
         A list of strings of length 1 or 'num_stacks'.

--- a/src/gluonts/model/n_beats/_estimator.py
+++ b/src/gluonts/model/n_beats/_estimator.py
@@ -91,8 +91,8 @@ class NBEATSEstimator(GluonEstimator):
         If type is "T" (trend), then it corresponds to the degree of the polynomial.
         If the type is "S" (seasonal) then its not used.
         A list of ints of length 1 or 'num_stacks'.
-        Default and recommended value for generic mode: [2]
-        Recommended value for interpretable mode: [2]
+        Default and recommended value for generic mode: [32]
+        Recommended value for interpretable mode: [3]
     stack_types
         One of the following values: "G" (generic), "S" (seasonal) or "T" (trend).
         A list of strings of length 1 or 'num_stacks'.
@@ -188,7 +188,7 @@ class NBEATSEstimator(GluonEstimator):
         self.expansion_coefficient_lengths = self._validate_nbeats_argument(
             argument_value=expansion_coefficient_lengths,
             argument_name="expansion_coefficient_lengths",
-            default_value=[2],
+            default_value=[32],
             validation_condition=lambda val: val > 0,
             invalidation_message="Values of 'expansion_coefficient_lengths' should be > 0",
         )

--- a/src/gluonts/model/n_beats/_estimator.py
+++ b/src/gluonts/model/n_beats/_estimator.py
@@ -91,7 +91,7 @@ class NBEATSEstimator(GluonEstimator):
         If type is "T" (trend), then it corresponds to the degree of the polynomial.
         If the type is "S" (seasonal) then its not used.
         A list of ints of length 1 or 'num_stacks'.
-        Default and recommended value for generic mode: [32]
+        Default value for generic mode: [32]
         Recommended value for interpretable mode: [3]
     stack_types
         One of the following values: "G" (generic), "S" (seasonal) or "T" (trend).

--- a/src/gluonts/model/n_beats/_network.py
+++ b/src/gluonts/model/n_beats/_network.py
@@ -396,7 +396,7 @@ class NBEATSNetwork(mx.gluon.HybridBlock):
         If type is "T" (trend), then it corresponds to the degree of the polynomial.
         If the type is "S" (seasonal) then its not used.
         A list of ints of length 1 or 'num_stacks'.
-        Default and recommended value for generic mode: [32]
+        Default value for generic mode: [32]
         Recommended value for interpretable mode: [3]
     stack_types
         One of the following values: "G" (generic), "S" (seasonal) or "T" (trend).

--- a/src/gluonts/model/n_beats/_network.py
+++ b/src/gluonts/model/n_beats/_network.py
@@ -396,8 +396,8 @@ class NBEATSNetwork(mx.gluon.HybridBlock):
         If type is "T" (trend), then it corresponds to the degree of the polynomial.
         If the type is "S" (seasonal) then its not used.
         A list of ints of length 1 or 'num_stacks'.
-        Default and recommended value for generic mode: [2]
-        Recommended value for interpretable mode: [2]
+        Default and recommended value for generic mode: [32]
+        Recommended value for interpretable mode: [3]
     stack_types
         One of the following values: "G" (generic), "S" (seasonal) or "T" (trend).
         A list of strings of length 1 or 'num_stacks'.


### PR DESCRIPTION
*Description of changes:*
I found that the trend block expansion_coefficient_lengths default is off by one when compared to the paper. I checked again, and the paper doesn't specify the dimension of expansion_coefficient_lengths for the generic block. Before it was the same as for the trend block, however, I think it makes sense to increase it to 32, since for example the seasonality block has horizon/2 number of coefficients, so its reasonable to give the generic block more possibilities to learn a larger generic basis.
The changes marginally improve performance in some cases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
