### PR TITLE
Run unstable tests in separate environments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         python-version: [3.6, 3.7]
         platform: [ubuntu-latest, windows-latest]
-        pytest-parameters: [--ignore=test/model/unstable_tests, test/model/unstable_tests]
+        pytest-parameters: [test --ignore=test/model/unstable_tests, test/model/unstable_tests]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -30,4 +30,4 @@ jobs:
         pip install -r requirements/requirements-extras-m-competitions.txt
     - name: Test with pytest
       run: |
-        pytest -m 'not (gpu or serial)' ${{ matrix.pytest-parameters }} --cov src/gluonts --cov-report=term --cov-report xml test
+        pytest -m 'not (gpu or serial)' ${{ matrix.pytest-parameters }} --cov src/gluonts --cov-report=term --cov-report xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         python-version: [3.6, 3.7]
         platform: [ubuntu-latest, windows-latest]
-    
+        pytest-parameters: [--ignore=test/model/unstable_tests, test/model/unstable_tests]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -30,4 +30,4 @@ jobs:
         pip install -r requirements/requirements-extras-m-competitions.txt
     - name: Test with pytest
       run: |
-        pytest -m 'not (gpu or serial)' --cov src/gluonts --cov-report=term --cov-report xml test
+        pytest -m 'not (gpu or serial)' ${{ matrix.pytest-parameters }} --cov src/gluonts --cov-report=term --cov-report xml test

--- a/test/model/unstable_tests/test_deepstate.py
+++ b/test/model/unstable_tests/test_deepstate.py
@@ -15,7 +15,6 @@ import pytest
 
 from gluonts.model.deepstate import DeepStateEstimator
 
-
 @pytest.fixture()
 def hyperparameters(dsinfo):
     return dict(
@@ -33,9 +32,7 @@ def hyperparameters(dsinfo):
         use_symbol_block_predictor=False,
     )
 
-def test_repr(repr_test, hyperparameters):
-    repr_test(DeepStateEstimator, hyperparameters)
+def test_accuracy(accuracy_test, hyperparameters):
+    hyperparameters.update(num_batches_per_epoch=100)
 
-
-def test_serialize(serialize_test, hyperparameters):
-    serialize_test(DeepStateEstimator, hyperparameters)
+    accuracy_test(DeepStateEstimator, hyperparameters, accuracy=0.5)

--- a/test/model/wavenet/test_model.py
+++ b/test/model/wavenet/test_model.py
@@ -12,7 +12,6 @@
 # permissions and limitations under the License.
 
 import pytest
-import sys
 
 from gluonts.model.wavenet import WaveNetEstimator
 
@@ -31,18 +30,6 @@ def hyperparameters(dsinfo):
         use_symbol_block_predictor=False,
         cardinality=[dsinfo.cardinality],
     )
-
-
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="test times out for some reason"
-)
-@pytest.mark.parametrize("hybridize", [True, False])
-def test_accuracy(accuracy_test, hyperparameters, hybridize):
-    hyperparameters.update(num_batches_per_epoch=10, hybridize=hybridize)
-
-    # large value as this test is breaking frequently
-    accuracy_test(WaveNetEstimator, hyperparameters, accuracy=0.7)
-
 
 def test_repr(repr_test, hyperparameters):
     repr_test(WaveNetEstimator, hyperparameters)


### PR DESCRIPTION
*Issue #, if available:*764

*Description of changes:*
This commit splits up the troublesome tests of models into two parts, one stable and one unstable part. 
The unstable part of the tests are moved to a new file and are run during a seperate test execution.

The unstable parts of the tests are moved to the folder:

`/tests/model/unstable_tests/test_name.py`

for example the troublesome parts of the file:

`tests/model/deepstate/test_model.py`

is moved to:

`/tests/model/unstable_tests/test_deepstate.py`

In order to run these tests after a pull request ive modified the file:

`.github/workflows/tests.yml`

More specifically the change made should allow for the tests to run in parallel. However since this file is run on GitHub itself I have not been able to try this locally. I did however try partial changes on a private github repo.

The change

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
