### PR TITLE
Removing mp worker del method.

### DIFF
--- a/src/gluonts/dataset/parallelized_loader.py
+++ b/src/gluonts/dataset/parallelized_loader.py
@@ -528,17 +528,6 @@ class _MultiWorkerIter(object):
                 return
             yield next_batch
 
-    def __del__(self):
-        # Explicitly load the content from shared memory to delete it
-        # Unfortunately it seems the way the data is pickled prevents efficient implicit GarbageCollection
-        try:
-            for k in list(self._data_buffer.keys()):
-                res = pickle.loads(self._data_buffer.pop(k).get(self._timeout))
-                del res
-        except FileNotFoundError:
-            # The resources were already released
-            pass
-
 
 class ParallelDataLoader(object):
     """


### PR DESCRIPTION
*Issue #, if available:*
Fixes issue https://github.com/awslabs/gluon-ts/issues/837 

*Description of changes:*
Removes legacy `__del__` method from `_MultiWorkerIter` that was used to prevent memory leaks.

*TODO*
- [x]  make sure we don't get memory leaks

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
