### PR TITLE
Add shuffling function

### DIFF
--- a/src/gluonts/dataset/loader.py
+++ b/src/gluonts/dataset/loader.py
@@ -73,6 +73,7 @@ class DataLoader(Iterable[DataEntry]):
         dtype: DType = np.float32,
         num_workers: Optional[int] = None,
         num_prefetch: Optional[int] = None,
+        shuffle_buffer_length: Optional[int] = None,
         **kwargs,
     ) -> None:
         self.batch_size = batch_size
@@ -89,6 +90,7 @@ class DataLoader(Iterable[DataEntry]):
             )
         self.num_workers = num_workers
         self.num_prefetch = num_prefetch
+        self.shuffle_buffer_length = shuffle_buffer_length
 
         self.parallel_data_loader = ParallelDataLoader(
             dataset=dataset,
@@ -100,6 +102,7 @@ class DataLoader(Iterable[DataEntry]):
             dtype=self.dtype,
             num_workers=self.num_workers,
             num_prefetch=self.num_prefetch,
+            shuffle_buffer_length=self.shuffle_buffer_length,
             **kwargs,
         )
 
@@ -151,6 +154,7 @@ class TrainDataLoader(DataLoader):
         num_batches_per_epoch: int,
         num_workers: Optional[int] = None,
         num_prefetch: Optional[int] = None,
+        shuffle_buffer_length: Optional[int] = None,
         dtype: DType = np.float32,
         **kwargs,
     ) -> None:
@@ -166,6 +170,7 @@ class TrainDataLoader(DataLoader):
             cyclic=True,
             num_workers=num_workers,
             num_prefetch=num_prefetch,
+            shuffle_buffer_length=shuffle_buffer_length,
             **kwargs,
         )
 
@@ -196,6 +201,7 @@ class ValidationDataLoader(DataLoader):
         ctx: mx.Context,
         num_workers: Optional[int] = None,
         num_prefetch: Optional[int] = None,
+        shuffle_buffer_length: Optional[int] = None,
         dtype: DType = np.float32,
         **kwargs,
     ) -> None:
@@ -209,6 +215,7 @@ class ValidationDataLoader(DataLoader):
             cyclic=False,
             num_workers=num_workers,
             num_prefetch=num_prefetch,
+            shuffle_buffer_length=shuffle_buffer_length,
             **kwargs,
         )
 
@@ -236,5 +243,6 @@ class InferenceDataLoader(DataLoader):
             cyclic=False,
             num_workers=num_workers,
             num_prefetch=num_prefetch,
+            shuffle_buffer_length=None,
             **kwargs,
         )

--- a/src/gluonts/dataset/loader.py
+++ b/src/gluonts/dataset/loader.py
@@ -201,7 +201,6 @@ class ValidationDataLoader(DataLoader):
         ctx: mx.Context,
         num_workers: Optional[int] = None,
         num_prefetch: Optional[int] = None,
-        shuffle_buffer_length: Optional[int] = None,
         dtype: DType = np.float32,
         **kwargs,
     ) -> None:
@@ -215,7 +214,7 @@ class ValidationDataLoader(DataLoader):
             cyclic=False,
             num_workers=num_workers,
             num_prefetch=num_prefetch,
-            shuffle_buffer_length=shuffle_buffer_length,
+            shuffle_buffer_length=None,
             **kwargs,
         )
 

--- a/src/gluonts/dataset/parallelized_loader.py
+++ b/src/gluonts/dataset/parallelized_loader.py
@@ -368,12 +368,16 @@ class ShuffleIter(Iterator[DataEntry]):
         self.base_iterator = base_iterator
 
     def __next__(self) -> DataEntry:
+        # if the buffer is empty, fill the buffer first.
+        # (should only executed in the first round)
         if len(self.shuffle_buffer) == 0:
             self.shuffle_buffer = list(
                 itertools.islice(
                     self.base_iterator, self.shuffle_buffer_length
                 )
             )
+        # choose an element at a random index and yield it
+        # and fill it with the next element in the sequential generator
         idx = random.randint(0, self.shuffle_buffer_length - 1)
         next_sample = self.shuffle_buffer[idx]
         self.shuffle_buffer[idx] = next(self.base_iterator)

--- a/src/gluonts/dataset/parallelized_loader.py
+++ b/src/gluonts/dataset/parallelized_loader.py
@@ -257,6 +257,8 @@ class _WorkerData:
     transformation: Transformation
     # replicate transformation
     dataset_iterator: Iterator[DataEntry]
+    # shuffle buffer
+    shuffle_buffer: list = []
     # indicates which cycle the iterator has been reset last
     iterator_latest_reset_cycle: int = 0
     # indicates whether the iterator was previously depleted
@@ -265,16 +267,25 @@ class _WorkerData:
 
 # needed because some iterators are not cyclic
 def _worker_reset_iterator(
-    is_train: bool, cyclic: bool, cycle_num: int,
+    is_train: bool,
+    cyclic: bool,
+    cycle_num: int,
+    shuffle_buffer_length: Optional[int],
 ) -> None:
     """Initialize or reset iterators of workers."""
 
-    _WorkerData.dataset_iterator = _sequential_sample_generator(
+    generator = _sequential_sample_generator(
         dataset=_WorkerData.dataset,
         transformation=_WorkerData.transformation,
         is_train=is_train,
         cyclic=cyclic,
     )
+    if shuffle_buffer_length is not None:
+        generator = ShuffleIter(
+            base_iterator=generator,
+            shuffle_buffer_length=shuffle_buffer_length,
+        )
+    _WorkerData.dataset_iterator = generator
 
     _WorkerData.iterator_latest_reset_cycle = cycle_num
     _WorkerData.iterator_exhausted_indicator = False
@@ -308,6 +319,7 @@ def _worker_fn(
     is_train: bool,
     cyclic: bool,
     cycle_num: int,
+    shuffle_buffer_length: int,
 ):
     """Function for processing data in worker process."""
 
@@ -315,13 +327,14 @@ def _worker_fn(
     if (_WorkerData.iterator_latest_reset_cycle < cycle_num) and (
         _WorkerData.iterator_latest_reset_cycle == 0 or not cyclic
     ):
-        _worker_reset_iterator(is_train, cyclic, cycle_num)
+        _worker_reset_iterator(
+            is_train, cyclic, cycle_num, shuffle_buffer_length
+        )
 
     # retrieve the samples that will be batched
     batch_samples = list(
         itertools.islice(_WorkerData.dataset_iterator, batch_size)
     )
-
     # batch the samples, if there were any
     if batch_samples:
         success = True
@@ -346,6 +359,34 @@ def _worker_fn(
     return buf.getvalue()
 
 
+class ShuffleIter(Iterator[DataEntry]):
+    def __init__(
+        self, base_iterator: Iterator[DataEntry], shuffle_buffer_length: int
+    ):
+        self.shuffle_buffer: list = []
+        self.shuffle_buffer_length = shuffle_buffer_length
+        self.base_iterator = base_iterator
+
+    def __next__(self) -> DataEntry:
+        if len(self.shuffle_buffer) == 0:
+            self.shuffle_buffer = list(
+                itertools.islice(
+                    self.base_iterator, self.shuffle_buffer_length
+                )
+            )
+        idx = random.randint(0, self.shuffle_buffer_length - 1)
+        next_sample = self.shuffle_buffer[idx]
+        self.shuffle_buffer[idx] = next(self.base_iterator)
+        return next_sample
+
+    def __iter__(self) -> Iterator[DataEntry]:
+        while True:
+            next_sample = next(self)
+            if not next_sample:
+                return
+            yield next_sample
+
+
 class _MultiWorkerIter(object):
     """Internal multi-worker iterator for DataLoader."""
 
@@ -364,6 +405,7 @@ class _MultiWorkerIter(object):
         worker_fn: Callable,
         dataset_len: int,
         timeout: int,
+        shuffle_buffer_length: Optional[int],
     ):
         self._worker_pool = worker_pool
         self._batchify_fn = batchify_fn
@@ -385,7 +427,8 @@ class _MultiWorkerIter(object):
         self._num_workers = num_workers
         self._batch_size = batch_size
         self._dataset_len = dataset_len
-
+        # shuffle variable
+        self.shuffle_buffer_length = shuffle_buffer_length
         # pre-fetch batches
         self._num_prefetch = num_prefetch
         for i in range(self._num_prefetch):
@@ -407,6 +450,7 @@ class _MultiWorkerIter(object):
                 self._is_train,
                 self._cyclic,
                 self._cycle_num,
+                self.shuffle_buffer_length,
             ),
         )
         self._data_buffer[self._sent_idx] = async_ret
@@ -529,6 +573,7 @@ class ParallelDataLoader(object):
         batchify_fn: Callable = batchify,
         num_prefetch: Optional[int] = None,
         num_workers: Optional[int] = None,
+        shuffle_buffer_length: Optional[int] = None,
     ):
         # Some windows error with the ForkingPickler prevents usage currently:
         if sys.platform == "win32":
@@ -556,6 +601,10 @@ class ParallelDataLoader(object):
         assert (
             num_prefetch is None or num_prefetch >= 0
         ), "Num workers has to be >= 0."
+        assert (
+            shuffle_buffer_length is None
+            or shuffle_buffer_length >= batch_size
+        ), "Shuffle buffer length has to be at least the size of each batch."
 
         self.dataset = dataset
         self.dataset_len: int
@@ -599,6 +648,9 @@ class ParallelDataLoader(object):
         self.worker_id_queue: Optional[Queue] = None
         # In order to recycle unused but pre-calculated batches from last epoch for training:
         self.multi_worker_cache: Optional[Iterator[DataBatch]] = None
+        # Do shuffle or not
+        self.shuffle_buffer_length: Optional[int] = shuffle_buffer_length
+        self.shuffle_buffer: list = []
 
         if self.num_workers > 0:
             # generate unique ids for processes
@@ -627,6 +679,11 @@ class ParallelDataLoader(object):
             generator = _sequential_sample_generator(
                 self.dataset, self.transformation, self.is_train, self.cyclic,
             )
+            if self.shuffle_buffer_length is not None:
+                generator = ShuffleIter(
+                    base_iterator=generator,
+                    shuffle_buffer_length=self.shuffle_buffer_length,
+                )
 
             def same_process_iter():
                 while True:
@@ -634,7 +691,6 @@ class ParallelDataLoader(object):
                     batch_samples = list(
                         itertools.islice(generator, self.batch_size)
                     )
-
                     # terminate if no more batches to be dealt with
                     if len(batch_samples) == 0:
                         return
@@ -670,6 +726,7 @@ class ParallelDataLoader(object):
                     dataset_len=self.dataset_len,
                     cycle_num=self.cycle_num,
                     timeout=120,
+                    shuffle_buffer_length=self.shuffle_buffer_length,
                 )
                 if self.cyclic:
                     self.multi_worker_cache = iter(multi_worker)

--- a/src/gluonts/dataset/parallelized_loader.py
+++ b/src/gluonts/dataset/parallelized_loader.py
@@ -378,7 +378,7 @@ class ShuffleIter(Iterator[DataEntry]):
         # if buffer still empty, means all elements used,
         # return a signal of end of iterator
         if not self.shuffle_buffer:
-            return {}
+            raise StopIteration
         # choose an element at a random index and yield it
         # and fill it with the next element in the sequential generator
         idx = random.randint(0, len(self.shuffle_buffer) - 1)
@@ -386,20 +386,12 @@ class ShuffleIter(Iterator[DataEntry]):
 
         # replace the index with the next element in the iterator if the iterator has not finished.
         # delete the index otherwise.
-        to_replace: DataEntry = next(self.base_iterator, {})
-        if to_replace:
-            self.shuffle_buffer[idx] = to_replace
-        else:
+        try:
+            self.shuffle_buffer[idx] = next(self.base_iterator)
+        except StopIteration:
             del self.shuffle_buffer[idx]
 
         return next_sample
-
-    def __iter__(self) -> Iterator[DataEntry]:
-        while True:
-            next_sample = next(self)
-            if not next_sample:
-                return
-            yield next_sample
 
 
 class _MultiWorkerIter(object):

--- a/src/gluonts/model/estimator.py
+++ b/src/gluonts/model/estimator.py
@@ -229,7 +229,6 @@ class GluonEstimator(Estimator):
                 dtype=self.dtype,
                 num_workers=num_workers,
                 num_prefetch=num_prefetch,
-                shuffle_buffer_length=shuffle_buffer_length,
                 **kwargs,
             )
 

--- a/src/gluonts/model/estimator.py
+++ b/src/gluonts/model/estimator.py
@@ -201,6 +201,7 @@ class GluonEstimator(Estimator):
         validation_data: Optional[Dataset] = None,
         num_workers: Optional[int] = None,
         num_prefetch: Optional[int] = None,
+        shuffle_buffer_length: Optional[int] = None,
         **kwargs,
     ) -> TrainOutput:
         transformation = self.create_transformation()
@@ -214,6 +215,7 @@ class GluonEstimator(Estimator):
             dtype=self.dtype,
             num_workers=num_workers,
             num_prefetch=num_prefetch,
+            shuffle_buffer_length=shuffle_buffer_length,
             **kwargs,
         )
 
@@ -227,6 +229,7 @@ class GluonEstimator(Estimator):
                 dtype=self.dtype,
                 num_workers=num_workers,
                 num_prefetch=num_prefetch,
+                shuffle_buffer_length=shuffle_buffer_length,
                 **kwargs,
             )
 
@@ -257,8 +260,14 @@ class GluonEstimator(Estimator):
         validation_data: Optional[Dataset] = None,
         num_workers: Optional[int] = None,
         num_prefetch: Optional[int] = None,
+        shuffle_buffer_length: Optional[int] = None,
         **kwargs,
     ) -> Predictor:
         return self.train_model(
-            training_data, validation_data, num_workers, num_prefetch, **kwargs
+            training_data,
+            validation_data,
+            num_workers,
+            num_prefetch,
+            shuffle_buffer_length,
+            **kwargs,
         ).predictor

--- a/test/dataset/test_shuffling.py
+++ b/test/dataset/test_shuffling.py
@@ -1,0 +1,34 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from gluonts.dataset.artificial import constant_dataset
+from gluonts.dataset.parallelized_loader import ShuffleIter
+import itertools
+
+
+# test if ShuffleIter would return a iterator of the same size of the base iterator
+def test_shuffle_iter() -> None:
+    # test with range
+    data = [{str(i): str(i)} for i in range(20)]
+    shuffled_data = ShuffleIter(
+        base_iterator=iter(data), shuffle_buffer_length=10
+    )
+    assert len(list(shuffled_data)) == 20
+
+    # test with constant gluonts dataset
+    ds_info, train_ds, test_ds = constant_dataset()
+    base_iter, base_iter_backup = itertools.tee(iter(train_ds), 2)
+    shuffled_data = ShuffleIter(
+        base_iterator=base_iter, shuffle_buffer_length=5
+    )
+    assert len(list(shuffled_data)) == len(list(base_iter_backup))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Note: replaces #858*

Added ShuffleIter class to enable shuffling  in data loader.

In the first time comparison plot, the x-axis represents the shuffle buffer length, that is, if the x-axis is c, then the shuffle buffer is of size c * batch size, y-axis is the time used to generate 200 batches of size 32 from a dataset of length 300.

![comparison](https://user-images.githubusercontent.com/37573101/84977155-386d0d80-b15c-11ea-8384-446b55e7b7c1.jpg)

In the following heatmaps, x-axis is the batch index, y-axis is the time series index, and color intensity indicates how many elements in the x-batch are from the y-time-series

![single_process_1](https://user-images.githubusercontent.com/37573101/84758569-368a3980-aff8-11ea-988d-9c03fee1ad38.jpeg)
![single_process_10](https://user-images.githubusercontent.com/37573101/84758572-3722d000-aff8-11ea-8044-4ee8722b185b.jpeg)
![two_process_1](https://user-images.githubusercontent.com/37573101/84758577-3853fd00-aff8-11ea-9a2e-0850ca805028.jpeg)
![two_process_10](https://user-images.githubusercontent.com/37573101/84758579-38ec9380-aff8-11ea-82bd-fc32d236da84.jpeg)




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
