### PR TITLE
Multiprocessing support for metric calculation (inference)

### DIFF
--- a/src/gluonts/dataset/loader.py
+++ b/src/gluonts/dataset/loader.py
@@ -219,16 +219,6 @@ class InferenceDataLoader(DataLoader):
         dtype: DType = np.float32,
         **kwargs
     ) -> None:
-        # TODO fix this bug:
-        # Currently the is a bug with multi processing here,
-        # see: _worker_fn in parallelized_loader.py for explanation
-        if num_workers != 0 and num_workers is not None:
-            logging.warning(
-                "You have set `num_workers` for InferenceDataLoader to a non zero value, "
-                "however, currently multiprocessing is not supported for the InferenceDataLoader."
-            )
-        num_workers = 0
-
         super().__init__(
             dataset=dataset,
             transform=transform,

--- a/src/gluonts/dataset/parallelized_loader.py
+++ b/src/gluonts/dataset/parallelized_loader.py
@@ -414,9 +414,13 @@ class _MultiWorkerIter(object):
     def __del__(self):
         # Explicitly load the content from shared memory to delete it
         # Unfortunately it seems the way the data is pickled prevents efficient implicit GarbageCollection
-        for k in list(self._data_buffer.keys()):
-            res = pickle.loads(self._data_buffer.pop(k).get(self._timeout))
-            del res
+        try:
+            for k in list(self._data_buffer.keys()):
+                res = pickle.loads(self._data_buffer.pop(k).get(self._timeout))
+                del res
+        except FileNotFoundError:
+            # The resources were already released
+            pass
 
 
 # TODO: think about how a multiprocessing.Manager() would complement this implementation

--- a/src/gluonts/dataset/parallelized_loader.py
+++ b/src/gluonts/dataset/parallelized_loader.py
@@ -38,9 +38,9 @@ except ImportError:
 
 # Third-party imports
 import numpy as np
+import pandas as pd
 from mxnet import nd, context
 import mxnet as mx
-import pandas as pd
 
 # First-party imports
 from gluonts.core.component import DType
@@ -544,15 +544,6 @@ class ParallelDataLoader(object):
                         dtype=self.dtype,
                     )
 
-                    # either pin to cpu memory, or return with the right context straight away
-                    batch = {
-                        k: v.as_in_context(self.ctx)
-                        if isinstance(
-                            v, nd.NDArray
-                        )  # context.cpu_pinned(self.pin_device_id)
-                        else v
-                        for k, v in batch.items()
-                    }
                     yield batch
 
             return same_process_iter()

--- a/src/gluonts/dataset/util.py
+++ b/src/gluonts/dataset/util.py
@@ -24,8 +24,6 @@ from typing import (
     List,
     Tuple,
     TypeVar,
-    NamedTuple,
-    Optional,
 )
 
 # Third-party imports
@@ -39,12 +37,19 @@ T = TypeVar("T")
 class MPWorkerInfo(object):
     """Contains the current worker information."""
 
+    worker_process = False
     num_workers = 1
     worker_id = 0
 
     @classmethod
-    def set_worker_info(cls, num_workers: int, worker_id: int):
-        cls.num_workers, cls.worker_id = num_workers, worker_id
+    def set_worker_info(
+        cls, num_workers: int, worker_id: int, worker_process: bool
+    ):
+        cls.num_workers, cls.worker_id, cls.worker_process = (
+            num_workers,
+            worker_id,
+            worker_process,
+        )
 
 
 def _split(

--- a/src/gluonts/dataset/util.py
+++ b/src/gluonts/dataset/util.py
@@ -35,8 +35,7 @@ import pandas as pd
 T = TypeVar("T")
 
 
-# Each process has its own namespace, so the class attributes can be set by the
-# individual process and the accessed anywhere else, for example in the datasets
+# Each process has its own copy, so other processes can't interfere
 class MPWorkerInfo(object):
     """Contains the current worker information."""
 


### PR DESCRIPTION
*Description of changes:*
* Added multiprocessing support for metric calculation (inference)

I have measured speedups up to 3x on lager datasets like `m4_yearly` and up to 10% on smaller dataset like `m4_hourly`. Whats essentially limiting is the read/write speeds of the hard disk now. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
