### PR TITLE
Fixed sMAPE related learning issues.

### DIFF
--- a/src/gluonts/model/n_beats/_network.py
+++ b/src/gluonts/model/n_beats/_network.py
@@ -509,7 +509,6 @@ class NBEATSNetwork(mx.gluon.HybridBlock):
             # connect last block
             return forecast + self.net_blocks[-1](backcast)
 
-    # TODO: somehow interpretable mode not learning?
     def smape_loss(self, F, forecast: Tensor, future_target: Tensor) -> Tensor:
         r"""
         .. math::
@@ -519,7 +518,8 @@ class NBEATSNetwork(mx.gluon.HybridBlock):
         According to paper: https://arxiv.org/abs/1905.10437.
         """
 
-        denominator = F.abs(future_target) + F.abs(forecast)
+        # Stop gradient required for stable learning
+        denominator = F.stop_gradient(F.abs(future_target) + F.abs(forecast))
         flag = denominator == 0
 
         smape = (200 / self.prediction_length) * F.mean(


### PR DESCRIPTION
*Issue #, if available:*

Using the sMAPE function in conjunction with a trainer with a learning rate above 1e-4 lead to the models not converging/ learning at all in many cases (i.e. different datasets and different model instantiation like generic vs interpretable etc.).

This is now fixed by stopping gradient flow in the denominator of sMAPE.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
