### PR TITLE
Add lead_time to predictors and estimators, update LSTNet

### DIFF
--- a/src/gluonts/evaluation/backtest.py
+++ b/src/gluonts/evaluation/backtest.py
@@ -64,6 +64,7 @@ def make_evaluation_predictions(
 
     prediction_length = predictor.prediction_length
     freq = predictor.freq
+    lead_time = predictor.lead_time
 
     def add_ts_dataframe(
         data_iterator: Iterator[DataEntry],
@@ -90,7 +91,7 @@ def make_evaluation_predictions(
         assert (
             target.shape[-1] >= prediction_length
         )  # handles multivariate case (target_dim, history_length)
-        data["target"] = target[..., :-prediction_length]
+        data["target"] = target[..., : -prediction_length - lead_time]
         return data
 
     # TODO filter out time series with target shorter than prediction length

--- a/src/gluonts/model/estimator.py
+++ b/src/gluonts/model/estimator.py
@@ -44,6 +44,14 @@ class Estimator:
 
     prediction_length: int
     freq: str
+    lead_time: int
+
+    def __init__(self, lead_time: int = 0, **kwargs) -> None:
+        # TODO validation of prediction_length and freq could also
+        # TODO be bubbled-up here from subclasses classes
+        assert lead_time >= 0, "The value of `lead_time` should be >= 0"
+
+        self.lead_time = lead_time
 
     def train(
         self, training_data: Dataset, validation_data: Optional[Dataset] = None
@@ -85,6 +93,7 @@ class DummyEstimator(Estimator):
 
     @validated()
     def __init__(self, predictor_cls: type, **kwargs) -> None:
+        super().__init__(**kwargs)
         self.predictor = predictor_cls(**kwargs)
 
     def train(
@@ -110,7 +119,10 @@ class GluonEstimator(Estimator):
     """
 
     @validated()
-    def __init__(self, trainer: Trainer, dtype: DType = np.float32) -> None:
+    def __init__(
+        self, trainer: Trainer, lead_time: int = 0, dtype: DType = np.float32
+    ) -> None:
+        super().__init__(lead_time=lead_time)
         self.trainer = trainer
         self.dtype = dtype
 

--- a/src/gluonts/model/n_beats/_ensemble.py
+++ b/src/gluonts/model/n_beats/_ensemble.py
@@ -77,7 +77,7 @@ class NBEATSEnsemblePredictor(Predictor):
         predictors: List[RepresentableBlockPredictor],
         aggregation_method: Optional[str] = "median",
     ) -> None:
-        super().__init__(prediction_length, freq)
+        super().__init__(freq=freq, prediction_length=prediction_length)
 
         assert aggregation_method in AGGREGATION_METHODS
 

--- a/src/gluonts/model/naive_2/_predictor.py
+++ b/src/gluonts/model/naive_2/_predictor.py
@@ -138,7 +138,7 @@ class Naive2Predictor(RepresentablePredictor):
         prediction_length: int,
         season_length: Optional[int] = None,
     ) -> None:
-        super().__init__(prediction_length, freq)
+        super().__init__(freq=freq, prediction_length=prediction_length)
 
         assert (
             season_length is None or season_length > 0

--- a/src/gluonts/model/npts/_predictor.py
+++ b/src/gluonts/model/npts/_predictor.py
@@ -167,11 +167,9 @@ class NPTSPredictor(RepresentablePredictor):
         num_default_time_features: int = 1,
         feature_scale: float = 1000.0,
     ) -> None:
-        self.prediction_length = prediction_length
-        self.freq = freq
-        # Similar to lag upper bound in AR2N2 we limit the context length to
-        # some maximum value instead of looking at the whole history which
-        # might be too large.
+        super().__init__(prediction_length=prediction_length, freq=freq)
+        # We limit the context length to some maximum value instead of
+        # looking at the whole history which might be too large.
         self.context_length = (
             context_length if context_length is not None else 1100
         )

--- a/src/gluonts/model/npts/_predictor.py
+++ b/src/gluonts/model/npts/_predictor.py
@@ -167,7 +167,7 @@ class NPTSPredictor(RepresentablePredictor):
         num_default_time_features: int = 1,
         feature_scale: float = 1000.0,
     ) -> None:
-        super().__init__(prediction_length=prediction_length, freq=freq)
+        super().__init__(freq=freq, prediction_length=prediction_length)
         # We limit the context length to some maximum value instead of
         # looking at the whole history which might be too large.
         self.context_length = (

--- a/src/gluonts/model/predictor.py
+++ b/src/gluonts/model/predictor.py
@@ -180,7 +180,9 @@ class RepresentablePredictor(Predictor):
     def __init__(
         self, prediction_length: int, freq: str, lead_time: int = 0
     ) -> None:
-        super().__init__(prediction_length, freq, lead_time)
+        super().__init__(
+            freq=freq, lead_time=lead_time, prediction_length=prediction_length
+        )
 
     def predict(self, dataset: Dataset, **kwargs) -> Iterator[Forecast]:
         for item in dataset:
@@ -252,7 +254,11 @@ class GluonPredictor(Predictor):
         output_transform: Optional[OutputTransform] = None,
         dtype: DType = np.float32,
     ) -> None:
-        super().__init__(prediction_length, freq, lead_time)
+        super().__init__(
+            freq=freq,
+            lead_time=lead_time,
+            prediction_length=prediction_length,
+        )
 
         self.input_names = input_names
         self.prediction_net = prediction_net
@@ -596,9 +602,9 @@ class ParallelizedPredictor(Predictor):
         chunk_size=1,
     ) -> None:
         super().__init__(
-            base_predictor.prediction_length,
-            base_predictor.freq,
-            base_predictor.lead_time,
+            freq=base_predictor.freq,
+            lead_time=base_predictor.lead_time,
+            prediction_length=base_predictor.prediction_length,
         )
 
         self._base_predictor = base_predictor
@@ -723,7 +729,9 @@ class Localizer(Predictor):
 
     def __init__(self, estimator: "Estimator"):
         super().__init__(
-            estimator.prediction_length, estimator.freq, estimator.lead_time
+            freq=estimator.freq,
+            lead_time=estimator.lead_time,
+            prediction_length=estimator.prediction_length,
         )
         self.estimator = estimator
 

--- a/src/gluonts/model/predictor.py
+++ b/src/gluonts/model/predictor.py
@@ -87,13 +87,17 @@ class Predictor:
 
     __version__: str = gluonts.__version__
 
-    def __init__(self, prediction_length: int, freq: str) -> None:
+    def __init__(
+        self, prediction_length: int, freq: str, lead_time: int = 0
+    ) -> None:
         assert (
             prediction_length > 0
         ), "The value of `prediction_length` should be > 0"
+        assert lead_time >= 0, "The value of `lead_time` should be >= 0"
 
         self.prediction_length = prediction_length
         self.freq = freq
+        self.lead_time = lead_time
 
     def predict(self, dataset: Dataset, **kwargs) -> Iterator[Forecast]:
         """
@@ -173,8 +177,10 @@ class RepresentablePredictor(Predictor):
     """
 
     @validated()
-    def __init__(self, prediction_length: int, freq: str) -> None:
-        super().__init__(prediction_length, freq)
+    def __init__(
+        self, prediction_length: int, freq: str, lead_time: int = 0
+    ) -> None:
+        super().__init__(prediction_length, freq, lead_time)
 
     def predict(self, dataset: Dataset, **kwargs) -> Iterator[Forecast]:
         for item in dataset:
@@ -241,11 +247,12 @@ class GluonPredictor(Predictor):
         freq: str,
         ctx: mx.Context,
         input_transform: Transformation,
+        lead_time: int = 0,
         forecast_generator: ForecastGenerator = SampleForecastGenerator(),
         output_transform: Optional[OutputTransform] = None,
         dtype: DType = np.float32,
     ) -> None:
-        super().__init__(prediction_length, freq)
+        super().__init__(prediction_length, freq, lead_time)
 
         self.input_names = input_names
         self.prediction_net = prediction_net
@@ -438,6 +445,7 @@ class RepresentableBlockPredictor(GluonPredictor):
         freq: str,
         ctx: mx.Context,
         input_transform: Transformation,
+        lead_time: int = 0,
         forecast_generator: ForecastGenerator = SampleForecastGenerator(),
         output_transform: Optional[
             Callable[[DataEntry, np.ndarray], np.ndarray]
@@ -452,6 +460,7 @@ class RepresentableBlockPredictor(GluonPredictor):
             freq=freq,
             ctx=ctx,
             input_transform=input_transform,
+            lead_time=lead_time,
             forecast_generator=forecast_generator,
             output_transform=output_transform,
             dtype=dtype,
@@ -474,6 +483,7 @@ class RepresentableBlockPredictor(GluonPredictor):
             freq=self.freq,
             ctx=self.ctx,
             input_transform=self.input_transform,
+            lead_time=self.lead_time,
             forecast_generator=self.forecast_generator,
             output_transform=self.output_transform,
             dtype=self.dtype,
@@ -585,7 +595,11 @@ class ParallelizedPredictor(Predictor):
         num_workers: Optional[int] = None,
         chunk_size=1,
     ) -> None:
-        super().__init__(base_predictor.prediction_length, base_predictor.freq)
+        super().__init__(
+            base_predictor.prediction_length,
+            base_predictor.freq,
+            base_predictor.lead_time,
+        )
 
         self._base_predictor = base_predictor
         self._num_workers = (
@@ -708,7 +722,9 @@ class Localizer(Predictor):
     """
 
     def __init__(self, estimator: "Estimator"):
-        super().__init__(estimator.prediction_length, estimator.freq)
+        super().__init__(
+            estimator.prediction_length, estimator.freq, estimator.lead_time
+        )
         self.estimator = estimator
 
     def predict(self, dataset: Dataset, **kwargs) -> Iterator[Forecast]:

--- a/src/gluonts/model/prophet/_predictor.py
+++ b/src/gluonts/model/prophet/_predictor.py
@@ -127,7 +127,7 @@ class ProphetPredictor(RepresentablePredictor):
         prophet_params: Optional[Dict] = None,
         init_model: Callable = lambda m: m,
     ) -> None:
-        super().__init__(prediction_length, freq)
+        super().__init__(freq=freq, prediction_length=prediction_length)
 
         if not PROPHET_IS_INSTALLED:
             raise ImportError(USAGE_MESSAGE)

--- a/src/gluonts/model/r_forecast/_predictor.py
+++ b/src/gluonts/model/r_forecast/_predictor.py
@@ -49,13 +49,13 @@ class RForecastPredictor(RepresentablePredictor):
 
     Parameters
     ----------
+    freq
+        The granularity of the time series (e.g. '1H')
+    prediction_length
+        Number of time points to be predicted.
     method
         The method from rforecast to be used one of
         "ets", "arima", "tbats", "croston", "mlp".
-    prediction_length
-        Number of time points to be predicted.
-    freq
-        The granularity of the time series (e.g. '1H')
     period
         The period to be used (this is called `frequency` in the R forecast
         package), result to a tentative reasonable default if not specified
@@ -78,6 +78,8 @@ class RForecastPredictor(RepresentablePredictor):
         trunc_length: Optional[int] = None,
         params: Optional[Dict] = None,
     ) -> None:
+        super().__init__(prediction_length=prediction_length, freq=freq)
+
         try:
             from rpy2 import robjects, rinterface
             import rpy2.robjects.packages as rpackages

--- a/src/gluonts/model/r_forecast/_predictor.py
+++ b/src/gluonts/model/r_forecast/_predictor.py
@@ -78,7 +78,7 @@ class RForecastPredictor(RepresentablePredictor):
         trunc_length: Optional[int] = None,
         params: Optional[Dict] = None,
     ) -> None:
-        super().__init__(prediction_length=prediction_length, freq=freq)
+        super().__init__(freq=freq, prediction_length=prediction_length)
 
         try:
             from rpy2 import robjects, rinterface

--- a/src/gluonts/model/seasonal_naive/_predictor.py
+++ b/src/gluonts/model/seasonal_naive/_predictor.py
@@ -56,7 +56,7 @@ class SeasonalNaivePredictor(RepresentablePredictor):
         prediction_length: int,
         season_length: Optional[int] = None,
     ) -> None:
-        super().__init__(prediction_length, freq)
+        super().__init__(freq=freq, prediction_length=prediction_length)
 
         assert (
             season_length is None or season_length > 0

--- a/src/gluonts/model/trivial/constant.py
+++ b/src/gluonts/model/trivial/constant.py
@@ -78,7 +78,7 @@ class ConstantValuePredictor(RepresentablePredictor, FallbackPredictor):
         # line on default
         num_samples: int = 1,
     ) -> None:
-        super().__init__(prediction_length, freq)
+        super().__init__(freq=freq, prediction_length=prediction_length)
         self.value = value
         self.num_samples = num_samples
 

--- a/src/gluonts/model/trivial/identity.py
+++ b/src/gluonts/model/trivial/identity.py
@@ -46,7 +46,7 @@ class IdentityPredictor(RepresentablePredictor):
     def __init__(
         self, prediction_length: int, freq: str, num_samples: int
     ) -> None:
-        super().__init__(prediction_length, freq)
+        super().__init__(freq=freq, prediction_length=prediction_length)
 
         assert num_samples > 0, "The value of `num_samples` should be > 0"
 

--- a/src/gluonts/model/trivial/mean.py
+++ b/src/gluonts/model/trivial/mean.py
@@ -55,7 +55,7 @@ class MeanPredictor(RepresentablePredictor, FallbackPredictor):
         num_samples: int = 100,
         context_length: Optional[int] = None,
     ) -> None:
-        super().__init__(prediction_length, freq)
+        super().__init__(freq=freq, prediction_length=prediction_length)
         self.context_length = context_length
         self.num_samples = num_samples
         self.shape = (self.num_samples, self.prediction_length)

--- a/src/gluonts/model/trivial/mean.py
+++ b/src/gluonts/model/trivial/mean.py
@@ -103,6 +103,7 @@ class MeanEstimator(Estimator):
         freq: str,
         num_samples: PositiveInt,
     ) -> None:
+        super().__init__()
         self.prediction_length = prediction_length
         self.freq = freq
         self.num_samples = num_samples

--- a/src/gluonts/transform/split.py
+++ b/src/gluonts/transform/split.py
@@ -97,20 +97,22 @@ class InstanceSplitter(FlatMapTransformation):
         length of the target seen before making prediction
     future_length
         length of the target that must be predicted
+    lead_time
+        gap between the past and future windows (default: 0)
     output_NTC
         whether to have time series output in (time, dimension) or in
-        (dimension, time) layout
+        (dimension, time) layout (default: True)
     time_series_fields
         fields that contains time-series, they are split in the same interval
-        as the target
+        as the target (default: None)
     pick_incomplete
         whether training examples can be sampled with only a part of
         past_length time-units
         present for the time series. This is useful to train models for
         cold-start. In such case, is_pad_out contains an indicator whether
-        data is padded or not.
+        data is padded or not. (default: True)
     dummy_value
-        Value to use for padding.
+        Value to use for padding. (default: 0.0)
     """
 
     @validated()
@@ -123,6 +125,7 @@ class InstanceSplitter(FlatMapTransformation):
         train_sampler: InstanceSampler,
         past_length: int,
         future_length: int,
+        lead_time: int = 0,
         output_NTC: bool = True,
         time_series_fields: Optional[List[str]] = None,
         pick_incomplete: bool = True,
@@ -134,6 +137,7 @@ class InstanceSplitter(FlatMapTransformation):
         self.train_sampler = train_sampler
         self.past_length = past_length
         self.future_length = future_length
+        self.lead_time = lead_time
         self.output_NTC = output_NTC
         self.ts_fields = (
             time_series_fields if time_series_fields is not None else []
@@ -155,6 +159,7 @@ class InstanceSplitter(FlatMapTransformation):
         self, data: DataEntry, is_train: bool
     ) -> Iterator[DataEntry]:
         pl = self.future_length
+        lt = self.lead_time
         slice_cols = self.ts_fields + [self.target_field]
         target = data[self.target_field]
 
@@ -164,16 +169,19 @@ class InstanceSplitter(FlatMapTransformation):
             self.future_length
             if self.pick_incomplete
             else self.past_length + self.future_length
-        )
+        ) + self.lead_time
 
         if is_train:
             sampling_bounds = (
                 (
                     0,
-                    len_target - self.future_length,
+                    len_target - self.future_length - self.lead_time,
                 )  # TODO: create parameter lower sampling bound for NBEATS
                 if self.pick_incomplete
-                else (self.past_length, len_target - self.future_length)
+                else (
+                    self.past_length,
+                    len_target - self.future_length - self.lead_time,
+                )
             )
 
             # We currently cannot handle time series that are
@@ -213,7 +221,9 @@ class InstanceSplitter(FlatMapTransformation):
                 else:
                     past_piece = d[ts_field][..., :i]
                 d[self._past(ts_field)] = past_piece
-                d[self._future(ts_field)] = d[ts_field][..., i : i + pl]
+                d[self._future(ts_field)] = d[ts_field][
+                    ..., i + lt : i + lt + pl
+                ]
                 del d[ts_field]
             pad_indicator = np.zeros(self.past_length)
             if pad_length > 0:
@@ -230,7 +240,7 @@ class InstanceSplitter(FlatMapTransformation):
 
             d[self._past(self.is_pad_field)] = pad_indicator
             d[self.forecast_start_field] = shift_timestamp(
-                d[self.start_field], i
+                d[self.start_field], i + lt
             )
             yield d
 

--- a/test/model/lstnet/test_lstnet.py
+++ b/test/model/lstnet/test_lstnet.py
@@ -107,9 +107,3 @@ def test_lstnet(
         iter(tss), iter(forecasts), num_series=len(dataset.test)
     )
     assert agg_metrics["ND"] < 1.5
-
-
-if __name__ == "__main__":
-    test_lstnet(
-        2, 2, dataset.metadata.prediction_length - 1, 1, True, np.float32
-    )

--- a/test/model/lstnet/test_lstnet.py
+++ b/test/model/lstnet/test_lstnet.py
@@ -44,19 +44,21 @@ def load_multivariate_constant_dataset():
 
 dataset = load_multivariate_constant_dataset()
 freq = dataset.metadata.metadata.freq
-prediction_length = dataset.metadata.prediction_length
 
 
 @pytest.mark.parametrize("skip_size", [1, 2])
 @pytest.mark.parametrize("ar_window", [1, 2])
 @pytest.mark.parametrize(
-    "horizon, prediction_length",
-    [[prediction_length, None], [None, prediction_length]],
+    "lead_time, prediction_length",
+    [
+        (dataset.metadata.prediction_length - 1, 1),
+        (0, dataset.metadata.prediction_length),
+    ],
 )
 @pytest.mark.parametrize("hybridize", [True, False])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_lstnet(
-    skip_size, ar_window, horizon, prediction_length, hybridize, dtype
+    skip_size, ar_window, lead_time, prediction_length, hybridize, dtype
 ):
     estimator = LSTNetEstimator(
         skip_size=skip_size,
@@ -66,7 +68,7 @@ def test_lstnet(
         kernel_size=3,
         context_length=4,
         freq=freq,
-        horizon=horizon,
+        lead_time=lead_time,
         prediction_length=prediction_length,
         trainer=Trainer(
             epochs=1, batch_size=2, learning_rate=0.01, hybridize=hybridize
@@ -84,22 +86,18 @@ def test_lstnet(
     test_ds = dataset.test.list_data[0]
     for fct in forecasts:
         assert fct.freq == freq
-        if estimator.horizon:
-            assert fct.samples.shape == (NUM_SAMPLES, 1, NUM_SERIES)
-        else:
-            assert fct.samples.shape == (
-                NUM_SAMPLES,
-                prediction_length,
-                NUM_SERIES,
-            )
+        assert fct.samples.shape == (
+            NUM_SAMPLES,
+            prediction_length,
+            NUM_SERIES,
+        )
         assert (
             fct.start_date
             == pd.date_range(
                 start=str(test_ds["start"]),
                 periods=test_ds["target"].shape[1],  # number of test periods
                 freq=freq,
-                closed="right",
-            )[-(horizon or prediction_length)]
+            )[-prediction_length]
         )
 
     evaluator = MultivariateEvaluator(
@@ -109,3 +107,9 @@ def test_lstnet(
         iter(tss), iter(forecasts), num_series=len(dataset.test)
     )
     assert agg_metrics["ND"] < 1.5
+
+
+if __name__ == "__main__":
+    test_lstnet(
+        2, 2, dataset.metadata.prediction_length - 1, 1, True, np.float32
+    )

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -40,6 +40,7 @@ TEST_VALUES = {
     ],
     "use_prediction_features": [True, False],
     "allow_target_padding": [True, False],
+    "lead_time": [0, 1, 10, 20],
 }
 
 
@@ -182,8 +183,9 @@ def test_AddAgeFeatures(start, target, is_train: bool):
 @pytest.mark.parametrize("is_train", TEST_VALUES["is_train"])
 @pytest.mark.parametrize("target", TEST_VALUES["target"])
 @pytest.mark.parametrize("start", TEST_VALUES["start"])
+@pytest.mark.parametrize("lead_time", TEST_VALUES["lead_time"])
 def test_InstanceSplitter(
-    start, target, is_train: bool, pick_incomplete: bool
+    start, target, lead_time: int, is_train: bool, pick_incomplete: bool
 ):
     train_length = 100
     pred_length = 13
@@ -195,6 +197,7 @@ def test_InstanceSplitter(
         train_sampler=transform.UniformSplitSampler(p=1.0),
         past_length=train_length,
         future_length=pred_length,
+        lead_time=lead_time,
         time_series_fields=["some_time_feature"],
         pick_incomplete=pick_incomplete,
     )
@@ -221,6 +224,7 @@ def test_InstanceSplitter(
             0,
             len(target)
             - pred_length
+            - lead_time
             + 1
             - (0 if pick_incomplete else train_length),
         )


### PR DESCRIPTION
*Issue #, if available:* #677 

*Description of changes:* This PR adds a lead_time attribute to both predictor and estimators, and modifies the InstanceSplitter class to take into account for lead_time. By default, lead_time is everywhere 0, so existing predictors and estimators are backwards compatible (provided that they invoke the super constructor upon construction).

Some evaluation code needed to be adjusted, and the LSTNet implementation was also updated accordingly (and simplified in some aspects).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
