### PR TITLE
Shell: Fix writing of `output/failure` file in case of error in provided hyper-parameters.

### DIFF
--- a/src/gluonts/shell/__main__.py
+++ b/src/gluonts/shell/__main__.py
@@ -155,8 +155,7 @@ def train_command(data_path: str, forecaster: Optional[str]) -> None:
     from gluonts.shell import train
 
     logger.info("Run 'train' command")
-    path = Path(data_path)
-    train_paths = TrainPaths(path)
+    train_paths = TrainPaths(Path(data_path))
 
     try:
         env = TrainEnv(train_paths)

--- a/src/gluonts/shell/__main__.py
+++ b/src/gluonts/shell/__main__.py
@@ -28,6 +28,7 @@ from gluonts.model.estimator import Estimator
 from gluonts.model.predictor import Predictor
 
 # Relative imports
+from gluonts.shell.sagemaker import TrainPaths
 from gluonts.shell.serve import Settings
 
 from .sagemaker import ServeEnv, TrainEnv
@@ -154,11 +155,11 @@ def train_command(data_path: str, forecaster: Optional[str]) -> None:
     from gluonts.shell import train
 
     logger.info("Run 'train' command")
-    data_path = Path(data_path)
-    failure_path = data_path / "output" / "failure"
+    path = Path(data_path)
+    train_paths = TrainPaths(path)
 
     try:
-        env = TrainEnv(data_path)
+        env = TrainEnv(train_paths)
         if forecaster is None:
             try:
                 forecaster = env.hyperparameters["forecaster_name"]
@@ -173,7 +174,7 @@ def train_command(data_path: str, forecaster: Optional[str]) -> None:
         assert forecaster is not None
         train.run_train_and_test(env, forecaster_type_by_name(forecaster))
     except Exception as error:
-        with open(failure_path, "w") as out_file:
+        with open(train_paths.output / "failure", "w") as out_file:
             out_file.write(str(error))
             out_file.write("\n\n")
             out_file.write(traceback.format_exc())

--- a/src/gluonts/shell/__main__.py
+++ b/src/gluonts/shell/__main__.py
@@ -154,9 +154,11 @@ def train_command(data_path: str, forecaster: Optional[str]) -> None:
     from gluonts.shell import train
 
     logger.info("Run 'train' command")
-    env = TrainEnv(Path(data_path))
+    data_path = Path(data_path)
+    failure_path = data_path / "output" / "failure"
 
     try:
+        env = TrainEnv(data_path)
         if forecaster is None:
             try:
                 forecaster = env.hyperparameters["forecaster_name"]
@@ -171,7 +173,7 @@ def train_command(data_path: str, forecaster: Optional[str]) -> None:
         assert forecaster is not None
         train.run_train_and_test(env, forecaster_type_by_name(forecaster))
     except Exception as error:
-        with open(env.path.output / "failure", "w") as out_file:
+        with open(failure_path, "w") as out_file:
             out_file.write(str(error))
             out_file.write("\n\n")
             out_file.write(traceback.format_exc())

--- a/src/gluonts/shell/sagemaker/__init__.py
+++ b/src/gluonts/shell/sagemaker/__init__.py
@@ -35,8 +35,8 @@ DATASET_NAMES = "train", "test"
 
 
 class TrainEnv:
-    def __init__(self, path: Path = Path("/opt/ml")) -> None:
-        self.path = TrainPaths(path)
+    def __init__(self, path: TrainPaths = TrainPaths(Path("/opt/ml"))) -> None:
+        self.path = path
         self.inputdataconfig = _load_inputdataconfig(self.path.inputdataconfig)
         self.channels = _load_channels(self.path, self.inputdataconfig)
         self.hyperparameters = _load_hyperparameters(

--- a/src/gluonts/testutil/shell.py
+++ b/src/gluonts/testutil/shell.py
@@ -209,7 +209,7 @@ def temporary_train_env(
         path_train.symlink_to(ds_path / "train", target_is_directory=True)
         path_test.symlink_to(ds_path / "test", target_is_directory=True)
 
-        yield TrainEnv(path=paths.base)
+        yield TrainEnv(path=paths)
 
 
 @contextmanager  # type: ignore


### PR DESCRIPTION
Missing or incorrect mandatory Hyperparameters are leading to errors that are not captured inside the `failure` file inside the `output` folder. This PR fixes this problem by including the `env = TrainEnv(Path(data_path))` inside the `try` block and instantiate the `path` beforehand.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
