### PR TITLE
Fixing cardinality array when use_feat_static_cat = False

### DIFF
--- a/src/gluonts/model/seq2seq/_forking_estimator.py
+++ b/src/gluonts/model/seq2seq/_forking_estimator.py
@@ -113,7 +113,7 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
         and ``feat_dynamic_real`` if enabled respectively). (default: True)
     enable_decoder_dynamic_feature
         Whether the decoder should also be provided with the dynamic features (``age``, ``time``
-        and ``feat_dynamic_real`` if enabled respectively). (default: False)
+        and ``feat_dynamic_real`` if enabled respectively). (default: True)
         It makes sense to disable this, if you don't have ``feat_dynamic_real`` for the prediction range.
     trainer
         trainer (default: Trainer())
@@ -142,7 +142,7 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
         add_time_feature: bool = True,
         add_age_feature: bool = False,
         enable_encoder_dynamic_feature: bool = True,
-        enable_decoder_dynamic_feature: bool = False,
+        enable_decoder_dynamic_feature: bool = True,
         trainer: Trainer = Trainer(),
         scaling: bool = False,
         scaling_decoder_dynamic_feature: bool = False,

--- a/test/model/seq2seq/test_model.py
+++ b/test/model/seq2seq/test_model.py
@@ -101,6 +101,32 @@ def test_mqcnn_covariate_smoke_test(
     assert len(forecasts) == len(dataset_test)
 
 
+@pytest.mark.parametrize("use_feat_static_cat", [True, False])
+@pytest.mark.parametrize("cardinality", [[], [3, 10]])
+def test_feat_static_cat_smoke_test(use_feat_static_cat, cardinality):
+    hps = {
+        "seed": 42,
+        "freq": "D",
+        "prediction_length": 3,
+        "quantiles": [0.5, 0.1],
+        "epochs": 3,
+        "num_batches_per_epoch": 3,
+        "use_feat_static_cat": use_feat_static_cat,
+    }
+
+    dataset_train, dataset_test = make_dummy_datasets_with_features(
+        cardinality=cardinality,
+        num_feat_dynamic_real=2,
+        freq=hps["freq"],
+        prediction_length=hps["prediction_length"],
+    )
+    estimator = MQCNNEstimator.from_inputs(dataset_train, **hps)
+
+    predictor = estimator.train(dataset_train, num_workers=0)
+    forecasts = list(predictor.predict(dataset_test))
+    assert len(forecasts) == len(dataset_test)
+
+
 # Test scaling and from inputs
 @pytest.mark.parametrize("scaling", [True, False])
 @pytest.mark.parametrize("scaling_decoder_dynamic_feature", [True, False])


### PR DESCRIPTION
*Description of changes:*
- Fixes cardinality when `use_feat_static_cat = False` but `feat_static_cat` present in the dataset
- In this case cardinality was computed in `derive_auto_fields()` 
- Resulted in `AssertionError: You should setcardinality if and only if use_feat_static_cat=True`
- Added `test_feat_static_cat_smoke_test()` to toggle `use_feat_static_cat` on and off for datasets with `feat_static_cat` fields present or not
- Updated defaults:
`add_time_feature = True`
`enable_decoder_dynamic_feature = True`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
