### PR TITLE
Scale the negative binomial's gamma()

### DIFF
--- a/src/gluonts/mx/distribution/neg_binomial.py
+++ b/src/gluonts/mx/distribution/neg_binomial.py
@@ -133,9 +133,7 @@ class NegativeBinomialOutput(DistributionOutput):
             return NegativeBinomial(mu, alpha)
         else:
             F = getF(mu)
-            scale = 1.0 + softplus(F, scale - 1.0)
             mu = F.broadcast_mul(mu, scale)
-            alpha = F.broadcast_add(alpha, F.broadcast_div(scale - 1, mu))
             return NegativeBinomial(mu, alpha, F)
 
     @property


### PR DESCRIPTION
For issue #906 

The `theta` param. of Gamma gets scaled by `scale *theta = alpha * mu * scale`. So only need to scale the `mu` . See: https://en.wikipedia.org/wiki/Gamma_distribution#Scaling

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
