### PR TITLE
Shape squeeze edge case bug fix

### DIFF
--- a/src/gluonts/transform/feature.py
+++ b/src/gluonts/transform/feature.py
@@ -107,7 +107,8 @@ class LastValueImputation(MissingValueImputation):
         out = values[np.arange(idx.shape[0])[:, None], idx]
 
         values = np.squeeze(out)
-
+        if values.shape == ():  # edge case when we pass a single value
+            values = values.reshape(1,)
         # in case we need to replace nan at the start of the array
         mask = np.isnan(values)
         values[mask] = np.interp(

--- a/src/gluonts/transform/feature.py
+++ b/src/gluonts/transform/feature.py
@@ -87,6 +87,8 @@ class MeanValueImputation(MissingValueImputation):
     """
 
     def __call__(self, values: np.ndarray) -> np.ndarray:
+        if len(values) == 1:
+            return DummyValueImputation()(values)
         nan_indices = np.where(np.isnan(values))
         values[nan_indices] = np.nanmean(values)
         return values
@@ -125,6 +127,8 @@ class CausalMeanValueImputation(MissingValueImputation):
     """
 
     def __call__(self, values: np.ndarray) -> np.ndarray:
+        if len(values) == 1:
+            return DummyValueImputation()(values)
         mask = np.isnan(values)
 
         # we cannot compute the mean with this method if there are nans
@@ -161,6 +165,8 @@ class RollingMeanValueImputation(MissingValueImputation):
         self.window_size = 1 if window_size < 1 else window_size
 
     def __call__(self, values: np.ndarray) -> np.ndarray:
+        if len(values) == 1:
+            return DummyValueImputation()(values)
         mask = np.isnan(values)
 
         # we cannot compute the mean with this method if there are nans

--- a/src/gluonts/transform/feature.py
+++ b/src/gluonts/transform/feature.py
@@ -99,6 +99,8 @@ class LastValueImputation(MissingValueImputation):
     """
 
     def __call__(self, values: np.ndarray) -> np.ndarray:
+        if len(values) == 1:
+            return DummyValueImputation()(values)
         values = np.expand_dims(values, axis=0)
 
         mask = np.isnan(values)
@@ -107,8 +109,6 @@ class LastValueImputation(MissingValueImputation):
         out = values[np.arange(idx.shape[0])[:, None], idx]
 
         values = np.squeeze(out)
-        if values.shape == ():  # edge case when we pass a single value
-            values = values.reshape(1,)
         # in case we need to replace nan at the start of the array
         mask = np.isnan(values)
         values[mask] = np.interp(

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -969,8 +969,6 @@ def test_AddObservedIndicator():
 
             res = transfo.transform(d)
 
-            print(i)
-            print(method)
             assert np.array_equal(d_expected_results[method][i], res["target"])
             assert np.array_equal(
                 expected_missindicators[i], res[FieldName.OBSERVED_VALUES]

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -894,9 +894,11 @@ def test_AddObservedIndicator():
     Tests the different methods to impute missing values.
     """
 
-    array_value = np.array(
-        [np.nan, 1.0, 1.0, np.nan, 2.0, np.nan, 1.0, np.nan]
-    )
+    array_values = [
+        np.array([np.nan, 1.0, 1.0, np.nan, 2.0, np.nan, 1.0, np.nan]),
+        np.array([np.nan]),
+        np.array([10.0]),
+    ]
 
     l_methods = [
         "dummy_value",
@@ -916,32 +918,63 @@ def test_AddObservedIndicator():
         "rolling_mean10": RollingMeanValueImputation(10),
     }
 
-    d_expected_result = {
-        "dummy_value": np.array([0.0, 1.0, 1.0, 0.0, 2.0, 0.0, 1.0, 0.0]),
-        "mean": np.array([1.25, 1.0, 1.0, 1.25, 2.0, 1.25, 1.0, 1.25]),
-        "causal_mean": np.array([1.0, 1.0, 1.0, 1.0, 2.0, 1.2, 1.0, 9 / 7]),
-        "last_value": np.array([1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 1.0, 1.0]),
-        "rolling_mean10": np.array([1.0, 1.0, 1.0, 1.0, 2.0, 1.1, 1.0, 1.2]),
-        "rolling_mean1": np.array([1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 1.0, 1.0]),
+    d_expected_results = {
+        "dummy_value": [
+            np.array([0.0, 1.0, 1.0, 0.0, 2.0, 0.0, 1.0, 0.0]),
+            np.array([0.0]),
+            np.array([10.0]),
+        ],
+        "mean": [
+            np.array([1.25, 1.0, 1.0, 1.25, 2.0, 1.25, 1.0, 1.25]),
+            np.array([0.0]),
+            np.array([10.0]),
+        ],
+        "causal_mean": [
+            np.array([1.0, 1.0, 1.0, 1.0, 2.0, 1.2, 1.0, 9 / 7]),
+            np.array([0.0]),
+            np.array([10.0]),
+        ],
+        "last_value": [
+            np.array([1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 1.0, 1.0]),
+            np.array([0.0]),
+            np.array([10.0]),
+        ],
+        "rolling_mean10": [
+            np.array([1.0, 1.0, 1.0, 1.0, 2.0, 1.1, 1.0, 1.2]),
+            np.array([0.0]),
+            np.array([10.0]),
+        ],
+        "rolling_mean1": [
+            np.array([1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 1.0, 1.0]),
+            np.array([0.0]),
+            np.array([10.0]),
+        ],
     }
 
-    expected_missindicator = np.array([0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0])
+    expected_missindicators = [
+        np.array([0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0]),
+        np.array([0.0]),
+        np.array([1.0]),
+    ]
 
-    for method in l_methods:
-        transfo = transform.AddObservedValuesIndicator(
-            target_field=FieldName.TARGET,
-            output_field=FieldName.OBSERVED_VALUES,
-            imputation_method=d_method_instances[method],
-        )
+    for i, array_value in enumerate(array_values):
+        for method in l_methods:
+            transfo = transform.AddObservedValuesIndicator(
+                target_field=FieldName.TARGET,
+                output_field=FieldName.OBSERVED_VALUES,
+                imputation_method=d_method_instances[method],
+            )
 
-        d = {"target": array_value.copy()}
+            d = {"target": array_value.copy()}
 
-        res = transfo.transform(d)
+            res = transfo.transform(d)
 
-        assert np.array_equal(d_expected_result[method], res["target"])
-        assert np.array_equal(
-            expected_missindicator, res[FieldName.OBSERVED_VALUES]
-        )
+            print(i)
+            print(method)
+            assert np.array_equal(d_expected_results[method][i], res["target"])
+            assert np.array_equal(
+                expected_missindicators[i], res[FieldName.OBSERVED_VALUES]
+            )
 
 
 def make_dataset(N, train_length):


### PR DESCRIPTION
Fixes an edge case where we pass a single value and `np.squeeze` suppresses all dimensions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
