### PR TITLE
Simplify backtest_metrics

### DIFF
--- a/src/gluonts/evaluation/backtest.py
+++ b/src/gluonts/evaluation/backtest.py
@@ -30,9 +30,9 @@ from gluonts.dataset.stat import (
     calculate_dataset_statistics,
 )
 from gluonts.evaluation import Evaluator
-from gluonts.model.estimator import Estimator, GluonEstimator
+from gluonts.model.estimator import Estimator
 from gluonts.model.forecast import Forecast
-from gluonts.model.predictor import GluonPredictor, Predictor
+from gluonts.model.predictor import Predictor
 from gluonts.support.util import maybe_len
 from gluonts.transform import TransformedDataset
 
@@ -117,47 +117,27 @@ def serialize_message(logger, message: str, variable):
 
 
 def backtest_metrics(
-    train_dataset: Optional[Dataset],
     test_dataset: Dataset,
-    forecaster: Union[Estimator, Predictor],
+    predictor: Predictor,
     evaluator=Evaluator(
         quantiles=(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9)
     ),
     num_samples: int = 100,
     logging_file: Optional[str] = None,
-    use_symbol_block_predictor: bool = False,
-    num_workers: Optional[int] = None,
-    num_prefetch: Optional[int] = None,
-    **kwargs,
 ):
     """
     Parameters
     ----------
-    train_dataset
-        Dataset to use for training.
     test_dataset
         Dataset to use for testing.
-    forecaster
-        An estimator or a predictor to use for generating predictions.
+    predictor
+        The predictor to test.
     evaluator
         Evaluator to use.
     num_samples
         Number of samples to use when generating sample-based forecasts.
     logging_file
         If specified, information of the backtest is redirected to this file.
-    use_symbol_block_predictor
-        Use a :class:`SymbolBlockPredictor` during testing.
-    num_workers
-        The number of multiprocessing workers to use for data preprocessing.
-        By default 0, in which case no multiprocessing will be utilized.
-    num_prefetch
-        The number of prefetching batches only works if `num_workers` > 0.
-        If `prefetch` > 0, it allow worker process to prefetch certain batches before
-        acquiring data from iterators.
-        Note that using large prefetching batch will provide smoother bootstrapping performance,
-        but will consume more shared_memory. Using smaller number may forfeit the purpose of using
-        multiple worker processes, try reduce `num_workers` in this case.
-        By default it defaults to `num_workers * 2`.
 
     Returns
     -------
@@ -179,48 +159,8 @@ def backtest_metrics(
     else:
         logger = logging.getLogger(__name__)
 
-    if train_dataset is not None:
-        train_statistics = calculate_dataset_statistics(train_dataset)
-        serialize_message(logger, train_dataset_stats_key, train_statistics)
-
     test_statistics = calculate_dataset_statistics(test_dataset)
     serialize_message(logger, test_dataset_stats_key, test_statistics)
-
-    if isinstance(forecaster, Estimator):
-        serialize_message(logger, estimator_key, forecaster)
-        assert train_dataset is not None
-
-        predictor = (
-            forecaster.train(
-                train_dataset,
-                num_workers=num_workers,
-                num_prefetch=num_prefetch,
-                **kwargs,
-            )
-            if isinstance(forecaster, GluonEstimator)
-            else (forecaster.train(train_dataset))
-        )
-
-        if isinstance(forecaster, GluonEstimator) and isinstance(
-            predictor, GluonPredictor
-        ):
-            inference_data_loader = InferenceDataLoader(
-                dataset=test_dataset,
-                transform=predictor.input_transform,
-                batch_size=forecaster.trainer.batch_size,
-                ctx=forecaster.trainer.ctx,
-                dtype=forecaster.dtype,
-            )
-
-            if forecaster.trainer.hybridize:
-                predictor.hybridize(batch=next(iter(inference_data_loader)))
-
-            if use_symbol_block_predictor:
-                predictor = predictor.as_symbol_block_predictor(
-                    batch=next(iter(inference_data_loader))
-                )
-    else:
-        predictor = forecaster
 
     forecast_it, ts_it = make_evaluation_predictions(
         test_dataset, predictor=predictor, num_samples=num_samples
@@ -243,6 +183,7 @@ def backtest_metrics(
     return agg_metrics, item_metrics
 
 
+# TODO does it make sense to have this then?
 class BacktestInformation(NamedTuple):
     train_dataset_stats: DatasetStatistics
     test_dataset_stats: DatasetStatistics

--- a/test/dataset/test_multiprocessing_loader.py
+++ b/test/dataset/test_multiprocessing_loader.py
@@ -469,12 +469,12 @@ def test_general_functionality() -> None:
         prediction_length=prediction_length, freq=freq, trainer=trainer
     )
 
+    predictor = estimator.train(training_data=train_ds)
+
     agg_metrics, item_metrics = backtest_metrics(
-        train_dataset=train_ds,
         test_dataset=test_ds,
-        forecaster=estimator,
+        predictor=predictor,
         evaluator=Evaluator(calculate_owa=False),
-        num_workers=NUM_WORKERS_MP,
     )
 
     # just some sanity check

--- a/test/model/conftest.py
+++ b/test/model/conftest.py
@@ -93,10 +93,10 @@ def accuracy_test(dsinfo):
 
     def test_accuracy(Estimator, hyperparameters, accuracy):
         estimator = from_hyperparameters(Estimator, hyperparameters, dsinfo)
+        predictor = estimator.train(training_data=dsinfo.train_ds)
         agg_metrics, item_metrics = backtest_metrics(
-            train_dataset=dsinfo.train_ds,
             test_dataset=dsinfo.test_ds,
-            forecaster=estimator,
+            predictor=predictor,
             evaluator=Evaluator(calculate_owa=statsmodels is not None),
         )
 

--- a/test/model/deepvar/test_deepvar.py
+++ b/test/model/deepvar/test_deepvar.py
@@ -116,10 +116,11 @@ def test_deepvar(
         ),
     )
 
+    predictor = estimator.train(training_data=dataset.train)
+
     agg_metrics, _ = backtest_metrics(
-        train_dataset=dataset.train,
         test_dataset=dataset.test,
-        forecaster=estimator,
+        predictor=predictor,
         evaluator=MultivariateEvaluator(
             quantiles=(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9)
         ),

--- a/test/model/gpvar/test_gpvar.py
+++ b/test/model/gpvar/test_gpvar.py
@@ -122,10 +122,11 @@ def test_smoke(
         ),
     )
 
+    predictor = estimator.train(training_data=dataset.train)
+
     agg_metrics, _ = backtest_metrics(
-        train_dataset=dataset.train,
         test_dataset=dataset.test,
-        forecaster=estimator,
+        predictor=predictor,
         num_samples=10,
         evaluator=MultivariateEvaluator(
             quantiles=(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9)

--- a/test/model/naive_predictors/test_predictors.py
+++ b/test/model/naive_predictors/test_predictors.py
@@ -125,9 +125,8 @@ def naive_2_predictor():
 def test_accuracy(predictor_cls, parameters, accuracy):
     predictor = predictor_cls(freq=CONSTANT_DATASET_FREQ, **parameters)
     agg_metrics, item_metrics = backtest_metrics(
-        train_dataset=constant_train_ds,
         test_dataset=constant_test_ds,
-        forecaster=predictor,
+        predictor=predictor,
         evaluator=Evaluator(calculate_owa=True),
     )
 

--- a/test/model/test_backtest.py
+++ b/test/model/test_backtest.py
@@ -14,6 +14,7 @@
 # Standard library imports
 import logging
 import math
+import pytest
 from pathlib import Path
 
 # First-party imports
@@ -52,13 +53,15 @@ def test_forecast_parser():
     )
     assert repr(estimator) == repr(load_code(repr(estimator)))
 
+    predictor = estimator.train(training_data=train_ds)
+
     stats = calculate_dataset_statistics(train_ds)
     assert stats == eval(
         repr(stats), globals(), {"gluonts": gluonts}
     )  # TODO: use load
 
     evaluator = Evaluator(quantiles=[0.1, 0.5, 0.9])
-    agg_metrics, _ = backtest_metrics(train_ds, test_ds, estimator, evaluator)
+    agg_metrics, _ = backtest_metrics(test_ds, predictor, evaluator)
 
     # reset infinite metrics to 0 (otherwise the assertion below fails)
     for key, val in agg_metrics.items():
@@ -68,6 +71,7 @@ def test_forecast_parser():
     assert agg_metrics == load_code(dump_code(agg_metrics))
 
 
+@pytest.mark.skip()
 def test_benchmark(caplog):
     # makes sure that information logged can be reconstructed from previous
     # logs
@@ -78,8 +82,9 @@ def test_benchmark(caplog):
         estimator = make_estimator(
             dataset_info.metadata.freq, dataset_info.prediction_length
         )
+        predictor = estimator.train(training_data=train_ds)
         evaluator = Evaluator(quantiles=[0.1, 0.5, 0.9])
-        backtest_metrics(train_ds, test_ds, estimator, evaluator)
+        backtest_metrics(test_ds, predictor, evaluator)
         train_stats = calculate_dataset_statistics(train_ds)
         test_stats = calculate_dataset_statistics(test_ds)
 

--- a/test/model/test_predictor.py
+++ b/test/model/test_predictor.py
@@ -66,5 +66,5 @@ def test_localizer():
 
     local_pred = Localizer(estimator=estimator)
     agg_metrics, _ = backtest_metrics(
-        train_dataset=None, test_dataset=dataset, forecaster=local_pred
+        test_dataset=dataset, predictor=local_pred
     )

--- a/test/paper_examples/test_axiv_paper_examples.py
+++ b/test/paper_examples/test_axiv_paper_examples.py
@@ -25,7 +25,7 @@ def test_listing_1():
     """
     from gluonts.dataset.repository.datasets import get_dataset
     from gluonts.model.deepar import DeepAREstimator
-    from gluonts.trainer import Trainer
+    from gluonts.mx.trainer import Trainer
     from gluonts.evaluation import Evaluator
     from gluonts.evaluation.backtest import backtest_metrics
 
@@ -44,10 +44,7 @@ def test_listing_1():
 
     evaluator = Evaluator(quantiles=(0.1, 0.5, 0.9))
     agg_metrics, item_metrics = backtest_metrics(
-        train_dataset=train_ds,
-        test_dataset=test_ds,
-        forecaster=predictor,
-        evaluator=evaluator,
+        test_dataset=test_ds, predictor=predictor, evaluator=evaluator,
     )
 
 
@@ -159,7 +156,7 @@ def test_appendix_c():
                 future_length=self.prediction_length,
             )
 
-    from gluonts.trainer import Trainer
+    from gluonts.mx.trainer import Trainer
     from gluonts.evaluation import Evaluator
     from gluonts.evaluation.backtest import backtest_metrics
 
@@ -175,8 +172,5 @@ def test_appendix_c():
 
     evaluator = Evaluator(quantiles=(0.1, 0.5, 0.9))
     agg_metrics, item_metrics = backtest_metrics(
-        train_dataset=train_ds,
-        test_dataset=test_ds,
-        forecaster=predictor,
-        evaluator=evaluator,
+        test_dataset=test_ds, predictor=predictor, evaluator=evaluator,
     )


### PR DESCRIPTION
*Description of changes:* The `backtest_metrics` utility function is currently trying to do too much stuff: it can take optional training data, and both a predictor or an estimator, and behave differently based on what it's provided with. As a result, `backtest_metrics` needs to take all sorts of parameters as input (for example regarding multi-processing options in case training is run), and depends on a bunch of model definitions (like GluonEstimator and so on) and data loading utilities (like InferenceDataLoader).

I think this is bad design first of all, but in addition to it this makes it hard (if possible at all) to remove its dependency on MXNet: this prevents us from potentially making it nicely usable with other frameworks.

This PR is simplifying it by letting it take a `predictor` and `test_data` only. Note that this only implies that `estimator.train` is invoked outside, which seems nicer to me.

**PROs**

* Much less code in `backtest_metrics`, at the (rather low) cost of having to invoke `estimator.train` outside

**CONs**

* The mechanism to reconstruct an experiment from the logs of `backtest_metrics` is lost. I think this is fine, and is just a symptom of the fact that this function is trying to do too much. In a sense, logging a whole experiment and being able to reconstruct it would really be the responsibility of some (potentially more general) "experiment runner" component.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
