### PR TITLE
refactor imputation transformation

### DIFF
--- a/src/gluonts/transform/feature.py
+++ b/src/gluonts/transform/feature.py
@@ -201,14 +201,9 @@ class AddObservedValuesIndicator(SimpleTransformation):
         Field for which missing values will be replaced
     output_field
         Field name to use for the indicator
-    dummy_value
-        Value to use for replacing missing values.
     imputation_method
-        One of the methods from ImputationStrategy.
-    convert_nans
-        If set to true (default) missing values will be replaced. Otherwise
-        they will not be replaced. In any case the indicator is included in the
-        result.
+        One of the methods from ImputationStrategy. If set to None, no imputation is
+        done and only the indicator is included.
     """
 
     @validated()
@@ -216,28 +211,21 @@ class AddObservedValuesIndicator(SimpleTransformation):
         self,
         target_field: str,
         output_field: str,
-        dummy_value: float = 0.0,
-        imputation_method: Optional[MissingValueImputation] = None,
-        convert_nans: bool = True,
+        imputation_method: Optional[
+            MissingValueImputation
+        ] = DummyValueImputation(0.0),
         dtype: DType = np.float32,
     ) -> None:
-        self.dummy_value = dummy_value
         self.target_field = target_field
         self.output_field = output_field
-        self.convert_nans = convert_nans
         self.dtype = dtype
-
-        self.imputation_method = (
-            imputation_method
-            if imputation_method is not None
-            else DummyValueImputation(dummy_value)
-        )
+        self.imputation_method = imputation_method
 
     def transform(self, data: DataEntry) -> DataEntry:
         value = data[self.target_field]
         nan_entries = np.isnan(value)
 
-        if self.convert_nans:
+        if self.imputation_method is not None:
             data[self.target_field] = self.imputation_method(value)
 
         data[self.output_field] = np.invert(

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -424,7 +424,7 @@ def test_multi_dim_transformation(is_train):
             transform.AddObservedValuesIndicator(
                 target_field=FieldName.TARGET,
                 output_field="observed_values",
-                convert_nans=False,
+                imputation_method=None,
             ),
             transform.VstackFeatures(
                 output_field="dynamic_feat",


### PR DESCRIPTION
Small refactoring of `AddObservedValueIndicator` transformation. 

Removed unnecessary fields:
- `dummy_value`: This is imputation-method-dependent and should not be an argument of the transformation. Instead the transformation should take as input the imputation method with this field set already.
- `convert_nans`: This is unnecessary since we can just use None as imputation method.

With the above change we have control **IF** we want to do imputation or not in the transformation by including a hyperparameter in the estimator (setting it to the appropriate imputation method or to None). This gives the flexibility to select from a model-based imputation method (e.g. if set to None use a sample from the predictive distribution since the imputation from the transformation is disabled) or from a transformation based imputation (e.g. a dummy value).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
