### PR TITLE
splitting features and uses DataEntry instead of TimeSeriesItem

### DIFF
--- a/src/gluonts/dataset/split/splitter.py
+++ b/src/gluonts/dataset/split/splitter.py
@@ -95,9 +95,7 @@ class TimeSeriesSlice(pydantic.BaseModel):
             pd.Series(real, index=index) for real in item_dynamic_real
         ]
 
-        feat_static_cat = (
-            list(item["feat_static_cat"]) if "feat_static_cat" in item else []
-        )
+        feat_static_cat = list(item.get("feat_static_cat", []))
 
         feat_static_real = (
             list(item["feat_static_real"])

--- a/src/gluonts/dataset/split/splitter.py
+++ b/src/gluonts/dataset/split/splitter.py
@@ -119,7 +119,7 @@ class TimeSeriesSlice(pydantic.BaseModel):
             "target": self.target.values,
         }
 
-        if len(self.feat_static_cat) > 0:
+        if self.feat_static_cat:
             ret["feat_static_cat"] = self.feat_static_cat
         if len(self.feat_static_real) > 0:
             ret["feat_static_real"] = self.feat_static_real

--- a/src/gluonts/dataset/split/splitter.py
+++ b/src/gluonts/dataset/split/splitter.py
@@ -189,9 +189,11 @@ class TrainTestSplit(pydantic.BaseModel):
 
 class AbstractBaseSplitter(ABC):
     """Base class for all other splitter.
+
     Args:
         param prediction_length:
             The prediction length which is used to train themodel.
+            
         max_history:
             If given, all entries in the *test*-set have a max-length of
             `max_history`. This can be used to produce smaller file-sizes.

--- a/src/gluonts/dataset/split/splitter.py
+++ b/src/gluonts/dataset/split/splitter.py
@@ -159,7 +159,7 @@ class TimeSeriesSlice(pydantic.BaseModel):
 
         target = self.target[slice_]
 
-        assert all([len(target) == len(i) for i in feat_dynamic_real])
+        assert all([len(target) == len(feat) for feat in feat_dynamic_real])
         assert all([len(target) == len(i) for i in feat_dynamic_cat])
 
         return TimeSeriesSlice(

--- a/src/gluonts/dataset/split/splitter.py
+++ b/src/gluonts/dataset/split/splitter.py
@@ -81,27 +81,19 @@ class TimeSeriesSlice(pydantic.BaseModel):
             start=item["start"], freq=freq, periods=len(item["target"])
         )
 
-        item_dynamic_cat = (
-            item["feat_dynamic_cat"] if "feat_dynamic_cat" in item else []
-        )
         feat_dynamic_cat = [
-            pd.Series(cat, index=index) for cat in item_dynamic_cat
+            pd.Series(cat, index=index)
+            for cat in list(item.get("feat_dynamic_cat", []))
         ]
 
-        item_dynamic_real = (
-            item["feat_dynamic_real"] if "feat_dynamic_real" in item else []
-        )
         feat_dynamic_real = [
-            pd.Series(real, index=index) for real in item_dynamic_real
+            pd.Series(real, index=index)
+            for real in list(item.get("feat_dynamic_real", []))
         ]
 
         feat_static_cat = list(item.get("feat_static_cat", []))
 
-        feat_static_real = (
-            list(item["feat_static_real"])
-            if "feat_static_real" in item
-            else []
-        )
+        feat_static_real = list(item.get("feat_static_real", []))
 
         return TimeSeriesSlice(
             target=pd.Series(item["target"], index=index),
@@ -121,13 +113,13 @@ class TimeSeriesSlice(pydantic.BaseModel):
 
         if self.feat_static_cat:
             ret["feat_static_cat"] = self.feat_static_cat
-        if len(self.feat_static_real) > 0:
+        if self.feat_static_real:
             ret["feat_static_real"] = self.feat_static_real
-        if len(self.feat_dynamic_cat) > 0:
+        if self.feat_dynamic_cat:
             ret["feat_dynamic_cat"] = [
                 cat.values.tolist() for cat in self.feat_dynamic_cat
             ]
-        if len(self.feat_dynamic_real) > 0:
+        if self.feat_dynamic_real:
             ret["feat_dynamic_real"] = [
                 real.values.tolist() for real in self.feat_dynamic_real
             ]
@@ -160,7 +152,7 @@ class TimeSeriesSlice(pydantic.BaseModel):
         target = self.target[slice_]
 
         assert all([len(target) == len(feat) for feat in feat_dynamic_real])
-        assert all([len(target) == len(i) for i in feat_dynamic_cat])
+        assert all([len(target) == len(feat) for feat in feat_dynamic_cat])
 
         return TimeSeriesSlice(
             target=target,

--- a/src/gluonts/dataset/split/splitter.py
+++ b/src/gluonts/dataset/split/splitter.py
@@ -14,19 +14,26 @@
 """
 Train/test splitter
 ~~~~~~~~~~~~~~~~~~~
+
 This module defines strategies to split a whole dataset into train and test
 subsets.
+
 For uniform datasets, where all time-series start and end at the same point in
 time `OffsetSplitter` can be used::
+
     splitter = OffsetSplitter(prediction_length=24, split_offset=24)
     train, test = splitter.split(whole_dataset)
+
 For all other datasets, the more flexible `DateSplitter` can be used::
+
     splitter = DateSplitter(
         prediction_length=24,
         split_date=pd.Timestamp('2018-01-31', freq='D')
     )
     train, test = splitter.split(whole_dataset)
+
 The module also supports rolling splits::
+
     splitter = DateSplitter(
         prediction_length=24,
         split_date=pd.Timestamp('2018-01-31', freq='D')

--- a/test/dataset/split/test_split.py
+++ b/test/dataset/split/test_split.py
@@ -32,4 +32,4 @@ def test_ts_slice_to_item():
         feat_dynamic_real=[make_series(range(100))],
     )
 
-    sl.to_time_series_item()
+    sl.to_data_entry()


### PR DESCRIPTION
*Description of changes:* 

Enabled splitters to split features as well as the target for datasets. Also converted Splitters to intake and output type DataEntry instead of TimeSeriesItem, so that it is standard with the rest of the gluon-ts library.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
