### PR TITLE
MQCNN: Support for past dynamic features and scaling

### DIFF
--- a/src/gluonts/dataset/field_names.py
+++ b/src/gluonts/dataset/field_names.py
@@ -27,6 +27,11 @@ class FieldName:
     FEAT_STATIC_REAL = "feat_static_real"
     FEAT_DYNAMIC_CAT = "feat_dynamic_cat"
     FEAT_DYNAMIC_REAL = "feat_dynamic_real"
+    PAST_FEAT_DYNAMIC_REAL = "past_feat_dynamic_real"
+    FEAT_DYNAMIC_REAL_LEGACY = "dynamic_feat"
+
+    FEAT_DYNAMIC = "feat_dynamic"
+    PAST_FEAT_DYNAMIC = "past_feat_dynamic"
 
     FEAT_DYNAMIC = "feat_dynamic"
 

--- a/src/gluonts/dataset/stat.py
+++ b/src/gluonts/dataset/stat.py
@@ -117,6 +117,7 @@ class DatasetStatistics(NamedTuple):
     min_target: float
     feat_static_real: List[Set[float]]
     feat_static_cat: List[Set[int]]
+    num_past_feat_dynamic_real: Optional[int]
     num_feat_dynamic_real: Optional[int]
     num_feat_dynamic_cat: Optional[int]
     num_missing_values: int
@@ -164,6 +165,7 @@ def calculate_dataset_statistics(ts_dataset: Any) -> DatasetStatistics:
     observed_feat_static_real: Optional[List[Set[float]]] = None
     num_feat_static_real: Optional[int] = None
     num_feat_static_cat: Optional[int] = None
+    num_past_feat_dynamic_real: Optional[int] = None
     num_feat_dynamic_real: Optional[int] = None
     num_feat_dynamic_cat: Optional[int] = None
     num_missing_values = 0
@@ -300,6 +302,8 @@ def calculate_dataset_statistics(ts_dataset: Any) -> DatasetStatistics:
             feat_dynamic_real = None
             if FieldName.FEAT_DYNAMIC_REAL in ts:
                 feat_dynamic_real = ts[FieldName.FEAT_DYNAMIC_REAL]
+            elif FieldName.FEAT_DYNAMIC_REAL_LEGACY in ts:
+                feat_dynamic_real = ts[FieldName.FEAT_DYNAMIC_REAL_LEGACY]
 
             if feat_dynamic_real is None:
                 # feat_dynamic_real not found, check it was the first ts we encounter or
@@ -338,6 +342,40 @@ def calculate_dataset_statistics(ts_dataset: Any) -> DatasetStatistics:
                     len(target),
                 )
 
+            # PAST_FEAT_DYNAMIC_REAL
+            past_feat_dynamic_real = None
+            if FieldName.PAST_FEAT_DYNAMIC_REAL in ts:
+                past_feat_dynamic_real = ts[FieldName.PAST_FEAT_DYNAMIC_REAL]
+
+            if past_feat_dynamic_real is None:
+                # past_feat_dynamic_real not found, check it was the first ts we encounter or
+                # that past_feat_dynamic_real were seen before
+                assert_data_error(
+                    num_past_feat_dynamic_real is None
+                    or num_past_feat_dynamic_real == 0,
+                    "past_feat_dynamic_real was found for some instances but not others.",
+                )
+                num_past_feat_dynamic_real = 0
+            else:
+                if num_past_feat_dynamic_real is None:
+                    # first num_past_feat_dynamic_real found
+                    num_past_feat_dynamic_real = len(past_feat_dynamic_real)
+                else:
+                    assert_data_error(
+                        num_past_feat_dynamic_real
+                        == len(past_feat_dynamic_real),
+                        "Found instances with different number of features in "
+                        "past_feat_dynamic_real, found one with {} and another with {}.",
+                        num_past_feat_dynamic_real,
+                        len(past_feat_dynamic_real),
+                    )
+
+                assert_data_error(
+                    np.all(np.isfinite(past_feat_dynamic_real)),
+                    "Features values have to be finite and cannot exceed single "
+                    "precision floating point range.",
+                )
+
     assert_data_error(num_time_series > 0, "Time series dataset is empty!")
     assert_data_error(
         num_time_observations > 0,
@@ -371,6 +409,7 @@ def calculate_dataset_statistics(ts_dataset: Any) -> DatasetStatistics:
         feat_static_cat=observed_feat_static_cat
         if observed_feat_static_cat
         else [],
+        num_past_feat_dynamic_real=num_past_feat_dynamic_real,
         num_feat_dynamic_real=num_feat_dynamic_real,
         num_feat_dynamic_cat=num_feat_dynamic_cat,
         num_time_observations=num_time_observations,

--- a/src/gluonts/model/seq2seq/_forking_estimator.py
+++ b/src/gluonts/model/seq2seq/_forking_estimator.py
@@ -17,14 +17,13 @@ from typing import List, Optional
 # Third-party imports
 import numpy as np
 
+# First-party imports
 from gluonts.core.component import DType, validated
 from gluonts.dataset.field_names import FieldName
 from gluonts.model.estimator import GluonEstimator
 from gluonts.model.forecast import Quantile
 from gluonts.model.forecast_generator import QuantileForecastGenerator
 from gluonts.model.predictor import Predictor, RepresentableBlockPredictor
-
-# First-party imports
 from gluonts.mx.block.decoder import Seq2SeqDecoder
 from gluonts.mx.block.enc2dec import FutureFeatIntegratorEnc2Dec
 from gluonts.mx.block.encoder import Seq2SeqEncoder
@@ -91,30 +90,37 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
     prediction_length
         length of the decoding sequence.
     context_length
-        length of the encoding sequence (default: 4 * prediction_length)
+        length of the encoding sequence. (default: 4 * prediction_length)
+    use_past_feat_dynamic_real
+        Whether to use the ``past_feat_dynamic_real`` field from the data. (default: False)
     use_feat_dynamic_real
-        Whether to use the ``feat_dynamic_real`` field from the data (default: False)
+        Whether to use the ``feat_dynamic_real`` field from the data. (default: False)
     use_feat_static_cat:
-        Whether to use the ``feat_static_cat`` field from the data (default: False)
+        Whether to use the ``feat_static_cat`` field from the data. (default: False)
     cardinality: List[int] = None,
         Number of values of each categorical feature.
-        This must be set if ``use_feat_static_cat == True`` (default: None)
+        This must be set if ``use_feat_static_cat == True``. (default: None)
     embedding_dimension: List[int] = None,
-        Dimension of the embeddings for categorical features
+        Dimension of the embeddings for categorical features.
         (default: [min(50, (cat+1)//2) for cat in cardinality])
     add_time_feature
-        Adds a set of time features.  (default: False)
+        Adds a set of time features. (default: True)
     add_age_feature
         Adds an age feature. (default: False)
         The age feature starts with a small value at the start of the time series and grows over time.
+    enable_encoder_dynamic_feature
+        Whether the encoder should also be provided with the dynamic features (``age``, ``time``
+        and ``feat_dynamic_real`` if enabled respectively). (default: True)
     enable_decoder_dynamic_feature
         Whether the decoder should also be provided with the dynamic features (``age``, ``time``
         and ``feat_dynamic_real`` if enabled respectively). (default: False)
-        It makes sense to disable this, if you dont have ``feat_dynamic_real`` for the prediction range.
+        It makes sense to disable this, if you don't have ``feat_dynamic_real`` for the prediction range.
     trainer
         trainer (default: Trainer())
     scaling
-        Whether to automatically scale the target values (default: False)
+        Whether to automatically scale the target values. (default: False)
+    scaling_decoder_dynamic_feature
+        Whether to automatically scale the dynamic features for the decoder. (default: False)
     dtype
         (default: np.float32)
     """
@@ -128,15 +134,18 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
         freq: str,
         prediction_length: int,
         context_length: Optional[int] = None,
+        use_past_feat_dynamic_real: bool = False,
         use_feat_dynamic_real: bool = False,
         use_feat_static_cat: bool = False,
         cardinality: List[int] = None,
         embedding_dimension: List[int] = None,
-        add_time_feature: bool = False,
+        add_time_feature: bool = True,
         add_age_feature: bool = False,
+        enable_encoder_dynamic_feature: bool = True,
         enable_decoder_dynamic_feature: bool = False,
         trainer: Trainer = Trainer(),
         scaling: bool = False,
+        scaling_decoder_dynamic_feature: bool = False,
         dtype: DType = np.float32,
     ) -> None:
         super().__init__(trainer=trainer)
@@ -167,6 +176,7 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
             if context_length is not None
             else 4 * self.prediction_length
         )
+        self.use_past_feat_dynamic_real = use_past_feat_dynamic_real
         self.use_feat_dynamic_real = use_feat_dynamic_real
         self.use_feat_static_cat = use_feat_static_cat
         self.cardinality = (
@@ -182,8 +192,10 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
         self.use_dynamic_feat = (
             use_feat_dynamic_real or add_age_feature or add_time_feature
         )
+        self.enable_encoder_dynamic_feature = enable_encoder_dynamic_feature
         self.enable_decoder_dynamic_feature = enable_decoder_dynamic_feature
         self.scaling = scaling
+        self.scaling_decoder_dynamic_feature = scaling_decoder_dynamic_feature
         self.dtype = dtype
 
     def create_transformation(self) -> Transformation:
@@ -197,6 +209,8 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
         # --- GENERAL TRANSFORMATION CHAIN ---
 
         # determine unused input
+        if not self.use_past_feat_dynamic_real:
+            remove_field_names.append(FieldName.PAST_FEAT_DYNAMIC_REAL)
         if not self.use_feat_dynamic_real:
             remove_field_names.append(FieldName.FEAT_DYNAMIC_REAL)
         if not self.use_feat_static_cat:
@@ -239,6 +253,10 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
             dynamic_feat_fields.append(FieldName.FEAT_AGE)
 
         if self.use_feat_dynamic_real:
+            # Backwards compatibility:
+            chain.append(
+                RenameFields({"dynamic_feat": FieldName.FEAT_DYNAMIC_REAL})
+            )
             dynamic_feat_fields.append(FieldName.FEAT_DYNAMIC_REAL)
 
         # we need to make sure that there is always some dynamic input
@@ -249,12 +267,14 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
                     target_field=FieldName.TARGET,
                     output_field=FieldName.FEAT_CONST,
                     pred_length=self.prediction_length,
+                    const=0.0,  # For consistency in case with no dynamic features
                     dtype=self.dtype,
                 ),
             )
             dynamic_feat_fields.append(FieldName.FEAT_CONST)
 
-        # now we map all the dynamic input onto FieldName.FEAT_DYNAMIC
+        # now we map all the dynamic input of length context_length + prediction_length onto FieldName.FEAT_DYNAMIC
+        # we exclude past_feat_dynamic_real since its length is only context_length
         if len(dynamic_feat_fields) > 1:
             chain.append(
                 VstackFeatures(
@@ -288,17 +308,57 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
                 dec_len=self.prediction_length,
                 encoder_series_fields=[
                     FieldName.OBSERVED_VALUES,
+                    # RTS with past and future values which is never empty because added dummy constant variable
+                    FieldName.FEAT_DYNAMIC,
+                ]
+                + (
+                    # RTS with only past values are only used by the encoder
+                    [FieldName.PAST_FEAT_DYNAMIC_REAL]
+                    if self.use_past_feat_dynamic_real
+                    else []
+                ),
+                encoder_disabled_fields=(
+                    [FieldName.FEAT_DYNAMIC]
+                    if not self.enable_encoder_dynamic_feature
+                    else []
+                )
+                + (
+                    [FieldName.PAST_FEAT_DYNAMIC_REAL]
+                    if not self.enable_encoder_dynamic_feature
+                    and self.use_past_feat_dynamic_real
+                    else []
+                ),
+                decoder_series_fields=[
+                    FieldName.OBSERVED_VALUES,
+                    # Decoder will use all fields under FEAT_DYNAMIC which are the RTS with past and future values
                     FieldName.FEAT_DYNAMIC,
                 ],
-                decoder_series_fields=[FieldName.OBSERVED_VALUES]
-                + (
+                decoder_disabled_fields=(
                     [FieldName.FEAT_DYNAMIC]
-                    if self.enable_decoder_dynamic_feature
+                    if not self.enable_decoder_dynamic_feature
                     else []
                 ),
                 prediction_time_decoder_exclude=[FieldName.OBSERVED_VALUES],
             ),
         )
+
+        # past_feat_dynamic features generated above in ForkingSequenceSplitter from those under feat_dynamic - we need
+        # to stack with the other short related time series from the system labeled as past_past_feat_dynamic_real.
+        # The system labels them as past_feat_dynamic_real and the additional past_ is added to the string
+        # in the ForkingSequenceSplitter
+        if self.use_past_feat_dynamic_real:
+            # Stack features from ForkingSequenceSplitter horizontally since they were transposed
+            # so shape is now (enc_len, num_past_feature_dynamic)
+            chain.append(
+                VstackFeatures(
+                    output_field=FieldName.PAST_FEAT_DYNAMIC,
+                    input_fields=[
+                        "past_" + FieldName.PAST_FEAT_DYNAMIC_REAL,
+                        FieldName.PAST_FEAT_DYNAMIC,
+                    ],
+                    h_stack=True,
+                )
+            )
 
         return Chain(chain)
 
@@ -312,6 +372,7 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
             cardinality=self.cardinality,
             embedding_dimension=self.embedding_dimension,
             scaling=self.scaling,
+            scaling_decoder_dynamic_feature=self.scaling_decoder_dynamic_feature,
             dtype=self.dtype,
         )
 
@@ -335,6 +396,7 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
             cardinality=self.cardinality,
             embedding_dimension=self.embedding_dimension,
             scaling=self.scaling,
+            scaling_decoder_dynamic_feature=self.scaling_decoder_dynamic_feature,
             dtype=self.dtype,
         )
 

--- a/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
+++ b/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
@@ -11,20 +11,18 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-import logging
-
 # Standard library imports
+import logging
 import multiprocessing
 from typing import List, Optional
-
-import mxnet as mx
+from distutils.util import strtobool
 
 # Third-party imports
 import numpy as np
-
-from gluonts.core.component import validated
+import mxnet as mx
 
 # First-party imports
+from gluonts.core.component import validated
 from gluonts.dataset.common import Dataset, ListDataset
 from gluonts.dataset.stat import calculate_dataset_statistics
 from gluonts.model.seq2seq._forking_estimator import ForkingSeq2SeqEstimator
@@ -51,6 +49,9 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
     context_length
         Number of time units that condition the predictions, also known as 'lookback period'.
         (default: 4 * prediction_length)
+    use_past_feat_dynamic_real
+        Whether to use the ``past_feat_dynamic_real`` field from the data. (default: False)
+        Automatically inferred when creating the MQCNNEstimator with the `from_inputs` class method.
     use_feat_dynamic_real
         Whether to use the ``feat_dynamic_real`` field from the data. (default: False)
         Automatically inferred when creating the MQCNNEstimator with the `from_inputs` class method.
@@ -68,10 +69,13 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
     add_age_feature
         Adds an age feature. (default: False)
         The age feature starts with a small value at the start of the time series and grows over time.
+    enable_encoder_dynamic_feature
+        Whether the encoder should also be provided with the dynamic features (``age``, ``time``
+        and ``feat_dynamic_real`` if enabled respectively). (default: True)
     enable_decoder_dynamic_feature
         Whether the decoder should also be provided with the dynamic features (``age``, ``time``
-        and ``feat_dynamic_real`` if enabled respectively). (default: True)
-        It makes sense to disable this, if you dont have ``feat_dynamic_real`` for the prediction range.
+        and ``feat_dynamic_real`` if enabled respectively). (default: False)
+        It makes sense to disable this, if you don't have ``feat_dynamic_real`` for the prediction range.
     seed
         Will set the specified int seed for numpy anc MXNet if specified. (default: None)
     decoder_mlp_dim_seq
@@ -100,6 +104,8 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
         The GluonTS trainer to use for training. (default: Trainer())
     scaling
         Whether to automatically scale the target values. (default: False)
+    scaling_decoder_dynamic_feature
+        Whether to automatically scale the dynamic features for the decoder. (default: False)
     """
 
     @validated()
@@ -108,12 +114,14 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
         freq: str,
         prediction_length: int,
         context_length: Optional[int] = None,
+        use_past_feat_dynamic_real: bool = False,
         use_feat_dynamic_real: bool = False,
         use_feat_static_cat: bool = False,
         cardinality: List[int] = None,
         embedding_dimension: List[int] = None,
         add_time_feature: bool = False,
         add_age_feature: bool = False,
+        enable_encoder_dynamic_feature: bool = True,
         enable_decoder_dynamic_feature: bool = False,
         seed: Optional[int] = None,
         decoder_mlp_dim_seq: Optional[List[int]] = None,
@@ -124,6 +132,7 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
         quantiles: Optional[List[float]] = None,
         trainer: Trainer = Trainer(),
         scaling: bool = False,
+        scaling_decoder_dynamic_feature: bool = False,
     ) -> None:
 
         assert (
@@ -153,7 +162,7 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
             channels_seq if channels_seq is not None else [30, 30, 30]
         )
         self.dilation_seq = (
-            dilation_seq if dilation_seq is not None else [1, 3, 5]
+            dilation_seq if dilation_seq is not None else [1, 3, 9]
         )
         self.kernel_size_seq = (
             kernel_size_seq if kernel_size_seq is not None else [7, 3, 3]
@@ -176,6 +185,7 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
         if seed:
             np.random.seed(seed)
             mx.random.seed(seed)
+
 
         # `use_static_feat` and `use_dynamic_feat` always True because network
         # always receives input; either from the input data or constants
@@ -205,8 +215,10 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
             freq=freq,
             prediction_length=prediction_length,
             context_length=context_length,
+            use_past_feat_dynamic_real=use_past_feat_dynamic_real,
             use_feat_dynamic_real=use_feat_dynamic_real,
             use_feat_static_cat=use_feat_static_cat,
+            enable_encoder_dynamic_feature=enable_encoder_dynamic_feature,
             enable_decoder_dynamic_feature=enable_decoder_dynamic_feature,
             cardinality=cardinality,
             embedding_dimension=embedding_dimension,
@@ -214,26 +226,99 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
             add_age_feature=add_age_feature,
             trainer=trainer,
             scaling=scaling,
+            scaling_decoder_dynamic_feature=scaling_decoder_dynamic_feature,
         )
 
     @classmethod
     def derive_auto_fields(cls, train_iter):
         stats = calculate_dataset_statistics(train_iter)
 
-        auto_fields = {
+        return {
+            "use_past_feat_dynamic_real": stats.num_past_feat_dynamic_real > 0,
             "use_feat_dynamic_real": stats.num_feat_dynamic_real > 0,
             "use_feat_static_cat": bool(stats.feat_static_cat),
             "cardinality": [len(cats) for cats in stats.feat_static_cat],
         }
 
-        logger = logging.getLogger(__name__)
-        logger.info(
-            f"gluonts[from_inputs]: use_feat_dynamic_real set to "
-            f"'{auto_fields['use_feat_dynamic_real']}', and use use_feat_static_cat to "
-            f"'{auto_fields['use_feat_static_cat']}' with cardinality of '{auto_fields['cardinality']}'"
+    # FIXME: for now we always want the dataset to be cached and utilize multiprocessing.
+    # TODO it properly: Enable caching of the dataset in the `_load_datasets` function of the shell,
+    # TODO and pass `num_workers` from train_env in the `run_train_and_test` method to `run_train`,
+    # TODO which in turn has to pass it to train(...)
+    def train(
+        self,
+        training_data: Dataset,
+        validation_data: Optional[Dataset] = None,
+        num_workers: Optional[int] = None,
+        num_prefetch: Optional[int] = None,
+        **kwargs,
+    ):
+        cached_train_data = ListDataset(
+            data_iter=list(training_data), freq=self.freq,
+        )
+        cached_validation_data = (
+            None
+            if validation_data is None
+            else ListDataset(data_iter=list(validation_data), freq=self.freq)
+        )
+        num_workers = (
+            num_workers
+            if num_workers is not None
+            else min(4, int(np.ceil(np.sqrt(multiprocessing.cpu_count()))))
         )
 
-        return auto_fields
+        logger = logging.getLogger(__name__)
+        logger.info(f"gluonts[multiprocessing]: num_workers={num_workers}")
+
+        return super().train(
+            training_data=cached_train_data,
+            validation_data=cached_validation_data,
+            num_workers=num_workers,
+            num_prefetch=num_prefetch,
+            **kwargs,
+        )
+
+    @classmethod
+    def from_inputs(cls, train_iter, **params):
+        logger = logging.getLogger(__name__)
+        logger.info(
+            f"gluonts[from_inputs]: User supplied params set to {params}"
+        )
+        # auto_params usually include `use_feat_dynamic_real`, `use_past_feat_dynamic_real`,
+        # `use_feat_static_cat` and `cardinality`
+        auto_params = cls.derive_auto_fields(train_iter)
+
+        fields = [
+            "use_feat_dynamic_real",
+            "use_past_feat_dynamic_real",
+            "use_feat_static_cat",
+        ]
+        # user defined arguments become implications
+        for field in fields:
+            if (
+                field in params.keys()
+                and (
+                    params[field]
+                    if type(params[field]) == bool
+                    else strtobool(params[field])
+                )
+                and not auto_params[field]
+            ):
+                logger.warning(
+                    f"gluonts[from_inputs]: {field} set to False since it is not present in the data."
+                )
+                params[field] = False
+                if field == "use_feat_static_cat":
+                    params["cardinality"] = None
+
+        # user specified 'params' will take precedence:
+        params = {**auto_params, **params}
+        logger.info(
+            f"gluonts[from_inputs]: use_past_feat_dynamic_real set to "
+            f"'{params['use_past_feat_dynamic_real']}', use_feat_dynamic_real set to "
+            f"'{params['use_feat_dynamic_real']}', and use_feat_static_cat set to "
+            f"'{params['use_feat_static_cat']}' with cardinality of '{params['cardinality']}'"
+        )
+        return cls.from_hyperparameters(**params)
 
 
 class MQRNNEstimator(ForkingSeq2SeqEstimator):
@@ -251,7 +336,8 @@ class MQRNNEstimator(ForkingSeq2SeqEstimator):
         decoder_mlp_dim_seq: List[int] = None,
         trainer: Trainer = Trainer(),
         quantiles: List[float] = None,
-        scaling: bool = True,
+        scaling: bool = False,
+        scaling_decoder_dynamic_feature: bool = False,
     ) -> None:
 
         assert (
@@ -303,4 +389,5 @@ class MQRNNEstimator(ForkingSeq2SeqEstimator):
             context_length=context_length,
             trainer=trainer,
             scaling=scaling,
+            scaling_decoder_dynamic_feature=scaling_decoder_dynamic_feature,
         )

--- a/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
+++ b/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
@@ -186,7 +186,6 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
             np.random.seed(seed)
             mx.random.seed(seed)
 
-
         # `use_static_feat` and `use_dynamic_feat` always True because network
         # always receives input; either from the input data or constants
         encoder = HierarchicalCausalConv1DEncoder(
@@ -253,7 +252,7 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
         **kwargs,
     ):
         cached_train_data = ListDataset(
-            data_iter=list(training_data), freq=self.freq,
+            data_iter=list(training_data), freq=self.freq
         )
         cached_validation_data = (
             None

--- a/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
+++ b/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
@@ -249,6 +249,7 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
         validation_data: Optional[Dataset] = None,
         num_workers: Optional[int] = None,
         num_prefetch: Optional[int] = None,
+        shuffle_buffer_length: Optional[int] = None,
         **kwargs,
     ):
         cached_train_data = ListDataset(
@@ -273,6 +274,7 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
             validation_data=cached_validation_data,
             num_workers=num_workers,
             num_prefetch=num_prefetch,
+            shuffle_buffer_length=shuffle_buffer_length,
             **kwargs,
         )
 

--- a/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
+++ b/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
@@ -239,45 +239,6 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
             "cardinality": [len(cats) for cats in stats.feat_static_cat],
         }
 
-    # FIXME: for now we always want the dataset to be cached and utilize multiprocessing.
-    # TODO it properly: Enable caching of the dataset in the `_load_datasets` function of the shell,
-    # TODO and pass `num_workers` from train_env in the `run_train_and_test` method to `run_train`,
-    # TODO which in turn has to pass it to train(...)
-    def train(
-        self,
-        training_data: Dataset,
-        validation_data: Optional[Dataset] = None,
-        num_workers: Optional[int] = None,
-        num_prefetch: Optional[int] = None,
-        shuffle_buffer_length: Optional[int] = None,
-        **kwargs,
-    ):
-        cached_train_data = ListDataset(
-            data_iter=list(training_data), freq=self.freq
-        )
-        cached_validation_data = (
-            None
-            if validation_data is None
-            else ListDataset(data_iter=list(validation_data), freq=self.freq)
-        )
-        num_workers = (
-            num_workers
-            if num_workers is not None
-            else min(4, int(np.ceil(np.sqrt(multiprocessing.cpu_count()))))
-        )
-
-        logger = logging.getLogger(__name__)
-        logger.info(f"gluonts[multiprocessing]: num_workers={num_workers}")
-
-        return super().train(
-            training_data=cached_train_data,
-            validation_data=cached_validation_data,
-            num_workers=num_workers,
-            num_prefetch=num_prefetch,
-            shuffle_buffer_length=shuffle_buffer_length,
-            **kwargs,
-        )
-
     @classmethod
     def from_inputs(cls, train_iter, **params):
         logger = logging.getLogger(__name__)

--- a/src/gluonts/model/seq2seq/_seq2seq_estimator.py
+++ b/src/gluonts/model/seq2seq/_seq2seq_estimator.py
@@ -22,7 +22,7 @@ from gluonts import transform
 from gluonts.core.component import validated
 from gluonts.dataset.field_names import FieldName
 from gluonts.model.estimator import GluonEstimator
-from gluonts.model.forecast import Quantile, QuantileForecast
+from gluonts.model.forecast import Quantile
 from gluonts.model.forecast_generator import QuantileForecastGenerator
 from gluonts.model.predictor import Predictor, RepresentableBlockPredictor
 from gluonts.mx.block.decoder import OneShotDecoder

--- a/src/gluonts/testutil/dummy_datasets.py
+++ b/src/gluonts/testutil/dummy_datasets.py
@@ -34,6 +34,7 @@ def make_dummy_datasets_with_features(
     prediction_length: int = 3,
     cardinality: List[int] = [],
     num_feat_dynamic_real: int = 0,
+    num_past_feat_dynamic_real: int = 0,
 ) -> Tuple[ListDataset, ListDataset]:
 
     data_iter_train = []
@@ -49,6 +50,13 @@ def make_dummy_datasets_with_features(
             data_entry_train[FieldName.FEAT_STATIC_CAT] = [
                 randint(0, c) for c in cardinality
             ]
+        if num_past_feat_dynamic_real > 0:
+            data_entry_train[FieldName.PAST_FEAT_DYNAMIC_REAL] = [
+                [float(1 + k)] * ts_length
+                for k in range(num_past_feat_dynamic_real)
+            ]
+        # Since used directly in predict and not in make_evaluate_predictions,
+        # where the test target would be chopped, test and train target have the same lengths
         data_entry_test = data_entry_train.copy()
         if num_feat_dynamic_real > 0:
             data_entry_train[FieldName.FEAT_DYNAMIC_REAL] = [

--- a/src/gluonts/transform/convert.py
+++ b/src/gluonts/transform/convert.py
@@ -90,7 +90,8 @@ class ExpandDimArray(SimpleTransformation):
 
 class VstackFeatures(SimpleTransformation):
     """
-    Stack fields together using ``np.vstack``.
+    Stack fields together using ``np.vstack`` when h_stack = False.
+    Otherwise stack fields together using ``np.hstack``.
 
     Fields with value ``None`` are ignored.
 
@@ -102,6 +103,8 @@ class VstackFeatures(SimpleTransformation):
         Fields to stack together
     drop_inputs
         If set to true the input fields will be dropped.
+    h_stack
+        To stack horizontally instead of vertically
     """
 
     @validated()
@@ -110,6 +113,7 @@ class VstackFeatures(SimpleTransformation):
         output_field: str,
         input_fields: List[str],
         drop_inputs: bool = True,
+        h_stack: bool = False,
     ) -> None:
         self.output_field = output_field
         self.input_fields = input_fields
@@ -120,6 +124,7 @@ class VstackFeatures(SimpleTransformation):
                 fname for fname in self.input_fields if fname != output_field
             ]
         )
+        self.h_stack = h_stack
 
     def transform(self, data: DataEntry) -> DataEntry:
         r = [
@@ -127,7 +132,7 @@ class VstackFeatures(SimpleTransformation):
             for fname in self.input_fields
             if data[fname] is not None
         ]
-        output = np.vstack(r)
+        output = np.vstack(r) if not self.h_stack else np.hstack(r)
         data[self.output_field] = output
         for fname in self.cols_to_drop:
             del data[fname]

--- a/test/dataset/test_stat.py
+++ b/test/dataset/test_stat.py
@@ -48,6 +48,7 @@ def make_time_series(
     feat_static_real=fsr,
     num_feat_dynamic_cat=1,
     num_feat_dynamic_real=1,
+    num_past_feat_dynamic_real=1,
 ) -> DataEntry:
     feat_dynamic_cat = (
         make_dummy_dynamic_feat(target, num_feat_dynamic_cat).astype("int64")
@@ -59,6 +60,13 @@ def make_time_series(
         if num_feat_dynamic_real > 0
         else None
     )
+    past_feat_dynamic_real = (
+        make_dummy_dynamic_feat(target, num_past_feat_dynamic_real).astype(
+            "float"
+        )
+        if num_past_feat_dynamic_real > 0
+        else None
+    )
     data = {
         "start": start,
         "target": target,
@@ -66,6 +74,7 @@ def make_time_series(
         "feat_static_real": feat_static_real,
         "feat_dynamic_cat": feat_dynamic_cat,
         "feat_dynamic_real": feat_dynamic_real,
+        "past_feat_dynamic_real": past_feat_dynamic_real,
     }
     return data
 
@@ -118,6 +127,7 @@ class DatasetStatisticsTest(unittest.TestCase):
             feat_static_real=[{0.1}, {0.2, 0.3}],
             feat_static_cat=[{1}, {2, 3}],
             num_feat_dynamic_real=2,
+            num_past_feat_dynamic_real=3,
             num_feat_dynamic_cat=2,
             num_missing_values=0,
             scale_histogram=scale_histogram,
@@ -133,6 +143,7 @@ class DatasetStatisticsTest(unittest.TestCase):
                     feat_static_real=[0.1, 0.2],
                     num_feat_dynamic_cat=2,
                     num_feat_dynamic_real=2,
+                    num_past_feat_dynamic_real=3,
                 ),
                 make_time_series(
                     target=targets[1, :],
@@ -140,6 +151,7 @@ class DatasetStatisticsTest(unittest.TestCase):
                     feat_static_real=[0.1, 0.3],
                     num_feat_dynamic_cat=2,
                     num_feat_dynamic_real=2,
+                    num_past_feat_dynamic_real=3,
                 ),
                 make_time_series(
                     target=np.array([]),
@@ -147,6 +159,7 @@ class DatasetStatisticsTest(unittest.TestCase):
                     feat_static_real=[0.1, 0.3],
                     num_feat_dynamic_cat=2,
                     num_feat_dynamic_real=2,
+                    num_past_feat_dynamic_real=3,
                 ),
             ],
         )

--- a/test/model/seq2seq/test_model.py
+++ b/test/model/seq2seq/test_model.py
@@ -50,31 +50,38 @@ def test_accuracy(
         num_batches_per_epoch=100, hybridize=hybridize, quantiles=quantiles
     )
 
-    accuracy_test(Estimator, hyperparameters, accuracy=0.30)
+    accuracy_test(Estimator, hyperparameters, accuracy=0.20)
 
 
+@pytest.mark.parametrize("use_past_feat_dynamic_real", [True, False])
 @pytest.mark.parametrize("use_feat_dynamic_real", [True, False])
 @pytest.mark.parametrize("add_time_feature", [True, False])
 @pytest.mark.parametrize("add_age_feature", [True, False])
+@pytest.mark.parametrize("enable_encoder_dynamic_feature", [True, False])
 @pytest.mark.parametrize("enable_decoder_dynamic_feature", [True, False])
 @pytest.mark.parametrize("hybridize", [True, False])
 def test_mqcnn_covariate_smoke_test(
+    use_past_feat_dynamic_real,
     use_feat_dynamic_real,
     add_time_feature,
     add_age_feature,
+    enable_encoder_dynamic_feature,
     enable_decoder_dynamic_feature,
     hybridize,
 ):
     hps = {
         "seed": 42,
         "freq": "D",
+        "context_length": 5,
         "prediction_length": 3,
         "quantiles": [0.5, 0.1],
         "epochs": 3,
         "num_batches_per_epoch": 3,
+        "use_past_feat_dynamic_real": use_past_feat_dynamic_real,
         "use_feat_dynamic_real": use_feat_dynamic_real,
         "add_time_feature": add_time_feature,
         "add_age_feature": add_age_feature,
+        "enable_encoder_dynamic_feature": enable_encoder_dynamic_feature,
         "enable_decoder_dynamic_feature": enable_decoder_dynamic_feature,
         "hybridize": hybridize,
     }
@@ -82,6 +89,7 @@ def test_mqcnn_covariate_smoke_test(
     dataset_train, dataset_test = make_dummy_datasets_with_features(
         cardinality=[3, 10],
         num_feat_dynamic_real=2,
+        num_past_feat_dynamic_real=4,
         freq=hps["freq"],
         prediction_length=hps["prediction_length"],
     )
@@ -95,7 +103,8 @@ def test_mqcnn_covariate_smoke_test(
 
 # Test scaling and from inputs
 @pytest.mark.parametrize("scaling", [True, False])
-def test_mqcnn_scaling_smoke_test(scaling):
+@pytest.mark.parametrize("scaling_decoder_dynamic_feature", [True, False])
+def test_mqcnn_scaling_smoke_test(scaling, scaling_decoder_dynamic_feature):
     hps = {
         "seed": 42,
         "freq": "D",
@@ -104,6 +113,7 @@ def test_mqcnn_scaling_smoke_test(scaling):
         "epochs": 3,
         "num_batches_per_epoch": 3,
         "scaling": scaling,
+        "scaling_decoder_dynamic_feature": scaling_decoder_dynamic_feature,
     }
 
     dataset_train, dataset_test = make_dummy_datasets_with_features(
@@ -126,3 +136,48 @@ def test_repr(Estimator, repr_test, hyperparameters):
 
 def test_serialize(Estimator, serialize_test, hyperparameters):
     serialize_test(Estimator, hyperparameters)
+
+
+def test_backwards_compatibility():
+    hps = {
+        "freq": "D",
+        "context_length": 5,
+        "prediction_length": 3,
+        "quantiles": [0.5, 0.1],
+        "epochs": 3,
+        "num_batches_per_epoch": 3,
+        "use_feat_dynamic_real": True,
+        "use_past_feat_dynamic_real": True,
+        "enable_encoder_dynamic_feature": True,
+        "enable_decoder_dynamic_feature": True,
+        "num_workers": 0,
+        "scaling": True,
+        "scaling_decoder_dynamic_feature": True,
+        "num_batches_shuffle": 8,
+    }
+
+    dataset_train, dataset_test = make_dummy_datasets_with_features(
+        cardinality=[3, 10],
+        num_feat_dynamic_real=2,
+        num_past_feat_dynamic_real=4,
+        freq=hps["freq"],
+        prediction_length=hps["prediction_length"],
+    )
+
+    for i in range(len(dataset_train)):
+        dataset_train.list_data[i]["dynamic_feat"] = dataset_train.list_data[
+            i
+        ]["feat_dynamic_real"]
+        del dataset_train.list_data[i]["feat_dynamic_real"]
+
+    for i in range(len(dataset_test)):
+        dataset_test.list_data[i]["dynamic_feat"] = dataset_test.list_data[i][
+            "feat_dynamic_real"
+        ]
+        del dataset_test.list_data[i]["feat_dynamic_real"]
+
+    estimator = MQCNNEstimator.from_inputs(dataset_train, **hps)
+
+    predictor = estimator.train(dataset_train, num_workers=0)
+    forecasts = list(predictor.predict(dataset_test))
+    assert len(forecasts) == len(dataset_test)


### PR DESCRIPTION
*Description of changes:*
- Added support for past dynamic features with `use_past_feat_dynamic_real` boolean.
- Added scaling for dynamic features for the decoder using `scaling_decoder_dynamic_feature` and set default target `scaling = False`
- Enabled dynamic features to be used in only the encoder, only the decoder and both using the booleans `enable_encoder_dynamic_feature` and `enable_decoder_dynamic_feature`
- Updated default parameter values: set `add_time_feature` default to `True`
- Updated default `dilation_seq = [1, 3, 9]`, since that minimized the variance in the experiments


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
