### PR TITLE
add SampleForecast and Predictor objects for TPPs

### DIFF
--- a/src/gluonts/model/predictor.py
+++ b/src/gluonts/model/predictor.py
@@ -247,7 +247,7 @@ class GluonPredictor(Predictor):
     ctx
         MXNet context to use for computation
     forecast_generator
-        Class to generate forecasts from network ouputs
+        Class to generate forecasts from network outputs
     """
 
     BlockType = mx.gluon.Block

--- a/src/gluonts/model/tpp/__init__.py
+++ b/src/gluonts/model/tpp/__init__.py
@@ -1,0 +1,24 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from .forecast import PointProcessSampleForecast
+from .predictor import PointProcessGluonPredictor
+
+
+__all__ = ["PointProcessGluonPredictor", "PointProcessSampleForecast"]
+
+
+# fix Sphinx issues, see https://bit.ly/2K2eptM
+for item in __all__:
+    if hasattr(item, "__module__"):
+        setattr(item, "__module__", __name__)

--- a/src/gluonts/model/tpp/forecast.py
+++ b/src/gluonts/model/tpp/forecast.py
@@ -1,0 +1,163 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from typing import Dict, Optional, Union, cast
+
+# Third-party imports
+import mxnet as mx
+import numpy as np
+import pandas as pd
+
+# First-party imports
+from gluonts.model.forecast import OutputType, Forecast, Config
+from pandas import to_timedelta
+
+
+class PointProcessSampleForecast(Forecast):
+    """
+    Sample forecast object used for temporal point process inference.
+    Differs from standard forecast objects as it does not implement
+    fixed length samples. Each sample has a variable length, that is
+    kept in a separate :code:`valid_length` attribute.
+
+    Importantly, PointProcessSampleForecast does not implement some
+    methods (such as :code:`quantile` or :code:`plot`) that are available
+    in discrete time forecasts.
+
+    Parameters
+    ----------
+    samples
+        A multidimensional array of samples, of shape
+        (number_of_samples, max_pred_length, target_dim) or
+        (number_of_samples, max_pred_length). For marked TPP, the
+        target_dim is 2 with the first element keeping interarrival times
+        and the second keeping marks. If samples are two-dimensional, each
+        entry stands for the interarrival times in a (unmarked) TPP sample.
+    valid_length
+        An array of integers denoting the valid lengths of each sample
+        in :code:`samples`. That is, :code:`valid_length[0] == 2` implies
+        that only the first two entries of :code:`samples[0, ...]` are
+        valid "points".
+    start_date
+        Starting timestamp of the sample
+    freq
+        The time unit of interarrival times
+    prediction_interval_length
+        The length of the prediction interval for which samples were drawn.
+    item_id
+        Item ID, if available.
+    info
+        Optional dictionary of additional information.
+    """
+
+    prediction_interval_length: float
+
+    # not used
+    prediction_length = cast(int, None)
+    mean = None
+    _index = None
+
+    def __init__(
+        self,
+        samples: Union[mx.nd.NDArray, np.ndarray],
+        valid_length: Union[mx.nd.NDArray, np.ndarray],
+        start_date: pd.Timestamp,
+        freq: str,
+        prediction_interval_length: float,
+        item_id: Optional[str] = None,
+        info: Optional[Dict] = None,
+    ) -> None:
+        assert isinstance(
+            samples, (np.ndarray, mx.nd.NDArray)
+        ), "samples should be either a numpy or an mxnet array"
+        assert (
+            samples.ndim == 2 or samples.ndim == 3
+        ), f"samples should be a 2-dimensional or 3-dimensional array. Dimensions found: {samples.ndim}"
+
+        assert isinstance(
+            valid_length, (np.ndarray, mx.nd.NDArray)
+        ), "samples should be either a numpy or an mxnet array"
+        assert (
+            valid_length.ndim == 1
+        ), "valid_length should be a 1-dimensional array"
+        assert (
+            valid_length.shape[0] == samples.shape[0]
+        ), "valid_length and samples should have compatible dimensions"
+
+        self.samples, self.valid_length = (
+            x if isinstance(x, np.ndarray) else x.asnumpy()
+            for x in (samples, valid_length)
+        )
+
+        self._dim = samples.ndim
+        self.item_id = item_id
+        self.info = info
+
+        assert isinstance(
+            start_date, pd.Timestamp
+        ), "start_date should be a pandas Timestamp object"
+        self.start_date = start_date
+
+        assert isinstance(freq, str), "freq should be a string"
+        self.freq = freq
+
+        assert (
+            prediction_interval_length > 0
+        ), "prediction_interval_length must be greater than 0"
+        self.prediction_interval_length = prediction_interval_length
+
+        self.end_date = (
+            start_date
+            + to_timedelta(1, self.freq) * prediction_interval_length
+        )
+
+    def dim(self) -> int:
+        return self._dim
+
+    @property
+    def index(self) -> pd.DatetimeIndex:
+        raise AttributeError(
+            "Datetime index not defined for point process samples"
+        )
+
+    def as_json_dict(self, config: "Config") -> dict:
+        result = super().as_json_dict(config)
+
+        if OutputType.samples in config.output_types:
+            result["samples"] = self.samples.tolist()
+            result["valid_length"] = self.valid_length.tolist()
+
+        return result
+
+    def __repr__(self):
+        return ", ".join(
+            [
+                f"PointProcessSampleForecast({self.samples!r})",
+                f"{self.valid_length!r}",
+                f"{self.start_date!r}",
+                f"{self.end_date!r}",
+                f"{self.freq!r}",
+                f"item_id={self.item_id!r}",
+                f"info={self.info!r})",
+            ]
+        )
+
+    def quantile(self, q: Union[float, str]) -> np.ndarray:
+        raise NotImplementedError(
+            "Quantile function is not defined for point process samples"
+        )
+
+    def plot(self, **kwargs):
+        raise NotImplementedError(
+            "Plotting not implemented for point process samples"
+        )

--- a/src/gluonts/model/tpp/predictor.py
+++ b/src/gluonts/model/tpp/predictor.py
@@ -1,0 +1,189 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# Standard library imports
+from functools import partial
+from pathlib import Path
+from typing import Iterator, List, Optional, cast
+
+# Third-party imports
+import mxnet as mx
+import numpy as np
+
+# First-party imports
+from gluonts.core.component import DType
+from gluonts.dataset.common import Dataset
+from gluonts.dataset.loader import DataBatch, InferenceDataLoader
+from gluonts.dataset.parallelized_loader import batchify
+from gluonts.model.forecast import Forecast
+from gluonts.model.forecast_generator import ForecastGenerator
+from gluonts.model.predictor import (
+    GluonPredictor,
+    SymbolBlockPredictor,
+    OutputTransform,
+)
+from gluonts.transform import Transformation
+
+# Relative imports
+from .forecast import PointProcessSampleForecast
+
+
+class PointProcessForecastGenerator(ForecastGenerator):
+    def __call__(
+        self,
+        inference_data_loader: InferenceDataLoader,
+        prediction_net: mx.gluon.Block,
+        input_names: List[str],
+        freq: str,
+        output_transform: Optional[OutputTransform],
+        num_samples: Optional[int],
+        **kwargs,
+    ) -> Iterator[Forecast]:
+
+        for batch in inference_data_loader:
+            inputs = [batch[k] for k in input_names]
+
+            outputs, valid_length = (
+                x.asnumpy() for x in prediction_net(*inputs)
+            )
+
+            # sample until enough point process trajectories are collected
+            if num_samples:
+                num_collected_samples = outputs[0].shape[0]
+                collected_samples, collected_vls = [outputs], [valid_length]
+                while num_collected_samples < num_samples:
+                    outputs, valid_length = (
+                        x.asnumpy() for x in prediction_net(*inputs)
+                    )
+
+                    collected_samples.append(outputs)
+                    collected_vls.append(valid_length)
+
+                    num_collected_samples += outputs[0].shape[0]
+
+                outputs = [
+                    np.concatenate(s)[:num_samples]
+                    for s in zip(*collected_samples)
+                ]
+                valid_length = [
+                    np.concatenate(s)[:num_samples]
+                    for s in zip(*collected_vls)
+                ]
+
+                assert len(outputs[0]) == num_samples
+                assert len(valid_length[0]) == num_samples
+
+            assert len(batch["forecast_start"]) == len(outputs)
+
+            for i, output in enumerate(outputs):
+                yield PointProcessSampleForecast(
+                    output,
+                    valid_length=valid_length[i],
+                    start_date=batch["forecast_start"][i],
+                    freq=freq,
+                    prediction_interval_length=prediction_net.prediction_interval_length,
+                    item_id=batch["item_id"][i]
+                    if "item_id" in batch
+                    else None,
+                    info=batch["info"][i] if "info" in batch else None,
+                )
+
+
+class PointProcessGluonPredictor(GluonPredictor):
+    """
+    Predictor object for marked temporal point process models.
+
+    TPP predictions differ from standard discrete-time models in several
+    regards. First, at least for now, only sample forecasts implementing
+    PointProcessSampleForecast are available. Similar to TPP Estimator
+    objects, the Predictor works with :code:`prediction_interval_length`
+    as opposed to :code:`prediction_length`.
+
+    The predictor also accounts for the fact that the prediction network
+    outputs a 2-tuple of Tensors, for the samples themselves and their
+    `valid_length`.
+
+    Finally, this class uses a VariableLengthInferenceDataLoader as opposed
+    to the default InferenceDataLoader.
+
+    Parameters
+    ----------
+    prediction_interval_length
+        The length of the prediction interval
+    """
+
+    def __init__(
+        self,
+        input_names: List[str],
+        prediction_net: mx.gluon.Block,
+        batch_size: int,
+        prediction_interval_length: float,
+        freq: str,
+        ctx: mx.Context,
+        input_transform: Transformation,
+        dtype: DType = np.float32,
+        forecast_generator: ForecastGenerator = PointProcessForecastGenerator(),
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            input_names=input_names,
+            prediction_net=prediction_net,
+            batch_size=batch_size,
+            prediction_length=np.ceil(
+                prediction_interval_length
+            ),  # for validation only
+            freq=freq,
+            ctx=ctx,
+            input_transform=input_transform,
+            output_transform=None,
+            dtype=dtype,
+            lead_time=0,
+            **kwargs,
+        )
+
+        # not used by TPP predictor
+        self.prediction_length = cast(int, None)
+
+        self.forecast_generator = forecast_generator
+        self.prediction_interval_length = prediction_interval_length
+
+    def hybridize(self, batch: DataBatch) -> None:
+        raise NotImplementedError(
+            "Point process models are currently not hybridizable"
+        )
+
+    def as_symbol_block_predictor(
+        self, batch: DataBatch
+    ) -> SymbolBlockPredictor:
+        raise NotImplementedError(
+            "Point process models are currently not hybridizable"
+        )
+
+    def predict(
+        self,
+        dataset: Dataset,
+        num_samples: Optional[int] = None,
+        num_workers: Optional[int] = None,
+        num_prefetch: Optional[int] = None,
+        **kwargs,
+    ) -> Iterator[Forecast]:
+        yield from super().predict(
+            dataset=dataset,
+            num_samples=num_samples,
+            num_workers=num_workers,
+            num_prefetch=num_prefetch,
+            batchify_fn=partial(batchify, variable_length=True),
+        )
+
+    def serialize_prediction_net(self, path: Path) -> None:
+        raise NotImplementedError()

--- a/src/gluonts/transform/__init__.py
+++ b/src/gluonts/transform/__init__.py
@@ -24,6 +24,8 @@ __all__ = [
     "cdf_to_gaussian_forward_transform",
     "CDFtoGaussianTransform",
     "ConcatFeatures",
+    "ContinuousTimeInstanceSplitter",
+    "ContinuousTimeUniformSampler",
     "ExpandDimArray",
     "ExpectedNumInstanceSampler",
     "FilterTransformation",

--- a/test/model/tpp/__init__.py
+++ b/test/model/tpp/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.

--- a/test/model/tpp/common.py
+++ b/test/model/tpp/common.py
@@ -1,0 +1,78 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# Third-party imports
+import numpy as np
+import pandas as pd
+import pytest
+
+# First-party imports
+from gluonts.dataset.common import ListDataset
+
+
+@pytest.fixture
+def point_process_dataset():
+
+    ia_times = np.array([0.2, 0.7, 0.2, 0.5, 0.3, 0.3, 0.2, 0.1])
+    marks = np.array([0, 1, 2, 0, 1, 2, 2, 2])
+
+    lds = ListDataset(
+        [
+            {
+                "target": np.c_[ia_times, marks].T,
+                "start": pd.Timestamp("2011-01-01 00:00:00", freq="H"),
+                "end": pd.Timestamp("2011-01-01 03:00:00", freq="H"),
+            }
+        ],
+        freq="H",
+        one_dim_target=False,
+    )
+
+    return lds
+
+
+@pytest.fixture
+def point_process_dataset_2():
+
+    lds = ListDataset(
+        [
+            {
+                "target": np.c_[
+                    np.array([0.2, 0.7, 0.2, 0.5, 0.3, 0.3, 0.2, 0.1]),
+                    np.array([0, 1, 2, 0, 1, 2, 2, 2]),
+                ].T,
+                "start": pd.Timestamp("2011-01-01 00:00:00", freq="H"),
+                "end": pd.Timestamp("2011-01-01 03:00:00", freq="H"),
+            },
+            {
+                "target": np.c_[
+                    np.array([0.2, 0.1, 0.2, 0.1, 0.3, 0.3, 0.5, 0.4]),
+                    np.array([0, 1, 2, 0, 1, 2, 1, 1]),
+                ].T,
+                "start": pd.Timestamp("2011-01-01 00:00:00", freq="H"),
+                "end": pd.Timestamp("2011-01-01 03:00:00", freq="H"),
+            },
+            {
+                "target": np.c_[
+                    np.array([0.2, 0.7, 0.2, 0.5, 0.1, 0.1, 0.2, 0.1]),
+                    np.array([0, 1, 2, 0, 1, 0, 1, 2]),
+                ].T,
+                "start": pd.Timestamp("2011-01-01 00:00:00", freq="H"),
+                "end": pd.Timestamp("2011-01-01 03:00:00", freq="H"),
+            },
+        ],
+        freq="H",
+        one_dim_target=False,
+    )
+
+    return lds

--- a/test/model/tpp/test_tpp_predictor.py
+++ b/test/model/tpp/test_tpp_predictor.py
@@ -1,0 +1,128 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from typing import Tuple
+
+# Third-party imports
+import mxnet as mx
+import numpy as np
+import pandas as pd
+import pytest
+from mxnet import nd
+
+# First-party imports
+from gluonts.model.common import Tensor
+from gluonts.model.tpp import (
+    PointProcessGluonPredictor,
+    PointProcessSampleForecast,
+)
+from gluonts.transform import (
+    ContinuousTimeInstanceSplitter,
+    ContinuousTimeUniformSampler,
+)
+
+# Relative imports
+from .common import point_process_dataset, point_process_dataset_2
+
+
+class MockTPPPredictionNet(mx.gluon.HybridBlock):
+    def __init__(
+        self,
+        num_parallel_samples: int = 100,
+        prediction_interval_length: float = 5.0,
+        context_interval_length: float = 5.0,
+    ) -> None:
+        super().__init__()
+        self.num_parallel_samples = num_parallel_samples
+        self.prediction_interval_length = prediction_interval_length
+        self.context_interval_length = context_interval_length
+
+    def hybridize(self, active=True, **kwargs):
+        if active:
+            raise NotImplementedError()
+
+    # noinspection PyMethodOverriding
+    def hybrid_forward(
+        self, F, past_target: Tensor, past_valid_length: Tensor
+    ) -> Tuple[Tensor, Tensor]:
+        """
+        Return two tensors, of shape
+        (batch_size, num_samples, max_prediction_length, target_dim)
+        and (batch_size, num_samples) respectively.
+        """
+        batch_size = past_target.shape[0]
+        assert past_valid_length.shape[0] == batch_size
+
+        target_shape = (batch_size, self.num_parallel_samples, 25)
+        pred_target = nd.stack(
+            nd.random.uniform(shape=target_shape),
+            nd.random.randint(0, 10, shape=target_shape).astype(np.float32),
+            axis=-1,
+        )
+        pred_valid_length = nd.random.randint(
+            15, 25 + 1, shape=target_shape[:2]
+        )
+
+        return pred_target, pred_valid_length
+
+
+@pytest.fixture
+def predictor_factory():
+    def get_predictor(**kwargs) -> PointProcessGluonPredictor:
+        default_kwargs = dict(
+            input_names=["past_target", "past_valid_length"],
+            prediction_net=MockTPPPredictionNet(
+                prediction_interval_length=5.0
+            ),
+            batch_size=128,
+            prediction_interval_length=5.0,
+            freq="H",
+            ctx=mx.cpu(),
+            input_transform=ContinuousTimeInstanceSplitter(
+                1, 5, ContinuousTimeUniformSampler(num_instances=5)
+            ),
+        )
+
+        default_kwargs.update(**kwargs)
+
+        return PointProcessGluonPredictor(**default_kwargs)
+
+    return get_predictor
+
+
+@pytest.mark.parametrize(
+    "dataset_tuple", [(point_process_dataset, 1), (point_process_dataset_2, 3)]
+)
+def test_tpp_pred_dataset_2_shapes_ok(dataset_tuple, predictor_factory):
+
+    dataset, ds_length = dataset_tuple
+
+    predictor = predictor_factory()
+    forecasts = [fc for fc in predictor.predict(dataset(), 50)]
+
+    assert len(forecasts) == ds_length
+
+    for forecast in forecasts:
+        # each forecast should have 3dim samples, 1d valid lengths
+        assert isinstance(forecast, PointProcessSampleForecast)
+
+        assert forecast.samples.shape == (50, 25, 2)
+        assert forecast.valid_length.shape == (50,)
+
+        assert (
+            forecast.prediction_interval_length
+            == predictor.prediction_interval_length
+        )
+
+        assert forecast.start_date == pd.Timestamp("2011-01-01 03:00:00")
+        assert forecast.end_date == pd.Timestamp("2011-01-01 08:00:00")


### PR DESCRIPTION
*Issue #, if available:* Related to  #294

*Description of changes:* Adds `SampleForecast`, `ForecastGenerator` and `GluonPredictor` objects that will be shared among temporal point process models. TPPs need unique subclasses of each primarily since forecasts need to be ragged tensors (variable valid length) and predictors must be aware of unique inference data loaders / forecast generators.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
