### PR TITLE
Disable TQDM when running on SageMaker.

### DIFF
--- a/src/gluonts/gluonts_tqdm.py
+++ b/src/gluonts/gluonts_tqdm.py
@@ -22,10 +22,17 @@ from tqdm import tqdm as _tqdm
 # from tqdm.auto import tqdm as _tqdm
 
 
+USE_TQDM = True
+
+
 @functools.wraps(_tqdm)
-def tqdm(*args, **kwargs):
+def tqdm(it, *args, **kwargs):
+    # we want to be able to disable TQDM, for example when running in sagemaker
+    if not USE_TQDM:
+        return it
+
     kwargs = kwargs.copy()
     if not sys.stdout.isatty():
         kwargs.update(mininterval=10.0)
 
-    return _tqdm(*args, **kwargs)
+    return _tqdm(it, *args, **kwargs)

--- a/src/gluonts/shell/__main__.py
+++ b/src/gluonts/shell/__main__.py
@@ -179,6 +179,12 @@ def train_command(data_path: str, forecaster: Optional[str]) -> None:
 
 if __name__ == "__main__":
     import logging
+    import os
+
+    from gluonts import gluonts_tqdm
+
+    if "TRAINING_JOB_NAME" in os.environ:
+        gluonts_tqdm.USE_TQDM = False
 
     logging.basicConfig(
         level=logging.INFO,


### PR DESCRIPTION
When running on SageMaker, the logs get botched like this:

```
[2020-05-06 19:37:08] [INFO] gluonts.trainer Epoch[1] Learning rate is 0.001
#015  0%|          | 0/250 [00:00<?, ?it/s]#015 61%|██████    | 153/250 [00:10<00:06, 15.20it/s, epoch=2/250, avg_epoch_loss=21.7]#015100%|██████████| 250/250 [00:16<00:00, 15.24it/s, epoch=2/250, avg_epoch_loss=20.7]
[2020-05-06 19:37:25] [INFO] gluonts.trainer Epoch[1] Elapsed time 16.403 seconds
```

By checking for [`TRAINING_JOB_NAME`](https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-training-algo-running-container.html) we can test whether we are running on SageMaker and just turn the progress bar off.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
