### PR TITLE
Enable distribution output in seq2seq

### DIFF
--- a/src/gluonts/model/seq2seq/_forking_network.py
+++ b/src/gluonts/model/seq2seq/_forking_network.py
@@ -12,9 +12,10 @@
 # permissions and limitations under the License.
 
 # Third-party imports
-from typing import List
+from typing import List, Optional, Tuple
 
 # Third-party imports
+import mxnet as mx
 import numpy as np
 from mxnet import gluon
 
@@ -27,6 +28,7 @@ from gluonts.mx.block.encoder import Seq2SeqEncoder
 from gluonts.mx.block.feature import FeatureEmbedder
 from gluonts.mx.block.quantile_output import QuantileOutput
 from gluonts.mx.block.scaler import MeanScaler, NOPScaler
+from gluonts.mx.distribution import DistributionOutput
 from gluonts.support.util import weighted_average
 
 
@@ -42,8 +44,8 @@ class ForkingSeq2SeqNetworkBase(gluon.HybridBlock):
         encoder to decoder mapping block.
     decoder: Seq2SeqDecoder
         decoder block.
-    quantile_output: QuantileOutput
-        quantile output block
+    output
+        An instance of DistributionOutput or QuantileOutput to use
     context_length: int,
         length of the encoding sequence.
     cardinality: List[int],
@@ -66,10 +68,11 @@ class ForkingSeq2SeqNetworkBase(gluon.HybridBlock):
         encoder: Seq2SeqEncoder,
         enc2dec: Seq2SeqEnc2Dec,
         decoder: Seq2SeqDecoder,
-        quantile_output: QuantileOutput,
         context_length: int,
         cardinality: List[int],
         embedding_dimension: List[int],
+        distr_output: Optional[DistributionOutput] = None,
+        quantile_output: Optional[QuantileOutput] = None,
         scaling: bool = False,
         scaling_decoder_dynamic_feature: bool = False,
         dtype: DType = np.float32,
@@ -77,9 +80,12 @@ class ForkingSeq2SeqNetworkBase(gluon.HybridBlock):
     ) -> None:
         super().__init__(**kwargs)
 
+        assert (distr_output is None) != (quantile_output is None)
+
         self.encoder = encoder
         self.enc2dec = enc2dec
         self.decoder = decoder
+        self.distr_output = distr_output
         self.quantile_output = quantile_output
         self.context_length = context_length
         self.cardinality = cardinality
@@ -104,8 +110,12 @@ class ForkingSeq2SeqNetworkBase(gluon.HybridBlock):
             )
 
         with self.name_scope():
-            self.quantile_proj = quantile_output.get_quantile_proj()
-            self.loss = quantile_output.get_loss()
+            if self.quantile_output:
+                self.quantile_proj = self.quantile_output.get_quantile_proj()
+                self.loss = self.quantile_output.get_loss()
+            else:
+                assert self.distr_output is not None
+                self.distr_args_proj = self.distr_output.get_args_proj()
             self.embedder = FeatureEmbedder(
                 cardinalities=cardinality,
                 embedding_dims=embedding_dimension,
@@ -121,7 +131,7 @@ class ForkingSeq2SeqNetworkBase(gluon.HybridBlock):
         future_feat_dynamic: Tensor,
         feat_static_cat: Tensor,
         past_observed_values: Tensor,
-    ) -> Tensor:
+    ) -> Tuple[Tensor, Tensor]:
 
         # scale is computed on the context length last units of the past target
         # scale shape is (batch_size, 1, *target_shape)
@@ -172,7 +182,7 @@ class ForkingSeq2SeqNetworkBase(gluon.HybridBlock):
         dec_output = self.decoder(dec_input_dynamic, dec_input_static)
 
         # the output shape should be: (batch_size, enc_len, dec_len, final_dims)
-        return dec_output
+        return dec_output, scale
 
 
 class ForkingSeq2SeqTrainingNetwork(ForkingSeq2SeqNetworkBase):
@@ -212,7 +222,7 @@ class ForkingSeq2SeqTrainingNetwork(ForkingSeq2SeqNetworkBase):
         -------
         loss with shape (batch_size, prediction_length)
         """
-        dec_output = self.get_decoder_network_output(
+        dec_output, _ = self.get_decoder_network_output(
             F,
             past_target,
             past_feat_dynamic,
@@ -229,6 +239,62 @@ class ForkingSeq2SeqTrainingNetwork(ForkingSeq2SeqNetworkBase):
             F=F, x=loss, weights=future_observed_values, axis=1
         )
 
+        return weighted_loss
+
+
+class ForkingSeq2SeqDistributionTrainingNetwork(ForkingSeq2SeqNetworkBase):
+    # noinspection PyMethodOverriding
+    def hybrid_forward(
+        self,
+        F,
+        past_target: Tensor,
+        future_target: Tensor,
+        past_feat_dynamic: Tensor,
+        future_feat_dynamic: Tensor,
+        feat_static_cat: Tensor,
+        past_observed_values: Tensor,
+        future_observed_values: Tensor,
+    ) -> Tensor:
+        """
+        Parameters
+        ----------
+        F: mx.symbol or mx.ndarray
+            Gluon function space
+        past_target: Tensor
+            shape (batch_size, encoder_length, 1)
+        future_target: Tensor
+            shape (batch_size, encoder_length, decoder_length)
+        past_feat_dynamic
+            shape (batch_size, encoder_length, num_past_feature_dynamic)
+        future_feat_dynamic
+            shape (batch_size, encoder_length, decoder_length, num_feature_dynamic)
+        feat_static_cat
+            shape (batch_size, encoder_length, num_feature_static_cat)
+        past_observed_values: Tensor
+            shape (batch_size, encoder_length, 1)
+        future_observed_values: Tensor
+            shape (batch_size, encoder_length, decoder_length)
+
+        Returns
+        -------
+        loss with shape (batch_size, prediction_length)
+        """
+        assert self.distr_output is not None
+
+        dec_output, scale = self.get_decoder_network_output(
+            F,
+            past_target,
+            past_feat_dynamic,
+            future_feat_dynamic,
+            feat_static_cat,
+            past_observed_values,
+        )
+        distr_args = self.distr_args_proj(dec_output)
+        distr = self.distr_output.distribution(distr_args, scale=scale)
+        loss = distr.loss(future_target)
+        weighted_loss = weighted_average(
+            F=F, x=loss, weights=future_observed_values, axis=1
+        )
         return weighted_loss
 
 
@@ -264,7 +330,7 @@ class ForkingSeq2SeqPredictionNetwork(ForkingSeq2SeqNetworkBase):
         prediction tensor with shape (batch_size, prediction_length)
         """
 
-        dec_output = self.get_decoder_network_output(
+        dec_output, _ = self.get_decoder_network_output(
             F,
             past_target,
             past_feat_dynamic,
@@ -280,3 +346,52 @@ class ForkingSeq2SeqPredictionNetwork(ForkingSeq2SeqNetworkBase):
         predictions = self.quantile_proj(fcst_output).swapaxes(2, 1)
 
         return predictions
+
+
+class ForkingSeq2SeqDistributionPredictionNetwork(ForkingSeq2SeqNetworkBase):
+    # noinspection PyMethodOverriding
+    def hybrid_forward(
+        self,
+        F,
+        past_target: Tensor,
+        past_feat_dynamic: Tensor,
+        future_feat_dynamic: Tensor,
+        feat_static_cat: Tensor,
+        past_observed_values: Tensor,
+    ) -> Tuple[Tensor, Tensor, Tensor]:
+        """
+        Parameters
+        ----------
+        F: mx.symbol or mx.ndarray
+            Gluon function space
+        past_target: Tensor
+             shape (batch_size, encoder_length, 1)
+        feat_static_cat
+            shape (batch_size, encoder_length, num_feature_static_cat)
+        past_feat_dynamic
+            shape (batch_size, encoder_length, num_feature_dynamic)
+        future_feat_dynamic
+            shape (batch_size, encoder_length, decoder_length, num_feature_dynamic)
+        past_observed_values: Tensor
+            shape (batch_size, encoder_length, 1)
+        Returns
+        -------
+        distr_args: the parameters of distribution
+        loc: an array of zeros with the same shape of scale
+        scale: 
+        """
+
+        dec_output, scale = self.get_decoder_network_output(
+            F,
+            past_target,
+            past_feat_dynamic,
+            future_feat_dynamic,
+            feat_static_cat,
+            past_observed_values,
+        )
+        fcst_output = F.slice_axis(dec_output, axis=1, begin=-1, end=None)
+        fcst_output = F.squeeze(fcst_output, axis=1)
+        distr_args = self.distr_args_proj(fcst_output)
+
+        loc = F.zeros_like(scale)
+        return distr_args, loc, scale

--- a/test/model/seq2seq/test_model.py
+++ b/test/model/seq2seq/test_model.py
@@ -19,6 +19,8 @@ from gluonts.model.seq2seq import (
 )
 from gluonts.testutil.dummy_datasets import make_dummy_datasets_with_features
 
+from gluonts.mx.distribution import GaussianOutput
+
 
 @pytest.fixture()
 def hyperparameters(dsinfo):
@@ -29,7 +31,6 @@ def hyperparameters(dsinfo):
         hybridize=True,
         context_length=dsinfo.prediction_length,
         num_batches_per_epoch=1,
-        quantiles=[0.1, 0.5, 0.9],
         use_symbol_block_predictor=True,
     )
 
@@ -41,16 +42,29 @@ def Estimator(request):
     return request.param
 
 
-@pytest.mark.parametrize("quantiles", [[0.1, 0.5, 0.9], [0.5]])
 @pytest.mark.parametrize("hybridize", [True, False])
+@pytest.mark.parametrize(
+    "quantiles, distr_output",
+    [([0.1, 0.5, 0.9], None), (None, GaussianOutput())],
+)
 def test_accuracy(
-    Estimator, accuracy_test, hyperparameters, hybridize, quantiles
+    Estimator,
+    accuracy_test,
+    hyperparameters,
+    hybridize,
+    quantiles,
+    distr_output,
 ):
     hyperparameters.update(
-        num_batches_per_epoch=100, hybridize=hybridize, quantiles=quantiles
+        num_batches_per_epoch=100,
+        hybridize=hybridize,
+        quantiles=quantiles,
+        distr_output=distr_output,
     )
 
-    accuracy_test(Estimator, hyperparameters, accuracy=0.20)
+    accuracy_test(
+        Estimator, hyperparameters, accuracy=0.20 if quantiles else 0.40
+    )
 
 
 @pytest.mark.parametrize("use_past_feat_dynamic_real", [True, False])
@@ -60,6 +74,9 @@ def test_accuracy(
 @pytest.mark.parametrize("enable_encoder_dynamic_feature", [True, False])
 @pytest.mark.parametrize("enable_decoder_dynamic_feature", [True, False])
 @pytest.mark.parametrize("hybridize", [True, False])
+@pytest.mark.parametrize(
+    "quantiles, distr_output", [([0.5, 0.1], None), (None, GaussianOutput()),]
+)
 def test_mqcnn_covariate_smoke_test(
     use_past_feat_dynamic_real,
     use_feat_dynamic_real,
@@ -68,13 +85,16 @@ def test_mqcnn_covariate_smoke_test(
     enable_encoder_dynamic_feature,
     enable_decoder_dynamic_feature,
     hybridize,
+    quantiles,
+    distr_output,
 ):
     hps = {
         "seed": 42,
         "freq": "Y",
         "context_length": 5,
         "prediction_length": 3,
-        "quantiles": [0.5, 0.1],
+        "quantiles": quantiles,
+        "distr_output": distr_output,
         "epochs": 3,
         "num_batches_per_epoch": 3,
         "use_past_feat_dynamic_real": use_past_feat_dynamic_real,


### PR DESCRIPTION
*Issue #, if available:* Replaces #936, adds the option of configuring seq2seq models with a distribution output instead of specific quantiles.

Joint work with @YuntianYeAWS 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
