### PR TITLE
Fixed DeepAR typing error

### DIFF
--- a/src/gluonts/model/deepar/_network.py
+++ b/src/gluonts/model/deepar/_network.py
@@ -323,7 +323,7 @@ class DeepARTrainingNetwork(DeepARNetwork):
         future_target: Tensor,
         future_observed_values: Tensor,
         return_rnn_outputs: bool = False,
-    ) -> Union[Distribution, Tuple[Distribution, Tensor]]:
+    ) -> Union[Tuple[Distribution, Tensor], Distribution]:
         """
 
         Returns the distribution predicted by the model on the range of
@@ -407,7 +407,7 @@ class DeepARTrainingNetwork(DeepARNetwork):
 
         """
 
-        distr, rnn_outputs = self.distribution(
+        outputs = self.distribution(
             feat_static_cat=feat_static_cat,
             feat_static_real=feat_static_real,
             past_time_feat=past_time_feat,
@@ -418,6 +418,9 @@ class DeepARTrainingNetwork(DeepARNetwork):
             future_observed_values=future_observed_values,
             return_rnn_outputs=True,
         )
+        # since return_rnn_outputs=True, assert:
+        assert isinstance(outputs, tuple)
+        distr, rnn_outputs = outputs
 
         # put together target sequence
         # (batch_size, seq_len, *target_shape)

--- a/src/gluonts/model/deepar/_network.py
+++ b/src/gluonts/model/deepar/_network.py
@@ -323,7 +323,7 @@ class DeepARTrainingNetwork(DeepARNetwork):
         future_target: Tensor,
         future_observed_values: Tensor,
         return_rnn_outputs: bool = False,
-    ) -> Union[Tuple[Distribution, Tensor], Distribution]:
+    ) -> Union[Distribution, Tuple[Distribution, Tensor]]:
         """
 
         Returns the distribution predicted by the model on the range of


### PR DESCRIPTION
*Description of changes:*
I added an assertion to prevent the Mypy typing error:
`src/gluonts/model/deepar/_network.py:434: error: 'gluonts.mx.distribution.distribution.Distribution' object is not iterable`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
