### PR TITLE
fix scaling in negative binomial

### DIFF
--- a/src/gluonts/distribution/neg_binomial.py
+++ b/src/gluonts/distribution/neg_binomial.py
@@ -130,7 +130,9 @@ class NegativeBinomialOutput(DistributionOutput):
         else:
             F = getF(mu)
             mu = F.broadcast_mul(mu, scale)
-            alpha = F.broadcast_add(alpha, F.broadcast_div(scale - 1, mu))
+            alpha = F.broadcast_add(
+                alpha, F.broadcast_div(scale - 1, F.broadcast_mul(scale, mu))
+            )
             return NegativeBinomial(mu, alpha, F)
 
     @property


### PR DESCRIPTION
*Issue #, if available:* #718

*Description of changes:* From the relationship with mean and standard deviation, the scaled parameter `alpha` should be `alpha' = alpha + (nu-1)/(nu*mu)`. The latest fix just missed `nu` in the denominator.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
