### PR TITLE
Remove asserts on loc and scale in distributions that do not support them

### DIFF
--- a/src/gluonts/distribution/dirichlet.py
+++ b/src/gluonts/distribution/dirichlet.py
@@ -148,7 +148,6 @@ class DirichletOutput(DistributionOutput):
         self.mask = None
 
     def distribution(self, distr_args, loc=None, scale=None) -> Distribution:
-        assert loc is None and scale is None
         distr = Dirichlet(distr_args)
         return distr
 

--- a/src/gluonts/distribution/dirichlet_multinomial.py
+++ b/src/gluonts/distribution/dirichlet_multinomial.py
@@ -181,7 +181,6 @@ class DirichletMultinomialOutput(DistributionOutput):
         self.mask = None
 
     def distribution(self, distr_args, loc=None, scale=None) -> Distribution:
-        assert loc is None and scale is None
         distr = DirichletMultinomial(self.dim, self.n_trials, distr_args)
         return distr
 

--- a/src/gluonts/distribution/neg_binomial.py
+++ b/src/gluonts/distribution/neg_binomial.py
@@ -124,7 +124,6 @@ class NegativeBinomialOutput(DistributionOutput):
         loc: Optional[Tensor] = None,
         scale: Optional[Tensor] = None,
     ) -> NegativeBinomial:
-        assert loc is None
         mu, alpha = distr_args
         if scale is None:
             return NegativeBinomial(mu, alpha)

--- a/src/gluonts/distribution/poisson.py
+++ b/src/gluonts/distribution/poisson.py
@@ -102,7 +102,6 @@ class PoissonOutput(DistributionOutput):
         scale: Optional[Tensor] = None,
     ) -> Poisson:
         rate = distr_args
-        assert loc is None
         if scale is None:
             return Poisson(rate)
         else:


### PR DESCRIPTION
*Issue #, if available:* fixes #641 

*Description of changes:* For some distributions, it doesn't make sense to prescribe a "loc" or "scale" by which to translate and scale the distribution arguments. However, networks that do compute a location/scale for the (past) data (and potentially use them to scale the network inputs) may provide this information to the DistributionOutput class when invoking the `distribution` method: in these cases, we currently raise an exception. This is not ideal, because it means that you cannot excange a distribution family that does support loc/scale for one that doesn't, on top of the same network. I think the best solution is to simply ignore loc and scale in DistributionOutput classes that don't support them.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
