### PR TITLE
Implemented moving average

### DIFF
--- a/src/gluonts/model/trivial/mean.py
+++ b/src/gluonts/model/trivial/mean.py
@@ -70,10 +70,9 @@ class MeanPredictor(RepresentablePredictor, FallbackPredictor):
         std = np.nanstd(target)
         normal = np.random.standard_normal(self.shape)
 
-        start_date = forecast_start(item)
         return SampleForecast(
             samples=std * normal + mean,
-            start_date=start_date,
+            start_date=forecast_start(item),
             freq=self.freq,
             item_id=item.get(FieldName.ITEM_ID),
         )
@@ -112,9 +111,10 @@ class MovingAveragePredictor(RepresentablePredictor):
     ) -> None:
         super().__init__(freq=freq, prediction_length=prediction_length)
 
-        # assert (
-        #     context_length >= 1
-        # ), "The value of `context_length` should be >= 1"
+        if context_length is not None:
+            assert (
+                context_length >= 1
+            ), "The value of `context_length` should be >= 1 or None"
 
         self.context_length = context_length
 
@@ -129,10 +129,9 @@ class MovingAveragePredictor(RepresentablePredictor):
 
             target.append(np.nanmean(window))
 
-        start_date = forecast_start(item)
         return SampleForecast(
             samples=np.array([target[-self.prediction_length :]]),
-            start_date=start_date,
+            start_date=forecast_start(item),
             freq=self.freq,
             item_id=item.get(FieldName.ITEM_ID),
         )

--- a/src/gluonts/model/trivial/mean.py
+++ b/src/gluonts/model/trivial/mean.py
@@ -108,10 +108,14 @@ class MovingAveragePredictor(RepresentablePredictor):
         self, prediction_length: int, freq: str, context_length: int,
     ) -> None:
         super().__init__(freq=freq, prediction_length=prediction_length)
+
+        assert (
+            context_length >= 1
+        ), "The value of `context_length` should be >= 1"
+
         self.context_length = context_length
 
     def predict_item(self, item: DataEntry) -> SampleForecast:
-
         target = item["target"].tolist()
 
         for _ in range(self.prediction_length):

--- a/src/gluonts/model/trivial/mean.py
+++ b/src/gluonts/model/trivial/mean.py
@@ -114,7 +114,7 @@ class MovingAveragePredictor(RepresentablePredictor):
         if context_length is not None:
             assert (
                 context_length >= 1
-            ), "The value of `context_length` should be >= 1 or None"
+            ), "The value of 'context_length' must be >= 1 or None"
 
         self.context_length = context_length
 

--- a/src/gluonts/model/trivial/mean.py
+++ b/src/gluonts/model/trivial/mean.py
@@ -114,7 +114,7 @@ class MovingAveragePredictor(RepresentablePredictor):
         if context_length is not None:
             assert (
                 context_length >= 1
-            ), "The value of 'context_length' must be >= 1 or None"
+            ), "The value of 'context_length' should be >= 1 or None"
 
         self.context_length = context_length
 

--- a/src/gluonts/model/trivial/mean.py
+++ b/src/gluonts/model/trivial/mean.py
@@ -26,7 +26,7 @@ from gluonts.model.estimator import Estimator
 from gluonts.model.forecast import Forecast, SampleForecast
 from gluonts.model.predictor import FallbackPredictor, RepresentablePredictor
 from gluonts.model.trivial.constant import ConstantPredictor
-from gluonts.support.pandas import frequency_add
+from gluonts.support.pandas import frequency_add, forecast_start
 
 
 class MeanPredictor(RepresentablePredictor, FallbackPredictor):
@@ -105,7 +105,7 @@ class MovingAveragePredictor(RepresentablePredictor):
 
     @validated()
     def __init__(
-        self, prediction_length: int, freq: str, context_length: int,
+        self, prediction_length: int, freq: str, context_length: int = 1,
     ) -> None:
         super().__init__(freq=freq, prediction_length=prediction_length)
 
@@ -122,7 +122,7 @@ class MovingAveragePredictor(RepresentablePredictor):
             window = target[-self.context_length :]
             target.append(np.nanmean(window))
 
-        start_date = frequency_add(item["start"], len(item["target"]))
+        start_date = forecast_start(item)
         return SampleForecast(
             samples=np.array([target[-self.prediction_length :]]),
             start_date=start_date,

--- a/src/gluonts/model/trivial/mean.py
+++ b/src/gluonts/model/trivial/mean.py
@@ -78,6 +78,7 @@ class MeanPredictor(RepresentablePredictor, FallbackPredictor):
             item_id=item.get(FieldName.ITEM_ID),
         )
 
+
 class MovingAveragePredictor(RepresentablePredictor):
     """
     A :class:`Predictor` that predicts the moving average based on the
@@ -104,29 +105,27 @@ class MovingAveragePredictor(RepresentablePredictor):
 
     @validated()
     def __init__(
-            self,
-            prediction_length: int,
-            freq: str,
-            context_length: int,
+        self, prediction_length: int, freq: str, context_length: int,
     ) -> None:
         super().__init__(freq=freq, prediction_length=prediction_length)
         self.context_length = context_length
 
     def predict_item(self, item: DataEntry) -> SampleForecast:
 
-        target = item['target'].tolist()
+        target = item["target"].tolist()
 
         for _ in range(self.prediction_length):
-            window = target[-self.context_length:]
+            window = target[-self.context_length :]
             target.append(np.nanmean(window))
 
         start_date = frequency_add(item["start"], len(item["target"]))
         return SampleForecast(
-            samples=np.array([target[-self.prediction_length:]]),
+            samples=np.array([target[-self.prediction_length :]]),
             start_date=start_date,
             freq=self.freq,
             item_id=item.get(FieldName.ITEM_ID),
         )
+
 
 class MeanEstimator(Estimator):
     """

--- a/test/model/trivial/test_moving_average.py
+++ b/test/model/trivial/test_moving_average.py
@@ -1,0 +1,125 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# First-party imports
+from gluonts.dataset.common import ListDataset
+from gluonts.model.trivial.mean import MovingAveragePredictor
+
+# Third-party imports
+import numpy as np
+
+
+def set_data(target, freq):
+    """
+    Sets test data in the right format
+    """
+
+    start = "2020"
+    ds = ListDataset([{"target": target, "start": start}], freq=freq)
+    data = list(ds)
+
+    return data
+
+
+def get_predictions(data, prediction_length, context_length, freq):
+    """
+    Gets predictions based on moving average
+    """
+
+    mp = MovingAveragePredictor(
+        prediction_length=prediction_length,
+        context_length=context_length,
+        freq=freq,
+    )
+    predictions = mp.predict_item(data[0]).samples[0]
+
+    return predictions
+
+
+def check_equality_constant_sequence(
+    predictions, constant_value, prediction_length
+):
+    """
+    Checks if prediction values coincide with expected values.  This is for the case where the input is constant:
+    expected = [constant_value, constant_value, ..., constant_value]
+    """
+
+    expected = [constant_value] * prediction_length
+
+    if np.isnan(constant_value):
+        return list(np.isnan(predictions)) == list(np.isnan(expected))
+    else:
+        return list(predictions) == expected
+
+
+def run_evaluations(
+    data,
+    freq,
+    constant_value,
+    context_length_values=range(1, 10),
+    prediction_length_values=range(1, 10),
+):
+    """
+    Executes generic tests based on settings provided by input parameters
+    Performs asserts on the output and shape of output.
+    """
+
+    for context_length in context_length_values:
+        for prediction_length in prediction_length_values:
+            predictions = get_predictions(
+                data, prediction_length, context_length, freq
+            )
+            assert check_equality_constant_sequence(
+                predictions, constant_value, prediction_length
+            )
+            assert predictions.shape == (prediction_length,)
+
+
+def test_constant_sequence():
+    constant_value = 1
+    target_length = 3
+    target = [constant_value] * target_length  # [1, 1, 1]
+    freq = "D"
+    data = set_data(target, freq)
+
+    run_evaluations(data, freq, constant_value)
+
+
+def test_length_one_sequence():
+    constant_value = 1
+    # target_length = 1
+    target = [constant_value]
+    freq = "D"
+    data = set_data(target, freq)
+
+    run_evaluations(data, freq, constant_value)
+
+
+def test_empty_sequence():
+    constant_value = np.nan
+    target_length = 0
+    target = []
+    freq = "D"
+    data = set_data(target, freq)
+
+    run_evaluations(data, freq, constant_value)
+
+
+def test_nan_sequence():
+    constant_value = np.nan
+    target_length = 3
+    target = [constant_value] * target_length  # [1, 1, 1]
+    freq = "D"
+    data = set_data(target, freq)
+
+    run_evaluations(data, freq, constant_value)

--- a/test/model/trivial/test_moving_average.py
+++ b/test/model/trivial/test_moving_average.py
@@ -31,7 +31,7 @@ def get_predictions(
 
     ds = ListDataset([{"target": target, "start": start}], freq=freq)
     item = next(iter(ds))
-    predictions = mp.predict_item(item).samples[0]
+    predictions = mp.predict_item(item).mean
 
     return predictions
 
@@ -64,6 +64,12 @@ def get_predictions(
         ([1, 2, 3], [2], 1, 3),
         ([1, 2, 3], [2, 7 / 3], 2, 3),
         ([1, 2, 3], [2, 7 / 3, 22 / 9], 3, 3),
+        ([1, 1, 1], [1], 1, None),
+        ([1, 1, 1], [1, 1], 2, None),
+        ([1, 1, 1], [1, 1, 1], 3, None),
+        ([1, 3, np.nan], [2], 1, None),
+        ([1, 3, np.nan], [2, 2], 2, None),
+        ([1, 3, np.nan], [2, 2, 2], 3, None),
     ],
 )
 def testing(data, expected_output, prediction_length, context_length):
@@ -75,5 +81,3 @@ def testing(data, expected_output, prediction_length, context_length):
     )
 
     np.testing.assert_equal(predictions, expected_output)
-
-    np.testing.assert_equal(predictions.shape, (prediction_length,))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Added moving average.
-- This is a deterministic task (no distribution of observations is assumed)
-- For the case where _prediction_length_ = 1, the output is the standard moving average of the previous _context_length_ observations
-- For the case where _prediction_length_ > 1, the input target is appended with previous moving averages, further computing moving averages until _prediction_length_ of them are computed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
