### PR TITLE
fix bug local variable 'lv' referenced before assignment

### DIFF
--- a/src/gluonts/trainer/_base.py
+++ b/src/gluonts/trainer/_base.py
@@ -226,7 +226,7 @@ class Trainer:
                     tic = time.time()
 
                     epoch_loss = mx.metric.Loss()
-
+                    global lv
                     with tqdm(batch_iter) as it:
                         for batch_no, data_entry in enumerate(it, start=1):
                             if self.halt:


### PR DESCRIPTION
*Issue #, if available:*
When i train with validate data like this: 
predictor = estimator.train(training_data = train, validation_data =valid)
I got problem: 

> UnboundLocalError: local variable 'lv' referenced before assignment

*Description of changes:*

I make lv is global variable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
