### PR TITLE
Fix NegativeBinomial scaling

### DIFF
--- a/src/gluonts/distribution/neg_binomial.py
+++ b/src/gluonts/distribution/neg_binomial.py
@@ -129,6 +129,7 @@ class NegativeBinomialOutput(DistributionOutput):
             return NegativeBinomial(mu, alpha)
         else:
             F = getF(mu)
+            scale = 1.0 + softplus(F, scale - 1.0)
             mu = F.broadcast_mul(mu, scale)
             alpha = F.broadcast_add(alpha, F.broadcast_div(scale - 1, mu))
             return NegativeBinomial(mu, alpha, F)


### PR DESCRIPTION
*Issue #, if available:* #718 #719 and may be related to #636 

*Description of changes:* The scaling of `alpha` in #719 only makes sense if `scale >= 1.0`, otherwise the scaled `alpha` can become negative. Intuitively this makes a lot of sense for count data, which can only really be upscaled and not downscaled.

This PR makes sure that that's the case. Essentially, if `scale < 1.0` then it is set to `1.0`.

As a minimum working example, consider the following snippet:

```python
import numpy as np
import pandas as pd

import matplotlib.pyplot as plt

from gluonts.model.simple_feedforward import SimpleFeedForwardEstimator
from gluonts.distribution import NegativeBinomialOutput
from gluonts.dataset.common import ListDataset
from gluonts.trainer import Trainer

data = np.random.negative_binomial(n=3, p=0.9, size=(200,))

data_series = pd.Series(
    data=data,
    index=pd.date_range(
        start='2014-01-05 00:00:00',
        periods=len(data),
        freq='w'
    )
)

dataset = ListDataset(
    data_iter=[
        {
            "start": '2014-01-05 00:00:00',
            "target": list(data)
        }
    ],
    freq="w"
)

estimator = SimpleFeedForwardEstimator(
    freq="w",
    prediction_length=20,
    distr_output=NegativeBinomialOutput(),
    trainer=Trainer(epochs=10, hybridize=False),
)

predictor = estimator.train(dataset)

forecast = next(iter(predictor.predict(dataset)))
data_series.plot()
forecast.plot()
plt.show()
```

**Before the fix:**

```
Traceback (most recent call last):
  File "/Users/stellalo/gluon-ts/issues/issue_negbin.py", line 39, in <module>
    predictor = estimator.train(dataset)
  File "/Users/stellalo/gluon-ts/src/gluonts/model/estimator.py", line 252, in train
    training_data, validation_data, num_workers, num_prefetch, **kwargs
  File "/Users/stellalo/gluon-ts/src/gluonts/model/estimator.py", line 231, in train_model
    validation_iter=validation_data_loader,
  File "/Users/stellalo/gluon-ts/src/gluonts/trainer/_base.py", line 328, in __call__
    "Got NaN in first epoch. Try reducing initial learning rate."
gluonts.core.exception.GluonTSUserError: Got NaN in first epoch. Try reducing initial learning rate.
```

**After the fix:**

![issue_negbin](https://user-images.githubusercontent.com/433963/81402932-9e647f00-9132-11ea-9814-de9e69930c04.jpg)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
