### PR TITLE
Fix comparison of ParameterDict when non prefixed variables are in dict.

### DIFF
--- a/src/gluonts/core/component.py
+++ b/src/gluonts/core/component.py
@@ -263,17 +263,21 @@ def equals_parameter_dict(
     if type(this) != type(that):
         return False
 
-    this_prefix_length = len(this.prefix)
-    that_prefix_length = len(that.prefix)
+    def strip_prefix_enumeration(key, prefix):
+        if key.startswith(prefix):
+            name = key[len(prefix) :]
+        else:
+            prefix, args = key.split("_", 1)
+            name = prefix.rstrip("0123456789") + args
 
-    this_param_names_stripped = {
-        key[this_prefix_length:] if key.startswith(this.prefix) else key
-        for key in this.keys()
-    }
-    that_param_names_stripped = {
-        key[that_prefix_length:] if key.startswith(that.prefix) else key
-        for key in that.keys()
-    }
+        return name
+
+    this_param_names_stripped = [
+        strip_prefix_enumeration(key, this.prefix) for key in this.keys()
+    ]
+    that_param_names_stripped = [
+        strip_prefix_enumeration(key, that.prefix) for key in that.keys()
+    ]
 
     if not this_param_names_stripped == that_param_names_stripped:
         return False


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
