### PR TITLE
 Fixing case with only time features and yearly freq

### DIFF
--- a/src/gluonts/model/seq2seq/_forking_estimator.py
+++ b/src/gluonts/model/seq2seq/_forking_estimator.py
@@ -260,8 +260,14 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
             dynamic_feat_fields.append(FieldName.FEAT_DYNAMIC_REAL)
 
         # we need to make sure that there is always some dynamic input
-        # we will however disregard it in the hybrid forward
-        if len(dynamic_feat_fields) == 0:
+        # we will however disregard it in the hybrid forward.
+        # the time feature is empty for yearly freq so also adding a dummy feature
+        # in the case that the time feature is the only one on
+        if len(dynamic_feat_fields) == 0 or (
+            not self.add_age_feature
+            and not self.use_feat_dynamic_real
+            and self.freq == "Y"
+        ):
             chain.append(
                 AddConstFeature(
                     target_field=FieldName.TARGET,

--- a/test/model/seq2seq/test_model.py
+++ b/test/model/seq2seq/test_model.py
@@ -71,7 +71,7 @@ def test_mqcnn_covariate_smoke_test(
 ):
     hps = {
         "seed": 42,
-        "freq": "D",
+        "freq": "Y",
         "context_length": 5,
         "prediction_length": 3,
         "quantiles": [0.5, 0.1],


### PR DESCRIPTION
- Fixed MQ-CNN with yearly freq and only time as the dynamic feature
- In this case no dynamic features are created because the time feature is empty for `Y` freq and `dynamic_feat` is `None`
- Updated to create the dummy zero feature in this case
- Added `test_mqcnn_covariate_smoke_test` to use `freq` = `Y` to test this.  Before would fail with `add_time_feature = True`, `add_age_feature = False` and `use_feat_dyanmic_real = True`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
