### PR TITLE
Bug Fixes and Warnings for Rotbaum

### DIFF
--- a/src/gluonts/model/rotbaum/_preprocess.py
+++ b/src/gluonts/model/rotbaum/_preprocess.py
@@ -356,8 +356,8 @@ class PreprocessOnlyLagFeatures(PreprocessGeneric):
             [(np.floor(elem) == elem) for elem in feat_static_cat]
         )  # asserts that the categorical features are encoded
 
-        assert (not feat_static_cat) or all(
-            [(np.floor(elem) == elem) for elem in feat_dynamic_cat]
+        assert (not feat_dynamic_cat) or all(
+            [(np.floor(elem) == elem) for ent in feat_dynamic_cat for elem in ent]
         )  # asserts that the categorical features are encoded
 
         feat_dynamics = feat_dynamic_real + feat_dynamic_cat

--- a/src/gluonts/model/rotbaum/_preprocess.py
+++ b/src/gluonts/model/rotbaum/_preprocess.py
@@ -357,7 +357,7 @@ class PreprocessOnlyLagFeatures(PreprocessGeneric):
         )  # asserts that the categorical features are encoded
 
         assert (not feat_dynamic_cat) or all(
-            [(np.floor(elem) == elem) for ent in feat_dynamic_cat for elem in ent]
+            [(np.floor(elem) == elem) for elem in feat_dynamic_cat]
         )  # asserts that the categorical features are encoded
 
         feat_dynamics = feat_dynamic_real + feat_dynamic_cat


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR first fixes an issue in Rotbaum where the context_length is an optional parameter when creating a TreePredictor or TreeEstimator but will break if you do not explicitly pass in the context_length. 

It also prints a warning when using Rotbaum that if you are to use the Evaluator class to evaluate the TreePredictor, that you should not use multiprocessing in the Evaluator class.

Finally, this PR should fix a typo in an assertion when preprocessing features for Rotbaum


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
