### PR TITLE
Remove and replace DiscretePIT with more fine-grained representations

### DIFF
--- a/src/gluonts/mx/representation/__init__.py
+++ b/src/gluonts/mx/representation/__init__.py
@@ -13,12 +13,13 @@
 
 from .custom_binning import CustomBinning
 from .dim_expansion import DimExpansion
-from .discrete_pit import DiscretePIT
+from .const_norm import ConstNormalization
 from .embedding import Embedding
 from .global_relative_binning import GlobalRelativeBinning
 from .hybrid_representation import HybridRepresentation
 from .local_absolute_binning import LocalAbsoluteBinning
 from .mean_scaling import MeanScaling
+from .mlp_bin_transf import MLPBinningTransformation
 
 # Relative imports
 from .representation import Representation
@@ -33,8 +34,9 @@ __all__ = [
     "MeanScaling",
     "DimExpansion",
     "Embedding",
-    "DiscretePIT",
+    "ConstNormalization",
     "RepresentationChain",
+    "MLPBinningTransformation",
 ]
 
 # fix Sphinx issues, see https://bit.ly/2K2eptM

--- a/src/gluonts/mx/representation/const_norm.py
+++ b/src/gluonts/mx/representation/const_norm.py
@@ -1,0 +1,63 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# Standard library imports
+from typing import List, Optional, Tuple, Union
+
+import mxnet as mx
+import numpy as np
+from mxnet.gluon import nn
+
+# First-party imports
+from gluonts.core.component import get_mxnet_context, validated
+from gluonts.dataset.common import Dataset
+from gluonts.model.common import Tensor
+
+from .representation import Representation
+
+
+class ConstNormalization(Representation):
+    """
+    A class representing a normalization by a constant.
+
+    Parameters
+    ----------
+    const
+        Constant by which to normalize.
+    """
+
+    @validated()
+    def __init__(
+        self, const: int, *args, **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.const = const
+
+    # noinspection PyMethodOverriding
+    def hybrid_forward(
+        self,
+        F,
+        data: Tensor,
+        observed_indicator: Tensor,
+        scale: Optional[Tensor],
+        rep_params: List[Tensor],
+        **kwargs,
+    ) -> Tuple[Tensor, Tensor, List[Tensor]]:
+        data = data / self.const
+        return data, scale, rep_params
+
+    def post_transform(
+        self, F, samples: Tensor, scale: Tensor, rep_params: List[Tensor]
+    ) -> Tensor:
+        samples = samples * F.full(1, self.const)
+        return samples


### PR DESCRIPTION
*Description of changes:*
The `DiscretePIT` representation does not make much sense right now, since it requires the use of a quantile binning to be passed to it, which can be seen as the core operation behind `DiscretePIT`. What `DiscretePIT` does instead is to actually normalize the bins to real numbers in [0,1] and potentially pass it to an additional "binning + embedding" MLP to achieve the same expressiveness as binning + embedding. But in this case, the name `DiscretePIT` does not really fit the actual provided functionality. Therefore, I removed `DiscretePIT` and added two new representations: `ConstNormalization` which can normalize an incoming tensor using a fixed constant, and `MLPBinningTransformation` to provide the auxiliary MLP functionality described above. To achieve the same functionality as before, one needs to create the following representation

```python
RepresentationChain(chain=[
     GlobalRelativeBinning(num_bins=10, is_quantile=True), 
     ConstNormalization(const=10), 
     DimExpansion()
])
```

for a standard discrete probability integral transform and the following representation

```python
RepresentationChain(chain=[
     GlobalRelativeBinning(num_bins=10, is_quantile=True), 
     ConstNormalization(const=10), 
     MLPBinningTransformation(num_bins=10)
])
````

for that same discrete PIT to be additionally transformed trough an appropriate MLP.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
