### PR TITLE
Use of \n to split lines in batch transform.

### DIFF
--- a/src/gluonts/shell/serve/app.py
+++ b/src/gluonts/shell/serve/app.py
@@ -128,7 +128,7 @@ def batch_inference_invocations(
 
     def invocations() -> Response:
         request_data = request.data.decode("utf8").strip()
-        instances = list(map(json.loads, request_data.splitlines()))
+        instances = list(map(json.loads, request_data.split("\n")))
         predictions = []
 
         # we have to take this as the initial start-time since the first


### PR DESCRIPTION
`.splitlines()` also splits on `\u2028`, which is not intended since
it can occucr inside a field of the request.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
