### PR TITLE
LSTNet fixes

### DIFF
--- a/src/gluonts/model/lstnet/_estimator.py
+++ b/src/gluonts/model/lstnet/_estimator.py
@@ -54,7 +54,7 @@ class LSTNetEstimator(GluonEstimator):
         The maximum number of steps to unroll the RNN for computing the predictions
         (Note that it is constraints by the Conv2D output size)
     num_series
-        Number of time-series (variants)
+        Number of time-series (covariates)
     skip_size
         Skip size for the skip RNN layer
     ar_window

--- a/src/gluonts/model/lstnet/_estimator.py
+++ b/src/gluonts/model/lstnet/_estimator.py
@@ -160,7 +160,7 @@ class LSTNetEstimator(GluonEstimator):
                     past_length=self.context_length,
                     future_length=self.prediction_length,
                     lead_time=self.lead_time,
-                    output_NTC=False,  # output NCT for first layer conv1d
+                    output_NTC=False,  # output NCT for first layer conv2d
                 ),
             ]
         )

--- a/src/gluonts/model/lstnet/_estimator.py
+++ b/src/gluonts/model/lstnet/_estimator.py
@@ -81,10 +81,14 @@ class LSTNetEstimator(GluonEstimator):
         Type of the RNN cell. Either `lstm` or `gru` (default: `gru`)
     rnn_num_layers
         Number of RNN layers to be used
+    rnn_num_cells
+        Number of RNN cells for each layer (default: 100)
     skip_rnn_cell_type
         Type of the RNN cell for the skip layer. Either `lstm` or `gru` (default: `gru`)
     skip_rnn_num_layers
         Number of RNN layers to be used for skip part
+    skip_rnn_num_cells
+        Number of RNN cells for each layer for skip part (default: 10)
     scaling
         Whether to automatically scale the target values (default: True)
     dtype

--- a/src/gluonts/model/lstnet/_estimator.py
+++ b/src/gluonts/model/lstnet/_estimator.py
@@ -43,7 +43,7 @@ class LSTNetEstimator(GluonEstimator):
     The model has been described in this paper:
     https://arxiv.org/abs/1703.07015
 
-    Note that this implementation will change over time and we furthre work on
+    Note that this implementation will change over time as we further work on
     this method.
 
     Parameters
@@ -52,17 +52,17 @@ class LSTNetEstimator(GluonEstimator):
         Frequency of the data to train and predict
     context_length
         The maximum number of steps to unroll the RNN for computing the predictions
-        (Note that it is constraints by the Conv1D output size)
+        (Note that it is constraints by the Conv2D output size)
     num_series
-        Number of time-series (variats)
+        Number of time-series (variants)
     skip_size
         Skip size for the skip RNN layer
     ar_window
         Auto-regressive window size for the linear part
     channels
-        Number of channels for first layer Conv1D
+        Number of channels for first layer Conv2D
     kernel_size
-        Kernel size for first layer Conv1D (default: 6)
+        Kernel size for first layer Conv2D (default: 6)
     prediction_length
         Length of the prediction p where given `(y_1, ..., y_t)` the model predicts
         `(y_{t+1}, ..., y_{t+p})` (default: None)
@@ -76,7 +76,7 @@ class LSTNetEstimator(GluonEstimator):
         Dropout regularization parameter (default: 0.2)
     output_activation
         The last activation to be used for output.
-        Accepts either `None` (default no activation), `sigmoid` or `tahn`
+        Accepts either `None` (default no activation), `sigmoid` or `tanh`
     rnn_cell_type
         Type of the RNN cell. Either `lstm` or `gru` (default: `gru`)
     rnn_num_layers
@@ -112,9 +112,11 @@ class LSTNetEstimator(GluonEstimator):
         dropout_rate: Optional[float] = 0.2,
         output_activation: Optional[str] = None,
         rnn_cell_type: str = "gru",
-        rnn_num_layers: int = 10,
+        rnn_num_cells: int = 100,
+        rnn_num_layers: int = 3,
         skip_rnn_cell_type: str = "gru",
-        skip_rnn_num_layers: int = 5,
+        skip_rnn_num_layers: int = 1,
+        skip_rnn_num_cells: int = 10,
         scaling: bool = True,
         dtype: DType = np.float32,
     ) -> None:
@@ -135,8 +137,10 @@ class LSTNetEstimator(GluonEstimator):
         self.output_activation = output_activation
         self.rnn_cell_type = rnn_cell_type
         self.rnn_num_layers = rnn_num_layers
+        self.rnn_num_cells = rnn_num_cells
         self.skip_rnn_cell_type = skip_rnn_cell_type
         self.skip_rnn_num_layers = skip_rnn_num_layers
+        self.skip_rnn_num_cells = skip_rnn_num_cells
         self.scaling = scaling
         self.dtype = dtype
 
@@ -160,7 +164,7 @@ class LSTNetEstimator(GluonEstimator):
                     time_series_fields=[FieldName.OBSERVED_VALUES],
                     past_length=self.context_length,
                     future_length=self.future_length,
-                    output_NTC=False,  # output NCT for first layer conv1d
+                    output_NTC=False,  # output NCT for first layer conv2d
                 ),
             ]
         )
@@ -172,8 +176,10 @@ class LSTNetEstimator(GluonEstimator):
             kernel_size=self.kernel_size,
             rnn_cell_type=self.rnn_cell_type,
             rnn_num_layers=self.rnn_num_layers,
+            rnn_num_cells=self.rnn_num_cells,
             skip_rnn_cell_type=self.skip_rnn_cell_type,
             skip_rnn_num_layers=self.skip_rnn_num_layers,
+            skip_rnn_num_cells=self.skip_rnn_num_cells,
             skip_size=self.skip_size,
             ar_window=self.ar_window,
             context_length=self.context_length,
@@ -194,8 +200,10 @@ class LSTNetEstimator(GluonEstimator):
             kernel_size=self.kernel_size,
             rnn_cell_type=self.rnn_cell_type,
             rnn_num_layers=self.rnn_num_layers,
+            rnn_num_cells=self.rnn_num_cells,
             skip_rnn_cell_type=self.skip_rnn_cell_type,
             skip_rnn_num_layers=self.skip_rnn_num_layers,
+            skip_rnn_num_cells=self.skip_rnn_num_cells,
             skip_size=self.skip_size,
             ar_window=self.ar_window,
             context_length=self.context_length,

--- a/src/gluonts/model/lstnet/_network.py
+++ b/src/gluonts/model/lstnet/_network.py
@@ -98,7 +98,7 @@ class LSTNetBase(nn.HybridBlock):
                 activation="relu",
                 layout="NCHW",
                 in_channels=1,
-            )  # NCT
+            )  # NC1T
             self.cnn.cast(dtype)
             self.dropout = nn.Dropout(dropout_rate)
             self.rnn = self._create_rnn_layer(

--- a/src/gluonts/model/lstnet/_network.py
+++ b/src/gluonts/model/lstnet/_network.py
@@ -210,7 +210,7 @@ class LSTNetBase(nn.HybridBlock):
         Tensor
             Shape (batch_size, num_series, 1) if `horizon` was specified
             and of shape (batch_size, num_series, prediction_length)
-            if `prediction_length` was provided           
+            if `prediction_length` was provided
         """
 
         scaled_past_target, scale = self.scaler(
@@ -311,10 +311,9 @@ class LSTNetTrain(LSTNetBase):
         pred, scale = super().hybrid_forward(
             F, past_target, past_observed_values
         )
-        loss = self.loss_fn(
+        return self.loss_fn(
             F.broadcast_mul(pred, scale.expand_dims(axis=-1)), future_target
         )
-        return loss
 
 
 class LSTNetPredict(LSTNetBase):

--- a/src/gluonts/model/lstnet/_network.py
+++ b/src/gluonts/model/lstnet/_network.py
@@ -170,7 +170,7 @@ class LSTNetBase(nn.HybridBlock):
 
         s, _ = self.skip_rnn.unroll(
             inputs=skip_c,
-            length=self.channel_skip_count,
+            length=self.conv_skip,
             layout="TNC",
             merge_outputs=True,
             begin_state=begin_state,
@@ -210,8 +210,7 @@ class LSTNetBase(nn.HybridBlock):
         Tensor
             Shape (batch_size, num_series, 1) if `horizon` was specified
             and of shape (batch_size, num_series, prediction_length)
-            if `prediction_length` was provided
-            
+            if `prediction_length` was provided           
         """
 
         scaled_past_target, scale = self.scaler(

--- a/src/gluonts/model/lstnet/_network.py
+++ b/src/gluonts/model/lstnet/_network.py
@@ -170,7 +170,7 @@ class LSTNetBase(nn.HybridBlock):
 
         s, _ = self.skip_rnn.unroll(
             inputs=skip_c,
-            length=self.conv_skip,
+            length=min(self.conv_skip, self.context_length),
             layout="TNC",
             merge_outputs=True,
             begin_state=begin_state,
@@ -243,7 +243,7 @@ class LSTNetBase(nn.HybridBlock):
 
         r, _ = self.rnn.unroll(
             inputs=r,
-            length=self.conv_out,
+            length=min(self.conv_out, self.context_length),
             layout="TNC",
             merge_outputs=True,
             begin_state=rnn_begin_state,

--- a/test/model/lstnet/test_lstnet.py
+++ b/test/model/lstnet/test_lstnet.py
@@ -55,7 +55,7 @@ freq = dataset.metadata.metadata.freq
         (0, dataset.metadata.prediction_length),
     ],
 )
-@pytest.mark.parametrize("hybridize", [False])
+@pytest.mark.parametrize("hybridize", [True, False])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_lstnet(
     skip_size, ar_window, lead_time, prediction_length, hybridize, dtype

--- a/test/model/lstnet/test_lstnet.py
+++ b/test/model/lstnet/test_lstnet.py
@@ -106,4 +106,4 @@ def test_lstnet(
     agg_metrics, item_metrics = evaluator(
         iter(tss), iter(forecasts), num_series=len(dataset.test)
     )
-    assert agg_metrics["ND"] < 0.21
+    assert agg_metrics["ND"] < 0.25

--- a/test/model/lstnet/test_lstnet.py
+++ b/test/model/lstnet/test_lstnet.py
@@ -55,7 +55,7 @@ freq = dataset.metadata.metadata.freq
         (0, dataset.metadata.prediction_length),
     ],
 )
-@pytest.mark.parametrize("hybridize", [True, False])
+@pytest.mark.parametrize("hybridize", [False])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_lstnet(
     skip_size, ar_window, lead_time, prediction_length, hybridize, dtype
@@ -63,9 +63,9 @@ def test_lstnet(
     estimator = LSTNetEstimator(
         skip_size=skip_size,
         ar_window=ar_window,
-        num_series=10,
+        num_series=NUM_SAMPLES,
         channels=6,
-        kernel_size=3,
+        kernel_size=2,
         context_length=4,
         freq=freq,
         lead_time=lead_time,
@@ -106,4 +106,4 @@ def test_lstnet(
     agg_metrics, item_metrics = evaluator(
         iter(tss), iter(forecasts), num_series=len(dataset.test)
     )
-    assert agg_metrics["ND"] < 1.5
+    assert agg_metrics["ND"] < 0.21

--- a/test/model/lstnet/test_lstnet.py
+++ b/test/model/lstnet/test_lstnet.py
@@ -63,7 +63,7 @@ def test_lstnet(
     estimator = LSTNetEstimator(
         skip_size=skip_size,
         ar_window=ar_window,
-        num_series=NUM_SAMPLES,
+        num_series=NUM_SERIES,
         channels=6,
         kernel_size=2,
         context_length=4,

--- a/test/model/lstnet/test_lstnet.py
+++ b/test/model/lstnet/test_lstnet.py
@@ -106,4 +106,4 @@ def test_lstnet(
     agg_metrics, item_metrics = evaluator(
         iter(tss), iter(forecasts), num_series=len(dataset.test)
     )
-    assert agg_metrics["ND"] < 0.25
+    assert agg_metrics["ND"] < 0.5


### PR DESCRIPTION
We need to use a Conv2D with appropriate kernel size

*Issue #, if available:*

*Description of changes:*
We now use the appropriate scaling and the loss takes it into account, and more importantly the Convolution has to be 2D with kernel size ` (num_series, kernel_size)`. 

We also need the hidden sizes of the two RNNs to be specified as they are not `channels`. 

I will debug the method shortly, but hopefully this describes the issues with the current implementation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
