### PR TITLE
fixing context when converting to symbol block predictor

### DIFF
--- a/src/gluonts/model/predictor.py
+++ b/src/gluonts/model/predictor.py
@@ -452,10 +452,11 @@ class RepresentableBlockPredictor(GluonPredictor):
     def as_symbol_block_predictor(
         self, batch: DataBatch
     ) -> SymbolBlockPredictor:
-        symbol_block_net = hybrid_block_to_symbol_block(
-            hb=self.prediction_net,
-            data_batch=[batch[k] for k in self.input_names],
-        )
+        with self.ctx:
+            symbol_block_net = hybrid_block_to_symbol_block(
+                hb=self.prediction_net,
+                data_batch=[batch[k] for k in self.input_names],
+            )
 
         return SymbolBlockPredictor(
             input_names=self.input_names,


### PR DESCRIPTION
*Issue #, if available:* The `as_symbol_block_predictor` method returns a predictor with a network that is on the wrong context. This is apparent when the original predictor was trained on GPU.

See the following minimal example:

```python
import pandas as pd
import numpy as np

import mxnet as mx

from gluonts.model.simple_feedforward import SimpleFeedForwardEstimator
from gluonts.trainer import Trainer
from gluonts.dataset.loader import InferenceDataLoader

estimator = SimpleFeedForwardEstimator(
    prediction_length=24,
    freq="1H",
    trainer=Trainer(num_batches_per_epoch=1, epochs=1, hybridize=True, ctx=mx.gpu())
)

dataset = [
    {"start": pd.Timestamp("2020-01-01", freq="1H"), "target": np.array([0.0]*500)}
]

predictor = estimator.train(dataset)

inference_data_loader = InferenceDataLoader(
    dataset,
    transform=predictor.input_transform,
    batch_size=predictor.batch_size,
    ctx=predictor.ctx,
    dtype=predictor.dtype,
)
data_batch = next(iter(inference_data_loader))
predictor_sym = predictor.as_symbol_block_predictor(data_batch)

for forecast in predictor_sym.predict(dataset):
    print(forecast.mean)
```

which yields

```
[...]
MXNetError: [14:05:28] src/imperative/cached_op.cc:849: Check failed: inputs[i]->ctx() == default_ctx (cpu(0) vs. gpu(0)) CachedOp requires all inputs to live on the same context. But data is on gpu(0) while simplefeedforwardtrainingnetwork0_dense0_weight is on cpu(0)
```

and works fine in this PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
