### PR TITLE
Fix lstnet scaling by circumventing defer init bug

### DIFF
--- a/test/model/lstnet/test_lstnet.py
+++ b/test/model/lstnet/test_lstnet.py
@@ -56,9 +56,16 @@ freq = dataset.metadata.metadata.freq
     ],
 )
 @pytest.mark.parametrize("hybridize", [True, False])
+@pytest.mark.parametrize("scaling", [True, False])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_lstnet(
-    skip_size, ar_window, lead_time, prediction_length, hybridize, dtype
+    skip_size,
+    ar_window,
+    lead_time,
+    prediction_length,
+    hybridize,
+    scaling,
+    dtype,
 ):
     estimator = LSTNetEstimator(
         skip_size=skip_size,
@@ -73,6 +80,7 @@ def test_lstnet(
         trainer=Trainer(
             epochs=1, batch_size=2, learning_rate=0.01, hybridize=hybridize
         ),
+        scaling=scaling,
         dtype=dtype,
     )
 
@@ -106,4 +114,4 @@ def test_lstnet(
     agg_metrics, item_metrics = evaluator(
         iter(tss), iter(forecasts), num_series=len(dataset.test)
     )
-    assert agg_metrics["ND"] < 0.5
+    assert agg_metrics["ND"] < 1.0


### PR DESCRIPTION
*Description of changes:*

The known deferred init [bug](https://github.com/apache/incubator-mxnet/issues/14373) prevents using `scaling=False` in hybridized mode. This is a work around at the expense of some computation until it's fix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
