### PR TITLE
Remove deprecated features

### DIFF
--- a/src/gluonts/dataset/parallelized_loader.py
+++ b/src/gluonts/dataset/parallelized_loader.py
@@ -22,7 +22,7 @@ import io
 import random
 import sys
 import time
-from collections import Sized
+from collections.abc import Sized
 from typing import Callable, Iterable, Optional, List
 
 import multiprocessing

--- a/src/gluonts/evaluation/_base.py
+++ b/src/gluonts/evaluation/_base.py
@@ -15,7 +15,6 @@
 import logging
 import multiprocessing
 import re
-from collections import Sized
 from functools import lru_cache
 from itertools import chain, tee
 from typing import (

--- a/src/gluonts/support/util.py
+++ b/src/gluonts/support/util.py
@@ -47,12 +47,12 @@ class Timer:
     """Context manager for measuring the time of enclosed code fragments."""
 
     def __enter__(self):
-        self.start = time.clock()
+        self.start = time.perf_counter()
         self.interval = None
         return self
 
     def __exit__(self, *args):
-        self.end = time.clock()
+        self.end = time.perf_counter()
         self.interval = self.end - self.start
 
 


### PR DESCRIPTION
*Description of changes:* Apparently `time.clock()` and `from collection import <some-ABC>` are deprecated and removed in Python 3.8 and 3.9 respectively. Fixing their usage since they pollute the logs with warnings.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
