### PR TITLE
Fixing the FileDataset case with caching off for num_workers calculation

### DIFF
--- a/src/gluonts/dataset/common.py
+++ b/src/gluonts/dataset/common.py
@@ -169,7 +169,7 @@ class FileDataset(Dataset):
         self.cache = cache
         self.path = path
         self.process = ProcessDataEntry(freq, one_dim_target=one_dim_target)
-        self._len = None
+        self._len_per_file = None
 
         if not self.files():
             raise OSError(f"no valid file found in {path}")
@@ -189,13 +189,17 @@ class FileDataset(Dataset):
                 )
                 yield data
 
+    # Returns array of the sizes for each subdataset per file
+    def len_per_file(self):
+        if self._len_per_file is None:
+            len_per_file = [
+                len(json_line_file) for json_line_file in self._json_line_files
+            ]
+            self._len_per_file = len_per_file
+        return self._len_per_file
+
     def __len__(self):
-        if self._len is None:
-            len_sum = sum(
-                [len(jsonl.JsonLinesFile(path=path)) for path in self.files()]
-            )
-            self._len = len_sum
-        return self._len
+        return sum(self.len_per_file())
 
     def files(self) -> List[Path]:
         """

--- a/src/gluonts/dataset/loader.py
+++ b/src/gluonts/dataset/loader.py
@@ -12,10 +12,8 @@
 # permissions and limitations under the License.
 
 # Standard library imports
-import itertools
 import logging
-import multiprocessing as mp
-from typing import Any, Dict, Iterable, Iterator, Optional
+from typing import Iterable, Iterator, Optional
 
 # Third-party imports
 import mxnet as mx
@@ -63,7 +61,6 @@ class DataLoader(Iterable[DataEntry]):
         If not None, the loader will perform pseudo shuffle when generating batches.
         Note that using a larger buffer will provide more randomized batches, but will make the job require a bit
         more time to be done.
-
     """
 
     def __init__(
@@ -88,11 +85,6 @@ class DataLoader(Iterable[DataEntry]):
         self.transform = transform
         self.cyclic = cyclic
         self.logger = logging.getLogger(__name__)
-        if num_workers is not None and num_workers > mp.cpu_count():
-            self.logger.warning(
-                f"num_workers is set to {num_workers}, but there are only {mp.cpu_count()} cpus "
-                f"please reduce the number of workers"
-            )
         self.num_workers = num_workers
         self.num_prefetch = num_prefetch
         self.shuffle_buffer_length = shuffle_buffer_length

--- a/src/gluonts/dataset/parallelized_loader.py
+++ b/src/gluonts/dataset/parallelized_loader.py
@@ -202,7 +202,7 @@ def batchify(
         referenced by identical key are reduced using the stack function"""
     return {
         key: stack(
-            data=[item.get(key, f"Key: {key} not found!") for item in data],
+            data=[item[key] for item in data],
             multi_processing=multi_processing,
             dtype=dtype,
             single_process_ctx=single_process_ctx,

--- a/src/gluonts/dataset/parallelized_loader.py
+++ b/src/gluonts/dataset/parallelized_loader.py
@@ -202,7 +202,7 @@ def batchify(
         referenced by identical key are reduced using the stack function"""
     return {
         key: stack(
-            data=[item[key] for item in data],
+            data=[item.get(key, f"Key: {key} not found!") for item in data],
             multi_processing=multi_processing,
             dtype=dtype,
             single_process_ctx=single_process_ctx,
@@ -615,8 +615,13 @@ class ParallelDataLoader(object):
         self.dataset = dataset
         self.dataset_len: int
         if isinstance(dataset, Sized):
-            assert isinstance(dataset, Sized)
-            self.dataset_len = len(dataset)
+            if isinstance(dataset, FileDataset):
+                # Take non-zero minimum dataset length to be used in num_workers calculation
+                self.dataset_len = min(
+                    filter(lambda x: x > 0, dataset.len_per_file())
+                )
+            else:
+                self.dataset_len = len(dataset)
         else:
             self.dataset_len = len(list(dataset))
         self.transformation = transformation
@@ -640,6 +645,11 @@ class ParallelDataLoader(object):
         self.logger.info(
             f"gluonts[multiprocessing]: num_workers={self.num_workers}"
         )
+        if self.num_workers > multiprocessing.cpu_count():
+            self.logger.warning(
+                f"num_workers is set to {self.num_workers}, but there are only {multiprocessing.cpu_count()} cpus "
+                f"please reduce the number of workers"
+            )
         self.num_prefetch = (
             num_prefetch if num_prefetch is not None else 2 * self.num_workers
         )


### PR DESCRIPTION
Fixing the FileDataset case with caching off for num_workers calculation to set it to the minimum dataset length across all the sub files

## Summary

- Fixed bug with `num_workers > 1` on non-cached dataset with `3` time series so each file only has `1` time series
- We see timeout here because some workers will get assigned 0 time series series and the multiprocessing loader expects the worker to return batches and waits for the `timeout = 120` seconds max but the worker cannot produce batches with 0 time series and will be in a infinite loop
- Added len_per_file__() method to `FileDataset` class for the non-cached case to set `num_workers = min(num_workers, len(dataset_per_file)`
- Updated to take non-zero minimum using lambda function so if we have empty file it will default to the non-zero minimum rather than 0
- Difference between num_workers = 0 and 1 is: 
    - 0 or None: synchronous
    - 1: asynchronous so 1 worker can create batches while the model is doing its forward or backward pass, whereas 0 workers cannot, since it is either processing batches or doing the actual network calculations.
- Moved `num_worker > num_cpu` warning to the appropriate place


## Testing
- Tested on failing test case which has 4 training json files, 3 with 1 time series and 1 with 0.
- `len_per_file()` returns `[1,1,1,0]` so non-zero minimum is 1
- Used to fail fo `num_workers > 0` with `Timeout Error`
- Tested with `"num_workers": "4"` and `"listify_dataset": "no"`, which internally gets adjusted to `num_workers = 1` and `num_prefetch = 2 * num_workers = 2`
- See logs below:

```
[2020-08-13 22:11:59] [INFO] __main__ Run 'train' command
[2020-08-13 22:12:00] [INFO] gluonts.shell.sagemaker gluonts[cached]: listify_dataset = 0
[2020-08-13 22:12:00] [INFO] root Ignoring input file `_SUCCESS`.
[2020-08-13 22:12:00] [INFO] root Ignoring input file `_SUCCESS`.
[2020-08-13 22:12:00] [INFO] gluonts.shell.sagemaker gluonts[cached]: Type of train dataset is gluonts.dataset.common.FileDataset
[2020-08-13 22:12:00] [INFO] gluonts.model.seq2seq._mq_dnn_estimator gluonts[from_inputs]: User supplied params set to {'prediction_length': '3', 'freq': 'H', 'epochs': '5', 'num_workers': '4', 'enable_decoder_dynamic_feature': 'True', 'quantiles': [0.1, 0.5, 0.9]}
[2020-08-13 22:12:00] [INFO] root Ignoring input file `_SUCCESS`.
100%|██████████| 3/3 [00:00<00:00, 78.46it/s]
[2020-08-13 22:12:00] [INFO] gluonts.model.seq2seq._mq_dnn_estimator gluonts[from_inputs]: use_past_feat_dynamic_real set to 'False', use_feat_dynamic_real set to 'False', and use_feat_static_cat set to 'False' with cardinality of '[]'
[2020-08-13 22:12:00] [INFO] gluonts.shell.train The forecaster can be reconstructed with the following expression: gluonts.model.seq2seq._mq_dnn_estimator.MQCNNEstimator(add_age_feature=False, add_time_feature=True, cardinality=[], channels_seq=None, context_length=None, decoder_mlp_dim_seq=None, dilation_seq=None, embedding_dimension=None, enable_decoder_dynamic_feature=True, enable_encoder_dynamic_feature=True, freq="H", kernel_size_seq=None, prediction_length=3, quantiles=[0.1, 0.5, 0.9], scaling=False, scaling_decoder_dynamic_feature=False, seed=None, trainer=gluonts.mx.trainer._base.Trainer(avg_strategy=gluonts.mx.trainer.model_averaging.SelectNBestMean(maximize=False, metric="score", num_models=1), batch_size=32, clip_gradient=10.0, ctx=None, epochs=5, hybridize=True, init="xavier", learning_rate=0.001, learning_rate_decay_factor=0.5, minimum_learning_rate=5e-05, num_batches_per_epoch=50, patience=10, weight_decay=1e-08), use_feat_dynamic_real=False, use_feat_static_cat=False, use_past_feat_dynamic_real=False, use_residual=True)
[2020-08-13 22:12:00] [INFO] gluonts.shell.train Using the following data channels: train
[2020-08-13 22:12:00] [WARNING] gluonts.dataset.parallelized_loader You have set `num_workers` to a non zero value, however, you have not enabled caching for your FileDataset. To improve training performance you can enable caching for the FileDataset.
[2020-08-13 22:12:00] [INFO] root Ignoring input file `_SUCCESS`.
[2020-08-13 22:12:00] [INFO] gluonts.dataset.parallelized_loader gluonts[multiprocessing]: num_workers=1
[2020-08-13 22:12:00] [INFO] gluonts.dataset.parallelized_loader gluonts[multiprocessing]: num_prefetch=2
[2020-08-13 22:12:00] [INFO] gluonts.dataset.parallelized_loader gluonts[multiprocessing]: shuffle_buffer_length=None
[2020-08-13 22:12:00] [INFO] gluonts.trainer Start model training
[2020-08-13 22:12:00] [INFO] gluonts.trainer Epoch[0] Learning rate is 0.001
0%|          | 0/50 [00:00<?, ?it/s][2020-08-13 22:12:00] [INFO] gluonts.trainer Number of parameters in ForkingSeq2SeqTrainingNetwork: 11224
100%|██████████| 50/50 [00:12<00:00,  4.04it/s, epoch=1/5, avg_epoch_loss=12.6]
 [2020-08-13 22:12:12] [INFO] gluonts.trainer Epoch[0] Elapsed time 12.378 seconds
[2020-08-13 22:12:12] [INFO] gluonts.trainer Epoch[0] Evaluation metric 'epoch_loss'=12.649287
[2020-08-13 22:12:12] [INFO] gluonts.trainer Epoch[1] Learning rate is 0.001
100%|██████████| 50/50 [00:11<00:00,  4.28it/s, epoch=2/5, avg_epoch_loss=3.5]
[2020-08-13 22:12:24] [INFO] gluonts.trainer Epoch[1] Elapsed time 11.682 seconds
[2020-08-13 22:12:24] [INFO] gluonts.trainer Epoch[1] Evaluation metric 'epoch_loss'=3.504171
[2020-08-13 22:12:24] [INFO] gluonts.trainer Epoch[2] Learning rate is 0.001
100%|██████████| 50/50 [00:12<00:00,  3.92it/s, epoch=3/5, avg_epoch_loss=1.7]
[2020-08-13 22:12:37] [INFO] gluonts.trainer Epoch[2] Elapsed time 12.774 seconds
[2020-08-13 22:12:37] [INFO] gluonts.trainer Epoch[2] Evaluation metric 'epoch_loss'=1.695773
[2020-08-13 22:12:37] [INFO] gluonts.trainer Epoch[3] Learning rate is 0.001
100%|██████████| 50/50 [00:11<00:00,  4.28it/s, epoch=4/5, avg_epoch_loss=1.5]
[2020-08-13 22:12:48] [INFO] gluonts.trainer Epoch[3] Elapsed time 11.688 seconds
[2020-08-13 22:12:48] [INFO] gluonts.trainer Epoch[3] Evaluation metric 'epoch_loss'=1.501191
[2020-08-13 22:12:48] [INFO] gluonts.trainer Epoch[4] Learning rate is 0.001
100%|██████████| 50/50 [00:16<00:00,  3.00it/s, epoch=5/5, avg_epoch_loss=1.39]
[2020-08-13 22:13:05] [INFO] gluonts.trainer Epoch[4] Elapsed time 16.646 seconds
[2020-08-13 22:13:05] [INFO] gluonts.trainer Epoch[4] Evaluation metric 'epoch_loss'=1.390211
[2020-08-13 22:13:05] [INFO] root Computing averaged parameters.
[2020-08-13 22:13:05] [INFO] root Loading averaged parameters.
[2020-08-13 22:13:05] [INFO] gluonts.trainer End model training
[2020-08-13 22:13:06] [WARNING] root Serializing RepresentableBlockPredictor instances does not save the prediction network structure in a backwards-compatible manner. Be careful not to use this method in production.`
```

Allow reviewer to merge ( pull requests )?


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
