### PR TITLE
Scaler for (N,T,C) and (N,C,T) tensors

### DIFF
--- a/src/gluonts/block/scaler.py
+++ b/src/gluonts/block/scaler.py
@@ -31,8 +31,8 @@ class Scaler(nn.HybridBlock):
     keepdims
         toggle to keep the dimension of the input tensor.
     input_NTC
-        toggle the shape of the input tensors from the default (N, T, C)
-        to (N, C, T) when this is False.
+        specify the shape of the input tensors either the default (N, T, C)
+        or (N, C, T) when this is False.
     """
 
     def __init__(self, keepdims: bool = False, input_NTC: bool = True):
@@ -52,7 +52,7 @@ class Scaler(nn.HybridBlock):
             API in MXNet.
 
         data
-            tensor of shape (N, T, C) containing the data to be scaled
+            tensor of shape (N, T, C) or (N, C, T) containing the data to be scaled.
 
         observed_indicator
             observed_indicator: binary tensor with the same shape as

--- a/src/gluonts/block/scaler.py
+++ b/src/gluonts/block/scaler.py
@@ -31,8 +31,8 @@ class Scaler(nn.HybridBlock):
     keepdims
         toggle to keep the dimension of the input tensor.
     input_NTC
-        specify the shape of the input tensors to the default (N, T, C)
-        or (N, C, T) when this is False.
+        toggle the shape of the input tensors from the default (N, T, C)
+        to (N, C, T) when this is False.
     """
 
     def __init__(self, keepdims: bool = False, input_NTC: bool = True):

--- a/src/gluonts/block/scaler.py
+++ b/src/gluonts/block/scaler.py
@@ -30,12 +30,16 @@ class Scaler(nn.HybridBlock):
     ----------
     keepdims
         toggle to keep the dimension of the input tensor.
+    input_NTC
+        specify the shape of the input tensors to the default (N, T, C)
+        or (N, C, T) when this is False.
     """
 
-    def __init__(self, keepdims: bool = False):
+    def __init__(self, keepdims: bool = False, input_NTC: bool = True):
 
         super().__init__()
         self.keepdims = keepdims
+        self.axis = 1 if input_NTC else 2
 
     def compute_scale(self, F, data: Tensor, observed_indicator: Tensor):
         """
@@ -69,7 +73,7 @@ class Scaler(nn.HybridBlock):
             API in MXNet.
 
         data
-            tensor of shape (N, T, C) containing the data to be scaled
+            tensor of shape (N, T, C) or (N, C, T) containing the data to be scaled.
 
         observed_indicator
             observed_indicator: binary tensor with the same shape as
@@ -79,7 +83,7 @@ class Scaler(nn.HybridBlock):
         Returns
         -------
         Tensor
-            Tensor containing the "scaled" data, shape: (N, T, C).
+            Tensor containing the "scaled" data, shape: (N, T, C) or (N, C, T).
         Tensor
             Tensor containing the scale, of shape (N, C) if ``keepdims == False``, and shape
             (N, 1, C) if ``keepdims == True``.
@@ -88,10 +92,10 @@ class Scaler(nn.HybridBlock):
         scale = self.compute_scale(F, data, observed_indicator)
 
         if self.keepdims:
-            scale = scale.expand_dims(axis=1)
+            scale = scale.expand_dims(axis=self.axis)
             return F.broadcast_div(data, scale), scale
         else:
-            return F.broadcast_div(data, scale.expand_dims(axis=1)), scale
+            return F.broadcast_div(data, scale.expand_dims(axis=self.axis)), scale
 
 
 class MeanScaler(Scaler):
@@ -114,7 +118,7 @@ class MeanScaler(Scaler):
         self.minimum_scale = minimum_scale
 
     def compute_scale(
-        self, F, data: Tensor, observed_indicator: Tensor  # shapes (N, T, C)
+        self, F, data: Tensor, observed_indicator: Tensor  # shapes (N, T, C) or (N, C, T)
     ) -> Tensor:
         """
         Parameters
@@ -124,7 +128,7 @@ class MeanScaler(Scaler):
             API in MXNet.
 
         data
-            tensor of shape (N, T, C) containing the data to be scaled
+            tensor of shape (N, T, C) or (N, C, T) containing the data to be scaled.
 
         observed_indicator
             observed_indicator: binary tensor with the same shape as
@@ -139,8 +143,8 @@ class MeanScaler(Scaler):
         """
 
         # these will have shape (N, C)
-        num_observed = F.sum(observed_indicator, axis=1)
-        sum_observed = (data.abs() * observed_indicator).sum(axis=1)
+        num_observed = F.sum(observed_indicator, axis=self.axis)
+        sum_observed = (data.abs() * observed_indicator).sum(axis=self.axis)
 
         # first compute a global scale per-dimension
         total_observed = num_observed.sum(axis=0)
@@ -185,7 +189,7 @@ class NOPScaler(Scaler):
             API in MXNet.
 
         data
-            tensor of shape (N, T, C) containing the data to be scaled
+            tensor of shape (N, T, C) or (N, T, C) containing the data to be scaled.
 
         observed_indicator
             observed_indicator: binary tensor with the same shape as
@@ -197,4 +201,4 @@ class NOPScaler(Scaler):
         Tensor
             shape (N, C), identically equal to 1.
         """
-        return F.ones_like(data).mean(axis=1)
+        return F.ones_like(data).mean(axis=self.axis)

--- a/test/block/test_scaler.py
+++ b/test/block/test_scaler.py
@@ -210,4 +210,4 @@ def test_nopscaler(target, observed):
     target_scaled, scale = s(target, observed)
 
     assert mx.nd.norm(target - target_scaled) == 0
-    assert mx.nd.norm(mx.nd.ones_like(target).mean(axis=1) - scale) == 0
+    assert mx.nd.norm(mx.nd.ones_like(target).mean(axis=s.axis) - scale) == 0

--- a/test/block/test_scaler.py
+++ b/test/block/test_scaler.py
@@ -196,7 +196,7 @@ def test_scaler(s, target, observed, expected_scale):
         expected_target_scaled = mx.nd.broadcast_div(target, expected_scale)
     else:
         expected_target_scaled = mx.nd.broadcast_div(
-            target, expected_scale.expand_dims(axis=1)
+            target, expected_scale.expand_dims(axis=s.axis)
         )
 
     assert np.allclose(

--- a/test/block/test_scaler.py
+++ b/test/block/test_scaler.py
@@ -145,6 +145,11 @@ test_cases = [
         mx.nd.zeros(shape=(5, 30)),
         1e-10 * mx.nd.ones(shape=(5,)),
     ),
+        scaler.MeanScaler(input_NTC=False),
+        mx.nd.random.normal(shape=(5, 1, 30)),
+        mx.nd.zeros(shape=(5, 30)),
+        1e-10 * mx.nd.ones(shape=(5,)),
+    ),
     (
         scaler.MeanScaler(minimum_scale=1e-6),
         mx.nd.random.normal(shape=(5, 30, 1)),

--- a/test/block/test_scaler.py
+++ b/test/block/test_scaler.py
@@ -146,10 +146,10 @@ test_cases = [
         1e-10 * mx.nd.ones(shape=(5,)),
     ),
     (
-        scaler.MeanScaler(axis=2),
+        scaler.MeanScaler(axis=2, minimum_scale=1e-6),
         mx.nd.random.normal(shape=(5, 3, 30)),
         mx.nd.zeros(shape=(5, 3, 30)),
-        1e-12 * mx.nd.ones(shape=(5, 3)),
+        1e-6 * mx.nd.ones(shape=(5, 3)),
     ),
     (
         scaler.MeanScaler(minimum_scale=1e-6),

--- a/test/block/test_scaler.py
+++ b/test/block/test_scaler.py
@@ -147,9 +147,9 @@ test_cases = [
     ),
     (
         scaler.MeanScaler(axis=2),
-        mx.nd.random.normal(shape=(5, 1, 30)),
-        mx.nd.zeros(shape=(5, 30)),
-        1e-10 * mx.nd.ones(shape=(5,)),
+        mx.nd.random.normal(shape=(5, 3, 30)),
+        mx.nd.zeros(shape=(5, 3, 30)),
+        1e-12 * mx.nd.ones(shape=(5, 3)),
     ),
     (
         scaler.MeanScaler(minimum_scale=1e-6),

--- a/test/block/test_scaler.py
+++ b/test/block/test_scaler.py
@@ -145,6 +145,7 @@ test_cases = [
         mx.nd.zeros(shape=(5, 30)),
         1e-10 * mx.nd.ones(shape=(5,)),
     ),
+    (
         scaler.MeanScaler(axis=2),
         mx.nd.random.normal(shape=(5, 1, 30)),
         mx.nd.zeros(shape=(5, 30)),

--- a/test/block/test_scaler.py
+++ b/test/block/test_scaler.py
@@ -145,7 +145,7 @@ test_cases = [
         mx.nd.zeros(shape=(5, 30)),
         1e-10 * mx.nd.ones(shape=(5,)),
     ),
-        scaler.MeanScaler(input_NTC=False),
+        scaler.MeanScaler(axis=2),
         mx.nd.random.normal(shape=(5, 1, 30)),
         mx.nd.zeros(shape=(5, 30)),
         1e-10 * mx.nd.ones(shape=(5,)),


### PR DESCRIPTION
fixed the scaler to work on time first and time last shaped tensors.

*Issue #, if available:*
#765 

*Description of changes:*

The scaler now takes axis argument to specify the axis over which to calculate the scaling.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
