### PR TITLE
Relax numpy requirement

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 holidays>=0.9,<0.10
 matplotlib~=3.0
-numpy~=1.18
+numpy~=1.16
 pandas~=1.0
 pydantic~=1.1
 tqdm~=4.23


### PR DESCRIPTION
*Description of changes:* Making the requirement on numpy a superset of the one imposed by mxnet 1.6.0 (see https://github.com/apache/incubator-mxnet/blob/1.6.0/python/setup.py#L33).

This may be needed in environments that come with pre-packaged mxnet 1.6.0 and a minimal requirement on numpy and no easy way to update it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
