### PR TITLE
Fix LSTNet observed indicator usage

### DIFF
--- a/src/gluonts/model/lstnet/_network.py
+++ b/src/gluonts/model/lstnet/_network.py
@@ -295,6 +295,7 @@ class LSTNetTrain(LSTNetBase):
         past_target: Tensor,
         past_observed_values: Tensor,
         future_target: Tensor,
+        future_observed_values: Tensor,
     ) -> Tensor:
         """
         Computes the training l1 loss for LSTNet for multivariate time-series.
@@ -309,6 +310,8 @@ class LSTNetTrain(LSTNetBase):
             Tensor of shape (batch_size, num_series, context_length)
         future_target
             Tensor of shape (batch_size, num_series, prediction_length)
+        future_observed_values
+            Tensor of shape (batch_size, num_series, prediction_length)
 
         Returns
         -------
@@ -319,7 +322,11 @@ class LSTNetTrain(LSTNetBase):
         pred, scale = super().hybrid_forward(
             F, past_target, past_observed_values
         )
-        return self.loss_fn(F.broadcast_mul(pred, scale), future_target)
+        return self.loss_fn(
+            F.broadcast_mul(pred, scale),
+            future_target,
+            future_observed_values,
+        )
 
 
 class LSTNetPredict(LSTNetBase):

--- a/test/model/lstnet/test_lstnet.py
+++ b/test/model/lstnet/test_lstnet.py
@@ -45,8 +45,8 @@ dataset = load_multivariate_constant_dataset()
 freq = dataset.metadata.metadata.freq
 
 
-@pytest.mark.parametrize("skip_size", [1, 2])
-@pytest.mark.parametrize("ar_window", [1, 2])
+@pytest.mark.parametrize("skip_size", [2])
+@pytest.mark.parametrize("ar_window", [3])
 @pytest.mark.parametrize(
     "lead_time, prediction_length",
     [

--- a/test/model/lstnet/test_lstnet.py
+++ b/test/model/lstnet/test_lstnet.py
@@ -19,7 +19,6 @@ import pandas as pd
 # First-party imports
 from gluonts.dataset.artificial import constant_dataset
 from gluonts.dataset.common import TrainDatasets
-from gluonts.evaluation.backtest import backtest_metrics
 from gluonts.model.lstnet import LSTNetEstimator
 from gluonts.trainer import Trainer
 from gluonts.dataset.multivariate_grouper import MultivariateGrouper
@@ -56,9 +55,16 @@ freq = dataset.metadata.metadata.freq
     ],
 )
 @pytest.mark.parametrize("hybridize", [True, False])
+@pytest.mark.parametrize("scaling", [True, False])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_lstnet(
-    skip_size, ar_window, lead_time, prediction_length, hybridize, dtype
+    skip_size,
+    ar_window,
+    lead_time,
+    prediction_length,
+    hybridize,
+    scaling,
+    dtype,
 ):
     estimator = LSTNetEstimator(
         skip_size=skip_size,
@@ -73,6 +79,7 @@ def test_lstnet(
         trainer=Trainer(
             epochs=1, batch_size=2, learning_rate=0.01, hybridize=hybridize
         ),
+        scaling=scaling,
         dtype=dtype,
     )
 
@@ -106,4 +113,4 @@ def test_lstnet(
     agg_metrics, item_metrics = evaluator(
         iter(tss), iter(forecasts), num_series=len(dataset.test)
     )
-    assert agg_metrics["ND"] < 0.5
+    assert agg_metrics["ND"] < 1.0


### PR DESCRIPTION
*Issue #, if available:* Addresses the same issue as #802 

*Description of changes:* This PR addresses the same issue as #802 (issues with scaling=False and hybridize=True) by
* using the observed indicator as input to the model blocks (CNN and FF)

Furthermore
* future observed indicator is added to the training network and used to mask the loss
* tests updates are copied from #802, except that the number of test cases is here reduced

cc @ehsanmok 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
