### PR TITLE
Label smoothing binned distribution

### DIFF
--- a/docs/bibliography.rst
+++ b/docs/bibliography.rst
@@ -11,6 +11,8 @@ Bibliography
 
 .. [LCY+18] Lai, Guokun, et al. "Modeling long-and short-term temporal patterns with deep neural networks." The 41st International ACM SIGIR Conference on Research & Development in Information Retrieval. ACM, 2018.
 
+.. [MKH19] Muller, Rafael, Simon Kornblith, and Geoffrey E. Hinton. "When does label smoothing help?." Advances in Neural Information Processing Systems. 2019.
+
 .. [ODZ+16] Oord, Aaron van den, et al. "Wavenet: A generative model for raw audio." arXiv preprint arXiv:1609.03499 (2016).
 
 .. [PKC+16] Paine, Tom Le, et al. "Fast wavenet generation algorithm." arXiv preprint arXiv:1611.09482 (2016).

--- a/src/gluonts/distribution/binned.py
+++ b/src/gluonts/distribution/binned.py
@@ -12,7 +12,7 @@
 # permissions and limitations under the License.
 
 # Standard library imports
-from typing import Tuple, List
+from typing import Tuple, List, Optional
 
 # Third-party imports
 import mxnet as mx
@@ -41,13 +41,24 @@ class Binned(Distribution):
     bin_centers
         Tensor containing the bin centers, of shape `(*batch_shape, num_bins)`.
     F
+    label_smoothing
+        The label smoothing weight, real number in `[0, 1)`. Default `None`. If not
+        `None`, then the loss of the distribution will be "label smoothed" cross-entropy.
+        For example, instead of computing cross-entropy loss between the estimated bin
+        probabilities and a hard-label (one-hot encoding) `[1, 0, 0]`, a soft label of
+        `[0.9, 0.05, 0.05]` is taken as the ground truth (when `label_smoothing=0.15`).
+        See (Muller et al., 2019) [MKH19]_, for further reference.
     """
 
     is_reparameterizable = False
 
     @validated()
     def __init__(
-        self, bin_log_probs: Tensor, bin_centers: Tensor, F=None
+        self,
+        bin_log_probs: Tensor,
+        bin_centers: Tensor,
+        F=None,
+        label_smoothing: Optional[float] = None,
     ) -> None:
         self.bin_centers = bin_centers
         self.bin_log_probs = bin_log_probs
@@ -55,6 +66,7 @@ class Binned(Distribution):
         self.F = F if F else getF(bin_log_probs)
 
         self.bin_edges = Binned._compute_edges(self.F, bin_centers)
+        self.label_smoothing = label_smoothing
 
     @staticmethod
     def _compute_edges(F, bin_centers: Tensor) -> Tensor:
@@ -123,9 +135,8 @@ class Binned(Distribution):
         ).sum(axis=-1)
         return self.F.broadcast_minus(ex2, self.mean.square()).sqrt()
 
-    def log_prob(self, x):
+    def _get_mask(self, x):
         F = self.F
-        x = x.expand_dims(axis=-1)
         # TODO: when mxnet has searchsorted replace this
         left_edges = self.bin_edges.slice_axis(axis=-1, begin=0, end=-1)
         right_edges = self.bin_edges.slice_axis(axis=-1, begin=1, end=None)
@@ -133,6 +144,33 @@ class Binned(Distribution):
             F.broadcast_lesser_equal(left_edges, x),
             F.broadcast_lesser(x, right_edges),
         )
+        return mask
+
+    @staticmethod
+    def _smooth_mask(F, mask, alpha):
+        return F.broadcast_add(
+            F.broadcast_mul(mask, F.broadcast_sub(F.ones_like(alpha), alpha)),
+            F.broadcast_mul(F.softmax(F.ones_like(mask)), alpha),
+        )
+
+    def smooth_ce_loss(self, x):
+        """
+        Cross-entropy loss with a "smooth" label.
+        """
+        assert self.label_smoothing is not None
+        F = self.F
+        x = x.expand_dims(axis=-1)
+        mask = self._get_mask(x)
+
+        alpha = F.full(shape=(1,), val=self.label_smoothing)
+        smooth_mask = self._smooth_mask(F, mask, alpha)
+
+        return -F.broadcast_mul(self.bin_log_probs, smooth_mask).sum(axis=-1)
+
+    def log_prob(self, x):
+        F = self.F
+        x = x.expand_dims(axis=-1)
+        mask = self._get_mask(x)
         return F.broadcast_mul(self.bin_log_probs, mask).sum(axis=-1)
 
     def cdf(self, x: Tensor) -> Tensor:
@@ -141,6 +179,13 @@ class Binned(Distribution):
         # left_edges = self.bin_edges.slice_axis(axis=-1, begin=0, end=-1)
         mask = F.broadcast_lesser_equal(self.bin_centers, x)
         return F.broadcast_mul(self.bin_probs, mask).sum(axis=-1)
+
+    def loss(self, x: Tensor) -> Tensor:
+        return (
+            self.smooth_ce_loss(x)
+            if self.label_smoothing
+            else -self.log_prob(x)
+        )
 
     def quantile(self, level: Tensor) -> Tensor:
         F = self.F
@@ -249,22 +294,25 @@ class BinnedOutput(DistributionOutput):
     distr_cls: type = Binned
 
     @validated()
-    def __init__(self, bin_centers: mx.nd.NDArray) -> None:
+    def __init__(
+        self,
+        bin_centers: mx.nd.NDArray,
+        label_smoothing: Optional[float] = None,
+    ) -> None:
+        assert label_smoothing is None or (
+            0 <= label_smoothing < 1
+        ), "Smoothing factor should be less than 1 and greater than or equal to 0."
         super().__init__(self)
         self.bin_centers = bin_centers
         self.num_bins = self.bin_centers.shape[0]
+        self.label_smoothing = label_smoothing
         assert len(self.bin_centers.shape) == 1
 
     def get_args_proj(self, *args, **kwargs) -> gluon.nn.HybridBlock:
         return BinnedArgs(self.num_bins, self.bin_centers)
 
-    def distribution(self, args, loc=None, scale=None) -> Binned:
-        probs = args[0]
-        bin_centers = args[1]
-        F = getF(probs)
-
-        bin_centers = F.broadcast_mul(bin_centers, F.ones_like(probs))
-
+    @staticmethod
+    def _scale_bin_centers(F, bin_centers, loc=None, scale=None):
         if scale is not None:
             bin_centers = F.broadcast_mul(
                 bin_centers, scale.expand_dims(axis=-1)
@@ -274,7 +322,19 @@ class BinnedOutput(DistributionOutput):
                 bin_centers, loc.expand_dims(axis=-1)
             )
 
-        return Binned(probs, bin_centers)
+        return bin_centers
+
+    def distribution(self, args, loc=None, scale=None) -> Binned:
+        probs = args[0]
+        bin_centers = args[1]
+        F = getF(probs)
+
+        bin_centers = F.broadcast_mul(bin_centers, F.ones_like(probs))
+        bin_centers = self._scale_bin_centers(
+            F, bin_centers, loc=loc, scale=scale
+        )
+
+        return Binned(probs, bin_centers, label_smoothing=self.label_smoothing)
 
     @property
     def event_shape(self) -> Tuple:

--- a/test/distribution/test_distribution_methods.py
+++ b/test/distribution/test_distribution_methods.py
@@ -86,6 +86,20 @@ test_cases = [
             ).repeat(axis=0, repeats=2),
         },
     ),
+    (
+        Binned,
+        {
+            "bin_log_probs": mx.nd.array(
+                [[1e-300, 0.3, 0.1, 0.05, 0.2, 0.1, 0.25]]
+            )
+            .log()
+            .repeat(axis=0, repeats=2),
+            "bin_centers": mx.nd.array(
+                [[-5, -3, -1.2, -0.5, 0, 0.1, 0.2]]
+            ).repeat(axis=0, repeats=2),
+            "label_smoothing": 0.1,
+        },
+    ),
     (Poisson, {"rate": mx.nd.array([1000.0, 1.0])}),
 ]
 

--- a/test/distribution/test_distribution_sampling.py
+++ b/test/distribution/test_distribution_sampling.py
@@ -91,6 +91,20 @@ test_cases = [
             ).repeat(axis=0, repeats=2),
         },
     ),
+    (
+        Binned,
+        {
+            "bin_log_probs": mx.nd.array(
+                [[0.1, 0.2, 0.1, 0.05, 0.2, 0.1, 0.25]]
+            )
+            .log()
+            .repeat(axis=0, repeats=2),
+            "bin_centers": mx.nd.array(
+                [[-5, -3, -1.2, -0.5, 0, 0.1, 0.2]]
+            ).repeat(axis=0, repeats=2),
+            "label_smoothing": 0.1,
+        },
+    ),
     (Poisson, {"rate": mx.nd.array([1000.0, 0])}),
 ]
 

--- a/test/distribution/test_label_smoothing.py
+++ b/test/distribution/test_label_smoothing.py
@@ -1,0 +1,117 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+import itertools
+
+import pytest
+import mxnet as mx
+import numpy as np
+
+from gluonts.distribution import Binned, BinnedOutput
+
+
+COMMON_KWARGS = {
+    "bin_log_probs": mx.nd.array([[0.1, 0.2, 0.1, 0.05, 0.2, 0.1, 0.25]])
+    .log()
+    .repeat(axis=0, repeats=2),
+    "bin_centers": mx.nd.array([[-5, -3, -1.2, -0.5, 0, 0.1, 0.2]]).repeat(
+        axis=0, repeats=2
+    ),
+}
+
+
+@pytest.fixture
+def labels():
+    return mx.random.uniform(low=-6, high=1, shape=(2,))  # T, N
+
+
+@pytest.mark.parametrize(
+    "K,alpha", itertools.product([1000, 10000, 100000], [0.001, 0.01, 0.1])
+)
+def test_smooth_mask_adds_to_one(K, alpha):
+    bin_log_probs = mx.nd.log_softmax(mx.nd.ones(K))
+    bin_centers = mx.nd.arange(K)
+
+    dist = Binned(
+        bin_log_probs=bin_log_probs,
+        bin_centers=bin_centers,
+        label_smoothing=0.2,
+    )
+
+    labels = mx.random.uniform(low=0, high=K, shape=(12,)).expand_dims(-1)
+    mask = dist._get_mask(labels)
+    smooth_mask = dist._smooth_mask(mx.nd, mask, alpha=mx.nd.array([alpha]))
+
+    # check smooth mask adds to one
+    assert np.allclose(
+        smooth_mask.asnumpy().sum(axis=-1), np.ones(12), atol=1e-6
+    )
+
+
+def test_get_smooth_mask_correct(labels):
+    dist = Binned(**COMMON_KWARGS, label_smoothing=0.2)
+    binned = Binned(**COMMON_KWARGS)
+
+    labels = labels.expand_dims(-1)
+
+    mask = dist._get_mask(labels)
+
+    assert np.allclose(mask.asnumpy(), binned._get_mask(labels).asnumpy())
+
+    smooth_mask = dist._smooth_mask(mx.nd, mask, alpha=mx.nd.array([0.2]))
+
+    # check smooth mask adds to one
+    assert np.allclose(smooth_mask.asnumpy().sum(axis=-1), np.ones(2))
+
+    # check smooth mask peaks same
+    assert np.allclose(
+        np.argmax(smooth_mask.asnumpy(), axis=-1),
+        np.argmax(mask.asnumpy(), axis=-1),
+    )
+
+    # check smooth mask mins correct
+    assert np.allclose(
+        smooth_mask.asnumpy().min(axis=-1), np.ones(2) * 0.2 / 7  # alpha / K
+    )
+
+
+def test_loss_correct(labels):
+    smooth_alpha = Binned(**COMMON_KWARGS, label_smoothing=0.4)
+    smooth_noalpha = Binned(**COMMON_KWARGS, label_smoothing=0.0)
+    binned = Binned(**COMMON_KWARGS)
+
+    assert np.allclose(
+        binned.loss(labels).asnumpy(), smooth_noalpha.loss(labels).asnumpy()
+    )
+
+    assert not np.allclose(
+        binned.loss(labels).asnumpy(), smooth_alpha.loss(labels).asnumpy()
+    )
+
+
+@pytest.mark.parametrize("hybridize", [True, False])
+def test_output_sets_alpha(labels, hybridize):
+    binned_output = BinnedOutput(
+        bin_centers=COMMON_KWARGS["bin_centers"][0], label_smoothing=0.35
+    )
+
+    arg_proj = binned_output.get_args_proj()
+    if hybridize:
+        arg_proj.hybridize()
+    arg_proj.initialize()
+
+    assert (
+        binned_output.distribution(
+            arg_proj(mx.nd.random.uniform(2, 10))
+        ).label_smoothing
+        == 0.35
+    )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Introduces a version of the `Binned` distribution that features [label smoothing](https://arxiv.org/abs/1906.02629), a technique formerly found to promote better calibration, faster training, and better generalization with binned type losses.

The implementation subclasses `Binned` and `BinnedOutput`, overriding the `loss()` method of the former. Edits to `binned.py` are to prevent code duplication.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
