### PR TITLE
Remove direct python-dateutil dependency.

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,3 @@
-boto3~=1.0
 holidays>=0.9,<0.10
 matplotlib~=3.0
 numpy~=1.18

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,3 @@
-# fixes conflict with dateutil requirement
-# see: https://github.com/boto/botocore/commit/e87e7a745fd972815b235a9ee685232745aa94f9
-python-dateutil==2.8.0
-
 boto3~=1.0
 holidays>=0.9,<0.10
 matplotlib~=3.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
