### PR TITLE
remove kwargs from hybrid_forward input name inference

### DIFF
--- a/src/gluonts/support/util.py
+++ b/src/gluonts/support/util.py
@@ -168,7 +168,7 @@ def copy_parameters(
 
 def get_hybrid_forward_input_names(hb: mx.gluon.HybridBlock):
     params = inspect.signature(hb.hybrid_forward).parameters
-    param_names = list(params)
+    param_names = [k for k, v in params.items() if not str(v).startswith("*")]
     assert param_names[0] == "F", (
         f"Expected first argument of HybridBlock to be `F`, "
         f"but found `{param_names[0]}`"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

GluonTS networks inherit from HybridBlocks whose `hybrid_forward` methods have arguments `(F, x1, x2,..., **kwargs)`. Our models exclude `**kwargs` when overriding and often suppress the IDE inspection with `#noinspection PyMethodOverriding`. 

The reason that this doesn't cause any problems is that GluonTS networks often do not have any parameters in their name scope, which would be passed into the `hybrid_forward` method as keyword arguments. 

When a GluonTS network does include `**kwargs` in the signature then `get_hybrid_forward_input_names` fails as it includes `"kwargs"` in `input_names`. 

This small fix removes special arguments in the `hybrid_forward` signature (*, *args, **kwargs) when inferring input names.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
