### PR TITLE
make distributions pickleable

### DIFF
--- a/src/gluonts/mx/distribution/beta.py
+++ b/src/gluonts/mx/distribution/beta.py
@@ -46,12 +46,13 @@ class Beta(Distribution):
     is_reparameterizable = False
 
     @validated()
-    def __init__(self, alpha: Tensor, beta: Tensor, F=None) -> None:
+    def __init__(self, alpha: Tensor, beta: Tensor) -> None:
         self.alpha = alpha
         self.beta = beta
-        self.F = (
-            F if F else getF(alpha)
-        )  # assuming alpha and beta of same type
+
+    @property
+    def F(self):
+        return getF(self.alpha)
 
     @property
     def batch_shape(self) -> Tuple:

--- a/src/gluonts/mx/distribution/categorical.py
+++ b/src/gluonts/mx/distribution/categorical.py
@@ -40,13 +40,16 @@ class Categorical(Distribution):
     """
 
     @validated()
-    def __init__(self, log_probs: Tensor, F=None) -> None:
+    def __init__(self, log_probs: Tensor) -> None:
         super().__init__()
         self.log_probs = log_probs
         self.num_cats = self.log_probs.shape[-1]
-        self.F = F if F else getF(log_probs)
         self.cats = self.F.arange(self.num_cats)
         self._probs = None
+
+    @property
+    def F(self):
+        return getF(self.log_probs)
 
     @property
     def probs(self):

--- a/src/gluonts/mx/distribution/dirichlet.py
+++ b/src/gluonts/mx/distribution/dirichlet.py
@@ -48,12 +48,13 @@ class Dirichlet(Distribution):
     is_reparameterizable = False
 
     @validated()
-    def __init__(
-        self, alpha: Tensor, F=None, float_type: DType = np.float32
-    ) -> None:
+    def __init__(self, alpha: Tensor, float_type: DType = np.float32) -> None:
         self.alpha = alpha
-        self.F = F if F else getF(alpha)
         self.float_type = float_type
+
+    @property
+    def F(self):
+        return getF(self.alpha)
 
     @property
     def args(self) -> List:

--- a/src/gluonts/mx/distribution/dirichlet_multinomial.py
+++ b/src/gluonts/mx/distribution/dirichlet_multinomial.py
@@ -63,14 +63,16 @@ class DirichletMultinomial(Distribution):
         dim: int,
         n_trials: int,
         alpha: Tensor,
-        F=None,
         float_type: DType = np.float32,
     ) -> None:
         self.dim = dim
         self.n_trials = n_trials
         self.alpha = alpha
-        self.F = F if F else getF(alpha)
         self.float_type = float_type
+
+    @property
+    def F(self):
+        return getF(self.alpha)
 
     @property
     def batch_shape(self) -> Tuple:

--- a/src/gluonts/mx/distribution/gaussian.py
+++ b/src/gluonts/mx/distribution/gaussian.py
@@ -47,10 +47,13 @@ class Gaussian(Distribution):
     is_reparameterizable = True
 
     @validated()
-    def __init__(self, mu: Tensor, sigma: Tensor, F=None) -> None:
+    def __init__(self, mu: Tensor, sigma: Tensor) -> None:
         self.mu = mu
         self.sigma = sigma
-        self.F = F if F else getF(mu)
+
+    @property
+    def F(self):
+        return getF(self.mu)
 
     @property
     def batch_shape(self) -> Tuple:

--- a/src/gluonts/mx/distribution/laplace.py
+++ b/src/gluonts/mx/distribution/laplace.py
@@ -44,10 +44,13 @@ class Laplace(Distribution):
     is_reparameterizable = True
 
     @validated()
-    def __init__(self, mu: Tensor, b: Tensor, F=None) -> None:
+    def __init__(self, mu: Tensor, b: Tensor) -> None:
         self.mu = mu
         self.b = b
-        self.F = F if F else getF(mu)
+
+    @property
+    def F(self):
+        return getF(self.mu)
 
     @property
     def batch_shape(self) -> Tuple:
@@ -62,9 +65,8 @@ class Laplace(Distribution):
         return 0
 
     def log_prob(self, x: Tensor) -> Tensor:
-        return -1.0 * (
-            self.F.log(2.0 * self.b) + self.F.abs((x - self.mu) / self.b)
-        )
+        F = self.F
+        return -1.0 * (F.log(2.0 * self.b) + F.abs((x - self.mu) / self.b))
 
     @property
     def mean(self) -> Tensor:

--- a/src/gluonts/mx/distribution/lds.py
+++ b/src/gluonts/mx/distribution/lds.py
@@ -140,7 +140,7 @@ class LDS(Distribution):
 
     @property
     def F(self):
-        return getF(self.noise_std)
+        return getF(self.prior_mean)
 
     @property
     def batch_shape(self) -> Tuple:

--- a/src/gluonts/mx/distribution/lds.py
+++ b/src/gluonts/mx/distribution/lds.py
@@ -104,7 +104,6 @@ class LDS(Distribution):
         latent_dim: int,
         output_dim: int,
         seq_length: int,
-        F=None,
     ) -> None:
         self.latent_dim = latent_dim
         self.output_dim = output_dim
@@ -138,7 +137,10 @@ class LDS(Distribution):
 
         self.prior_mean = prior_mean
         self.prior_cov = prior_cov
-        self.F = F if F else getF(noise_std)
+
+    @property
+    def F(self):
+        return getF(self.noise_std)
 
     @property
     def batch_shape(self) -> Tuple:

--- a/src/gluonts/mx/distribution/logit_normal.py
+++ b/src/gluonts/mx/distribution/logit_normal.py
@@ -41,11 +41,14 @@ class LogitNormal(Distribution):
     """
 
     @validated()
-    def __init__(self, mu: Tensor, sigma: Tensor, F=None) -> None:
+    def __init__(self, mu: Tensor, sigma: Tensor) -> None:
         super().__init__()
         self.mu = mu
         self.sigma = sigma
-        self.F = F if F else getF(mu)
+
+    @property
+    def F(self):
+        return getF(self.mu)
 
     @property
     def batch_shape(self) -> Tuple:

--- a/src/gluonts/mx/distribution/lowrank_multivariate_gaussian.py
+++ b/src/gluonts/mx/distribution/lowrank_multivariate_gaussian.py
@@ -199,8 +199,11 @@ class LowrankMultivariateGaussian(Distribution):
         self.mu = mu
         self.D = D
         self.W = W
-        self.F = getF(mu)
         self.Cov = None
+
+    @property
+    def F(self):
+        return getF(self.mu)
 
     @property
     def batch_shape(self) -> Tuple:
@@ -226,13 +229,14 @@ class LowrankMultivariateGaussian(Distribution):
     @property
     def variance(self) -> Tensor:
         assert self.dim is not None
+        F = self.F
 
         if self.Cov is not None:
             return self.Cov
         # reshape to a matrix form (..., d, d)
-        D_matrix = self.D.expand_dims(-1) * self.F.eye(self.dim)
+        D_matrix = self.D.expand_dims(-1) * F.eye(self.dim)
 
-        W_matrix = self.F.linalg_gemm2(self.W, self.W, transpose_b=True)
+        W_matrix = F.linalg_gemm2(self.W, self.W, transpose_b=True)
 
         self.Cov = D_matrix + W_matrix
 

--- a/src/gluonts/mx/distribution/multivariate_gaussian.py
+++ b/src/gluonts/mx/distribution/multivariate_gaussian.py
@@ -49,8 +49,11 @@ class MultivariateGaussian(Distribution):
     @validated()
     def __init__(self, mu: Tensor, L: Tensor, F=None) -> None:
         self.mu = mu
-        self.F = F if F else getF(mu)
         self.L = L
+
+    @property
+    def F(self):
+        return getF(self.mu)
 
     def __getitem__(self, item):
         raise NotImplementedError()
@@ -122,14 +125,12 @@ class MultivariateGaussian(Distribution):
         """
 
         def s(mu: Tensor, L: Tensor) -> Tensor:
-            samples_std_normal = self.F.sample_normal(
-                mu=self.F.zeros_like(mu),
-                sigma=self.F.ones_like(mu),
-                dtype=dtype,
+            F = self.F
+            samples_std_normal = F.sample_normal(
+                mu=F.zeros_like(mu), sigma=F.ones_like(mu), dtype=dtype,
             ).expand_dims(axis=-1)
             samples = (
-                self.F.linalg_gemm2(L, samples_std_normal).squeeze(axis=-1)
-                + mu
+                F.linalg_gemm2(L, samples_std_normal).squeeze(axis=-1) + mu
             )
             return samples
 

--- a/src/gluonts/mx/distribution/neg_binomial.py
+++ b/src/gluonts/mx/distribution/neg_binomial.py
@@ -44,10 +44,13 @@ class NegativeBinomial(Distribution):
     is_reparameterizable = False
 
     @validated()
-    def __init__(self, mu: Tensor, alpha: Tensor, F=None) -> None:
+    def __init__(self, mu: Tensor, alpha: Tensor) -> None:
         self.mu = mu
         self.alpha = alpha
-        self.F = F if F else getF(mu)
+
+    @property
+    def F(self):
+        return getF(self.mu)
 
     @property
     def batch_shape(self) -> Tuple:

--- a/src/gluonts/mx/distribution/piecewise_linear.py
+++ b/src/gluonts/mx/distribution/piecewise_linear.py
@@ -64,9 +64,8 @@ class PiecewiseLinear(Distribution):
 
     @validated()
     def __init__(
-        self, gamma: Tensor, slopes: Tensor, knot_spacings: Tensor, F=None
+        self, gamma: Tensor, slopes: Tensor, knot_spacings: Tensor
     ) -> None:
-        self.F = F if F else getF(gamma)
         self.gamma = gamma
         self.slopes = slopes
         self.knot_spacings = knot_spacings
@@ -76,6 +75,10 @@ class PiecewiseLinear(Distribution):
         self.b, self.knot_positions = PiecewiseLinear._to_orig_params(
             self.F, slopes, knot_spacings
         )
+
+    @property
+    def F(self):
+        return getF(self.gamma)
 
     @property
     def args(self) -> List:

--- a/src/gluonts/mx/distribution/poisson.py
+++ b/src/gluonts/mx/distribution/poisson.py
@@ -42,9 +42,12 @@ class Poisson(Distribution):
     is_reparameterizable = False
 
     @validated()
-    def __init__(self, rate: Tensor, F=None) -> None:
+    def __init__(self, rate: Tensor) -> None:
         self.rate = rate
-        self.F = F if F else getF(rate)
+
+    @property
+    def F(self):
+        return getF(self.rate)
 
     @property
     def batch_shape(self) -> Tuple:

--- a/src/gluonts/mx/distribution/student_t.py
+++ b/src/gluonts/mx/distribution/student_t.py
@@ -58,7 +58,10 @@ class StudentT(Distribution):
         self.mu = mu
         self.sigma = sigma
         self.nu = nu
-        self.F = F if F else getF(mu)
+
+    @property
+    def F(self):
+        return getF(self.mu)
 
     @property
     def batch_shape(self) -> Tuple:

--- a/src/gluonts/mx/distribution/uniform.py
+++ b/src/gluonts/mx/distribution/uniform.py
@@ -44,10 +44,13 @@ class Uniform(Distribution):
     is_reparameterizable = True
 
     @validated()
-    def __init__(self, low: Tensor, high: Tensor, F=None) -> None:
+    def __init__(self, low: Tensor, high: Tensor) -> None:
         self.low = low
         self.high = high
-        self.F = F if F else getF(low)
+
+    @property
+    def F(self):
+        return getF(self.low)
 
     @property
     def batch_shape(self) -> Tuple:
@@ -62,10 +65,11 @@ class Uniform(Distribution):
         return 0
 
     def log_prob(self, x: Tensor) -> Tensor:
-        is_in_range = self.F.broadcast_greater_equal(
+        F = self.F
+        is_in_range = F.broadcast_greater_equal(
             x, self.low
-        ) * self.F.broadcast_lesser(x, self.high)
-        return self.F.log(is_in_range) - self.F.log(self.high - self.low)
+        ) * F.broadcast_lesser(x, self.high)
+        return F.log(is_in_range) - F.log(self.high - self.low)
 
     @property
     def mean(self) -> Tensor:


### PR DESCRIPTION
*Issue #, if available:* Related to #870 

*Description of changes:* Many if not all of the distribution classes are not pickle-able because they have a module (`F`, either `mx.nd` or `mx.sym`) as attribute. This create problems if one needs to do multi-processing things involving distributions (like parallel evaluation).

Having `F` as an attribute seems like unnecessary optimization, since the `getF` utility function is inexpensive. Therefore I'm turning `self.F` into a `@property` that invokes `getF`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
