### PR TITLE
fix `time_feat` in deepvar

### DIFF
--- a/src/gluonts/model/deepvar/_network.py
+++ b/src/gluonts/model/deepvar/_network.py
@@ -323,7 +323,7 @@ class DeepVARNetwork(mx.gluon.HybridBlock):
 
         if future_time_feat is None or future_target_cdf is None:
             time_feat = past_time_feat.slice_axis(
-                axis=1, begin=-self.context_length, end=None
+                axis=1, begin=self.history_length-self.context_length, end=None
             )
             sequence = past_target_cdf
             sequence_length = self.history_length
@@ -331,7 +331,7 @@ class DeepVARNetwork(mx.gluon.HybridBlock):
         else:
             time_feat = F.concat(
                 past_time_feat.slice_axis(
-                    axis=1, begin=-self.context_length, end=None
+                    axis=1, begin=self.history_length-self.context_length, end=None
                 ),
                 future_time_feat,
                 dim=1,


### PR DESCRIPTION
When creating `time_feat ` don't we need to begin the slice from `self.history_length-self.context_length`?

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
