### PR TITLE
Fix pydanitc `create_model` usage.

### DIFF
--- a/src/gluonts/core/component.py
+++ b/src/gluonts/core/component.py
@@ -389,15 +389,13 @@ def validated(base_model=None):
 
         if base_model is None:
             PydanticModel = create_model(
-                model_name=f"{init_clsnme}Model",
+                f"{init_clsnme}Model",
                 __config__=BaseValidatedInitializerModel.Config,
                 **init_fields,
             )
         else:
             PydanticModel = create_model(
-                model_name=f"{init_clsnme}Model",
-                __base__=base_model,
-                **init_fields,
+                f"{init_clsnme}Model", __base__=base_model, **init_fields,
             )
 
         def validated_repr(self) -> str:


### PR DESCRIPTION
Fixes #767

The `model_name` argument was renamed to `__model_name` in
[1367](https://github.com/samuelcolvin/pydantic/pull/1367).

This change ensure that our code works with both future and past
versions of pydantic.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
