### PR TITLE
Refactor wavenet model

### DIFF
--- a/src/gluonts/model/wavenet/_estimator.py
+++ b/src/gluonts/model/wavenet/_estimator.py
@@ -190,7 +190,7 @@ class WaveNetEstimator(GluonEstimator):
           2 * prediction_length.
         :param n_stacks: Number of dilation stacks in wavenet architecture
         :param train_window_length: Length of windows used for training. This should be
-          longer than context + prediction length. Larger values result in more efficient
+          longer than prediction length. Larger values result in more efficient
           reuse of computations for convolutions.
         :param temperature: Temparature used for sampling from softmax distribution.
           For temperature = 1.0 sampling is according to estimated probability.

--- a/src/gluonts/model/wavenet/_network.py
+++ b/src/gluonts/model/wavenet/_network.py
@@ -13,7 +13,7 @@
 
 # Standard library imports
 import math
-from typing import List
+from typing import List, Optional
 
 # Third-party imports
 import mxnet as mx
@@ -209,6 +209,145 @@ class WaveNet(nn.HybridBlock):
         )
         return sum(dilations) + 1
 
+    def is_last_layer(self, i):
+        return i + 1 == len(self.dilations)
+
+    def get_full_features(
+        self,
+        F,
+        feat_static_cat: Tensor,
+        past_observed_values: Tensor,
+        past_time_feat: Tensor,
+        future_time_feat: Tensor,
+        future_observed_values: Optional[Tensor],
+        scale: Tensor,
+    ):
+        """
+        Prepares the inputs for the network by repeating static feature and concatenating it with time features and
+        observed value indicator.
+
+        Parameters
+        ----------
+        F
+        feat_static_cat
+            Static categorical features: (batch_size, num_cat_features)
+        past_observed_values
+            Observed value indicator for the past target: (batch_size, receptive_field)
+        past_time_feat
+            Past time features: (batch_size, num_time_features, receptive_field)
+        future_time_feat
+            Future time features: (batch_size, num_time_features, pred_length)
+        future_observed_values
+            Observed value indicator for the future target: (batch_size, pred_length).
+            This will be set to all ones, if not provided (e.g., during prediction).
+        scale
+            scale of the time series: (batch_size, 1)
+        Returns
+        -------
+        Tensor
+            A tensor containing all the features ready to be passed through the network.
+            Shape: (batch_size, num_features, receptive_field + pred_length)
+        """
+        embedded_cat = self.feature_embedder(feat_static_cat)
+        static_feat = F.concat(embedded_cat, F.log(scale + 1.0), dim=1)
+        repeated_static_feat = F.repeat(
+            F.expand_dims(static_feat, axis=-1),
+            repeats=self.pred_length + self.receptive_field,
+            axis=-1,
+        )
+
+        if future_observed_values is None:
+            future_observed_values = (
+                F.slice_axis(future_time_feat, begin=0, end=1, axis=1)
+                .squeeze(axis=1)
+                .ones_like()
+            )
+        full_observed = F.expand_dims(
+            F.concat(past_observed_values, future_observed_values, dim=-1),
+            axis=1,
+        )
+        full_time_features = F.concat(past_time_feat, future_time_feat, dim=-1)
+        full_features = F.concat(
+            full_time_features, full_observed, repeated_static_feat, dim=1
+        )
+        return full_features
+
+    def target_feature_embedding(
+        self, F, target, features,
+    ):
+        """
+        Provides a joint embedding for the target and features.
+
+        Parameters
+        ----------
+        F
+        target: (batch_size, receptive_field + pred_length - 1)
+        features: (batch_size, num_features, sequence_length)
+
+        Returns
+        -------
+        Tensor
+            A tensor containing a joint embedding of target and features.
+            Shape: (batch_size, n_residue, sequence_length)
+
+        """
+        # (batch_size, embed_dim, sequence_length)
+        o = self.target_embed(target).swapaxes(1, 2)
+        o = F.concat(o, features, dim=1)
+        o = self.conv_project(o)
+        return o
+
+    def base_net(self, F, inputs, one_step_prediction=False, queues=None):
+        """
+        Forward pass through the wavenet.
+
+        Parameters
+        ----------
+        F
+        inputs
+            Inputs to the network: (batch_size, n_residue, sequence_length)
+        one_step_prediction
+            Flag indicating whether the network is "unrolled" one step at a time (prediction phase).
+        queues
+            Convolutional queues containing past computations. Should be provided if `one_step_prediction` is True.
+
+        Returns
+        -------
+        Tuple: (Tensor, List)
+            A tensor containing the unnormalized outputs of the wavenet. Shape: (batch_size, pred_length, num_bins).
+            A list containing the convolutional queues for each layer. The queue corresponding to layer `l` has
+            shape: (batch_size, n_residue, 2^l).
+        """
+        if one_step_prediction:
+            assert (
+                queues is not None
+            ), "Queues must not be empty during prediction phase!"
+        skip_outs = []
+        queues_next = []
+        o = inputs
+        for i, d in enumerate(self.dilations):
+            skip, o = self.residuals[i](o)
+            if one_step_prediction:
+                skip_trim = skip
+                if not self.is_last_layer(i):
+                    q = queues[i]
+                    o = F.concat(q, o, num_args=2, dim=-1)
+                    queues_next.append(
+                        F.slice_axis(o, begin=1, end=None, axis=-1)
+                    )
+            else:
+                skip_trim = F.slice_axis(
+                    skip, begin=self.trim_lengths[i], end=None, axis=-1
+                )
+            skip_outs.append(skip_trim)
+        y = sum(skip_outs)
+        y = self.output_act(y)
+        y = self.conv1(y)
+        y = self.output_act(y)
+        y = self.conv2(y)
+        unnormalized_output = y.swapaxes(1, 2)
+        return unnormalized_output, queues
+
     def hybrid_forward(
         self,
         F,
@@ -221,56 +360,32 @@ class WaveNet(nn.HybridBlock):
         future_observed_values: Tensor,
         scale: Tensor,
     ) -> Tensor:
-
-        embedded_cat = self.feature_embedder(feat_static_cat)
-        static_feat = F.concat(embedded_cat, F.log(scale + 1.0), dim=1)
-
         full_target = F.concat(past_target, future_target, dim=-1).astype(
             "int32"
+        )
+        full_features = self.get_full_features(
+            F,
+            feat_static_cat=feat_static_cat,
+            past_observed_values=past_observed_values,
+            past_time_feat=past_time_feat,
+            future_time_feat=future_time_feat,
+            future_observed_values=future_observed_values,
+            scale=scale,
+        )
+        embedding = self.target_feature_embedding(
+            F,
+            F.slice_axis(full_target, begin=0, end=-1, axis=-1),
+            F.slice_axis(full_features, begin=1, end=None, axis=-1),
+        )
+        unnormalized_output, _ = self.base_net(F, embedding)
+
+        label = F.slice_axis(
+            full_target, begin=self.receptive_field, end=None, axis=-1
         )
 
         full_observed = F.expand_dims(
             F.concat(past_observed_values, future_observed_values, dim=-1),
             axis=1,
-        )
-
-        full_time_features = F.concat(past_time_feat, future_time_feat, dim=-1)
-
-        repeated_static_feat = F.repeat(
-            F.expand_dims(static_feat, axis=-1),
-            repeats=self.pred_length + self.receptive_field,
-            axis=-1,
-        )
-
-        full_features = F.concat(
-            full_time_features, full_observed, repeated_static_feat, dim=1
-        )
-
-        # (batch_size, embed_dim, sequence_length)
-        o = self.target_embed(
-            F.slice_axis(full_target, begin=0, end=-1, axis=-1)
-        ).swapaxes(1, 2)
-        o = F.concat(
-            o, F.slice_axis(full_features, begin=1, end=None, axis=-1), dim=1
-        )
-        o = self.conv_project(o)
-
-        skip_outs = []
-        for i, d in enumerate(self.dilations):
-            skip, o = self.residuals[i](o)
-            skip_trim = F.slice_axis(
-                skip, begin=self.trim_lengths[i], end=None, axis=-1
-            )
-            skip_outs.append(skip_trim)
-        y = sum(skip_outs)
-        y = self.output_act(y)
-        y = self.conv1(y)
-        y = self.output_act(y)
-        y = self.conv2(y)
-        unnormalized_output = y.swapaxes(1, 2)
-
-        label = F.slice_axis(
-            full_target, begin=self.receptive_field, end=None, axis=-1
         )
         loss_weight = F.slice_axis(
             full_observed, begin=self.receptive_field, end=None, axis=-1
@@ -323,6 +438,35 @@ class WaveNetSampler(WaveNet):
         with self.name_scope():
             self.post_transform = LookupValues(mx.nd.array(bin_values))
 
+    def get_initial_conv_queues(self, F, past_target, features):
+        """
+        Build convolutional queues saving intermediate computations.
+
+        Parameters
+        ----------
+        F
+        past_target: (batch_size, receptive_field)
+        features: (batch_size, num_features, receptive_field)
+
+        Returns
+        -------
+        List
+            A list containing the convolutional queues for each layer. The queue corresponding to layer `l` has
+            shape: (batch_size, n_residue, 2^l).
+        """
+        o = self.target_feature_embedding(F, past_target, features)
+
+        queues = []
+        for i, d in enumerate(self.dilations):
+            sz = 1 if d == 2 ** (self.dilation_depth - 1) else d * 2
+            _, o = self.residuals[i](o)
+            if not self.is_last_layer(i):
+                o_chunk = F.slice_axis(o, begin=-sz - 1, end=-1, axis=-1)
+            else:
+                o_chunk = o
+            queues.append(o_chunk)
+        return queues
+
     def hybrid_forward(
         self,
         F,
@@ -333,43 +477,21 @@ class WaveNetSampler(WaveNet):
         future_time_feat: Tensor,
         scale: Tensor,
     ) -> Tensor:
-
-        embedded_cat = self.feature_embedder(feat_static_cat)
-        static_feat = F.concat(embedded_cat, F.log(scale + 1.0), dim=1)
-
-        past_target = past_target.astype("int32")
-
         def blow_up(u):
             """
             Expand to (batch_size x num_samples)
             """
             return F.repeat(u, repeats=self.num_samples, axis=0)
 
-        def is_last_layer(i):
-            return i + 1 == len(self.dilations)
-
-        queues = []
-
-        full_time_features = F.concat(past_time_feat, future_time_feat, dim=-1)
-
-        future_observed_values = F.slice_axis(
-            future_time_feat, begin=0, end=1, axis=1
-        ).ones_like()
-
-        full_observed = F.concat(
-            F.expand_dims(past_observed_values, axis=1),
-            future_observed_values,
-            dim=-1,
-        )
-
-        repeated_static_feat = F.repeat(
-            F.expand_dims(static_feat, axis=-1),
-            repeats=self.pred_length + self.receptive_field,
-            axis=-1,
-        )
-
-        full_features = F.concat(
-            full_time_features, full_observed, repeated_static_feat, dim=1
+        past_target = past_target.astype("int32")
+        full_features = self.get_full_features(
+            F,
+            feat_static_cat=feat_static_cat,
+            past_observed_values=past_observed_values,
+            past_time_feat=past_time_feat,
+            future_time_feat=future_time_feat,
+            future_observed_values=None,
+            scale=scale,
         )
 
         feature_slice = F.slice_axis(
@@ -378,70 +500,47 @@ class WaveNetSampler(WaveNet):
             end=None,
             axis=-1,
         )
-
-        tmp = F.slice_axis(
-            past_target, begin=-self.receptive_field, end=None, axis=-1
-        )
-        o = self.target_embed(tmp).swapaxes(1, 2)
-        o = F.concat(
-            o,
-            F.slice_axis(
+        queues = self.get_initial_conv_queues(
+            F,
+            past_target=F.slice_axis(
+                past_target, begin=-self.receptive_field, end=None, axis=-1
+            ),
+            features=F.slice_axis(
                 feature_slice, begin=-self.receptive_field, end=None, axis=-1
             ),
-            dim=1,
         )
-        o = self.conv_project(o)
-
-        for i, d in enumerate(self.dilations):
-            sz = 1 if d == 2 ** (self.dilation_depth - 1) else d * 2
-            _, o = self.residuals[i](o)
-            if not is_last_layer(i):
-                o_chunk = F.slice_axis(o, begin=-sz - 1, end=-1, axis=-1)
-            else:
-                o_chunk = o
-            queues.append(blow_up(o_chunk))
+        queues = [blow_up(queue) for queue in queues]
 
         res = F.slice_axis(past_target, begin=-2, end=None, axis=-1)
         res = blow_up(res)
-
         for n in range(self.pred_length):
-            queues_next = []
-            o = self.target_embed(
-                F.slice_axis(res, begin=-2, end=None, axis=-1)
-            ).swapaxes(1, 2)
-            b = F.slice_axis(
+            # Generate one-step ahead predictions. The input consists of target and features
+            # corresponding to the last two time steps.
+            current_target = F.slice_axis(res, begin=-2, end=None, axis=-1)
+            current_features = F.slice_axis(
                 full_features,
                 begin=self.receptive_field + n - 1,
                 end=self.receptive_field + n + 1,
                 axis=-1,
             )
-            b = blow_up(b)
-            o = F.concat(o, b, dim=1)
-            o = self.conv_project(o)
+            embedding = self.target_feature_embedding(
+                F, target=current_target, features=blow_up(current_features),
+            )
 
-            skip_outs = []
-            for i, d in enumerate(self.dilations):
-                skip, o = self.residuals[i](o)
-                skip_outs.append(skip)
-                if not is_last_layer(i):
-                    q = queues[i]
-                    o = F.concat(q, o, num_args=2, dim=-1)
-                    queues_next.append(
-                        F.slice_axis(o, begin=1, end=None, axis=-1)
-                    )
-            queues = queues_next
-            y = sum(skip_outs)
-            y = self.output_act(y)
-            y = self.conv1(y)
-            y = self.output_act(y)
-            unnormalized_outputs = self.conv2(y)
+            # (batch_size, 1, num_bins) where 1 corresponds to the time axis.
+            unnormalized_outputs, queues = self.base_net(
+                F, embedding, one_step_prediction=True, queues=queues
+            )
             if self.temperature > 0:
+                # (batch_size, 1, num_bins) where 1 corresponds to the time axis.
                 probs = F.softmax(
-                    unnormalized_outputs / self.temperature, axis=1
+                    unnormalized_outputs / self.temperature, axis=-1
                 )
-                y = F.sample_multinomial(probs.swapaxes(1, 2))
+                # (batch_size, 1)
+                y = F.sample_multinomial(probs)
             else:
-                y = F.argmax(unnormalized_outputs, axis=1)
+                # (batch_size, 1)
+                y = F.argmax(unnormalized_outputs, axis=-1)
             y = y.astype("int32")
             res = F.concat(res, y, num_args=2, dim=-1)
         samples = F.slice_axis(res, begin=-self.pred_length, end=None, axis=-1)


### PR DESCRIPTION
This PR refactors the wavenet model in particular the network by moving out the common code used by both training and prediction networks. 

Running `benchmark.py` to make sure there is no regression. Initial result on `m4_hourly` dataset looks okay.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
