### PR TITLE
fix data loader and include validation channel in test

### DIFF
--- a/src/gluonts/dataset/loader.py
+++ b/src/gluonts/dataset/loader.py
@@ -14,12 +14,7 @@
 # Standard library imports
 import functools
 import itertools
-from typing import (
-    Any,
-    Dict,
-    Iterable,
-    Iterator,
-)
+from typing import Any, Dict, Iterable, Iterator
 
 # Third-party imports
 import mxnet as mx
@@ -67,7 +62,13 @@ class DataLoader(Iterable[DataEntry]):
         self.batch_size = batch_size
         self.ctx = ctx
         self.dtype = dtype
-        self.stream: Iterable = transform(dataset, is_train=is_train)
+        self.is_train = is_train
+        self.dataset = dataset
+        self.transform = transform
+
+    @property
+    def stream(self) -> Iterable:
+        return self.transform(self.dataset, is_train=self.is_train)
 
     def make_batch_iter(self):
         batches = batcher(self.stream, self.batch_size)
@@ -143,9 +144,15 @@ class TrainDataLoader(DataLoader):
         )
 
         self.num_batches_per_epoch = num_batches_per_epoch
+        self.shuffle_for_training = shuffle_for_training
+        self.num_batches_for_shuffling = num_batches_for_shuffling
 
-        if shuffle_for_training:
-            self.stream = shuffler(self.stream, num_batches_for_shuffling)
+    @property
+    def stream(self) -> Iterable:
+        s = self.transform(self.dataset, is_train=self.is_train)
+        if self.shuffle_for_training:
+            return shuffler(s, self.num_batches_for_shuffling)
+        return s
 
     def __len__(self) -> int:
         return self.num_batches_per_epoch

--- a/test/model/test_deepar_auxiliary_outputs.py
+++ b/test/model/test_deepar_auxiliary_outputs.py
@@ -35,11 +35,11 @@ def test_distribution():
     estimator = DeepAREstimator(
         freq=freq,
         prediction_length=prediction_length,
-        trainer=Trainer(epochs=1, num_batches_per_epoch=1),
+        trainer=Trainer(epochs=2, num_batches_per_epoch=1),
         distr_output=StudentTOutput(),
     )
 
-    train_output = estimator.train_model(train_ds)
+    train_output = estimator.train_model(train_ds, test_ds)
 
     # todo adapt loader to anomaly detection use-case
     batch_size = 2


### PR DESCRIPTION
Last refactoring broke the `DataLoader`'s ability to loop over the data multiple times.
This gives problems when using the validation channel for more than one epoch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
