### PR TITLE
Make data loader test flaky

### DIFF
--- a/test/dataset/test_multiprocessing_loader.py
+++ b/test/dataset/test_multiprocessing_loader.py
@@ -202,6 +202,7 @@ def test_validation_loader_equivalence() -> None:
     ), "Batches in incorrect context"
 
 
+@flaky(max_runs=5, min_passes=1)
 @pytest.mark.parametrize(
     "num_workers",
     [i for i in [None, 1, 2,] if i is None or i <= mp.cpu_count()],


### PR DESCRIPTION
*Description of changes:* one of the multiprocessing data loader tests is flaky and will likely block PRs going ahead; declaring it flaky. Note that this test is inherently noisy at the moment, since it’s hard to guarantee that workers goes through their respective subsets of the data the same number of times. In order to guarantee that, we would need to change the way batches are pulled out of the workers outputs 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
