### PR TITLE
Improve shuffle function

### DIFF
--- a/src/gluonts/dataset/loader.py
+++ b/src/gluonts/dataset/loader.py
@@ -58,6 +58,11 @@ class DataLoader(Iterable[DataEntry]):
         By default it defaults to `num_workers * 2`.
     cyclic
         Indicates whether the dataset is traversed potentially multiple times.
+    shuffle_buffer_length
+        The length of the buffer used to do pseudo shuffle.
+        If not None, the loader will perform pseudo shuffle when generating batches.
+        Note that using a larger buffer will provide more randomized batches, but will make the job require a bit
+        more time to be done.
 
     """
 
@@ -143,6 +148,11 @@ class TrainDataLoader(DataLoader):
         By default `num_workers * 2`.
     dtype
         Floating point type to use. Default is np.float32.
+    shuffle_buffer_length
+        The length of the buffer used to do pseudo shuffle.
+        If not None, the loader will perform pseudo shuffle when generating batches.
+        Note that using a larger buffer will provide more randomized batches, but will make the job require a bit
+        more time to be done.
     """
 
     def __init__(

--- a/src/gluonts/dataset/parallelized_loader.py
+++ b/src/gluonts/dataset/parallelized_loader.py
@@ -358,6 +358,11 @@ def _worker_fn(
 
 
 class ShuffleIter(Iterator[DataEntry]):
+    """
+    A wrapper class which takes a serialized iterator as an input and generates a
+    pseudo randomized iterator using the same elements from the input iterator.
+    """
+
     def __init__(
         self, base_iterator: Iterator[DataEntry], shuffle_buffer_length: int
     ):
@@ -566,6 +571,11 @@ class ParallelDataLoader(object):
         but will consume more shared_memory. Using smaller number may forfeit the purpose of using
         multiple worker processes, try reduce `num_workers` in this case.
         By default it defaults to `num_workers * 2`.
+    shuffle_buffer_length
+        The length of the buffer used to do pseudo shuffle.
+        If not None, the loader will perform pseudo shuffle when generating batches.
+        Note that using a larger buffer will provide more randomized batches, but will make the job require a bit
+        more time to be done.
     """
 
     def __init__(

--- a/src/gluonts/model/wavenet/_estimator.py
+++ b/src/gluonts/model/wavenet/_estimator.py
@@ -265,6 +265,7 @@ class WaveNetEstimator(GluonEstimator):
         validation_data: Optional[Dataset] = None,
         num_workers: Optional[int] = None,
         num_prefetch: Optional[int] = None,
+        shuffle_buffer_length: Optional[int] = None,
         **kwargs,
     ) -> Predictor:
         has_negative_data = any(np.any(d["target"] < 0) for d in training_data)
@@ -291,6 +292,7 @@ class WaveNetEstimator(GluonEstimator):
             ctx=self.trainer.ctx,
             num_workers=num_workers,
             num_prefetch=num_prefetch,
+            shuffle_buffer_length=shuffle_buffer_length,
             **kwargs,
         )
 

--- a/test/trainer/test_learning_rate_scheduler.py
+++ b/test/trainer/test_learning_rate_scheduler.py
@@ -17,7 +17,7 @@ import numpy as np
 import pytest
 
 # First-party imports
-from gluonts.trainer import learning_rate_scheduler as lrs
+from gluonts.mx.trainer import learning_rate_scheduler as lrs
 
 
 @pytest.mark.parametrize(

--- a/test/trainer/test_model_averaging.py
+++ b/test/trainer/test_model_averaging.py
@@ -17,7 +17,7 @@ import numpy as np
 import pytest
 
 # First-party imports
-from gluonts.trainer.model_averaging import (
+from gluonts.mx.trainer.model_averaging import (
     SelectNBestMean,
     SelectNBestSoftmax,
 )


### PR DESCRIPTION
In this PR, documentations are added related to ```shuffle_buffer_length``` in ```loader.py``` and ```parallelized_loader.py```.

And minor bugs are fixed where shuffle_buffer_length is taken as an implicit input in some model that reimplement train method in ```GluonEstimator```. Current I only find wavenet does this.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
