### PR TITLE
Fixed invalid num_worker possibility.

### DIFF
--- a/src/gluonts/dataset/parallelized_loader.py
+++ b/src/gluonts/dataset/parallelized_loader.py
@@ -634,13 +634,10 @@ class ParallelDataLoader(object):
 
         # TODO: switch to default multiprocessing.cpu_count() here
         default_num_workers = 0
-        self.num_workers = (
-            num_workers
-            if num_workers is not None
-            else min(
-                self.dataset_len, default_num_workers
-            )  # cannot have more than dataset entries
-        )
+        self.num_workers = min(
+            num_workers if num_workers is not None else default_num_workers,
+            self.dataset_len,
+        )  # cannot have more than dataset entries
         self.num_prefetch = (
             num_prefetch if num_prefetch is not None else 2 * self.num_workers
         )


### PR DESCRIPTION
*Issue #, if available:*
* There was a possibility of manually setting more workers than there are time series in the dataset, which currently is not supported.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
