### PR TITLE
Adding support for `num_forking` as MQ-CNN hp

### DIFF
--- a/src/gluonts/dataset/common.py
+++ b/src/gluonts/dataset/common.py
@@ -420,7 +420,19 @@ class ProcessDataEntry:
                     is_static=False,
                 ),
                 ProcessTimeSeriesField(
+                    "dynamic_feat",  # backwards compatible
+                    is_required=False,
+                    is_cat=False,
+                    is_static=False,
+                ),
+                ProcessTimeSeriesField(
                     "feat_dynamic_real",
+                    is_required=False,
+                    is_cat=False,
+                    is_static=False,
+                ),
+                ProcessTimeSeriesField(
+                    "past_feat_dynamic_real",
                     is_required=False,
                     is_cat=False,
                     is_static=False,

--- a/src/gluonts/model/seq2seq/_forking_estimator.py
+++ b/src/gluonts/model/seq2seq/_forking_estimator.py
@@ -128,6 +128,8 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
         Whether to automatically scale the dynamic features for the decoder. (default: False)
     dtype
         (default: np.float32)
+    num_forking
+        Decides how much forking to do in the decoder. 1 reduces to seq2seq and enc_len reduces to MQ-C(R)NN
     """
 
     @validated()
@@ -153,6 +155,7 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
         scaling: bool = False,
         scaling_decoder_dynamic_feature: bool = False,
         dtype: DType = np.float32,
+        num_forking: Optional[int] = None,
     ) -> None:
         super().__init__(trainer=trainer)
 
@@ -183,6 +186,9 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
             context_length
             if context_length is not None
             else 4 * self.prediction_length
+        )
+        self.num_forking = (
+            num_forking if num_forking is not None else self.context_length
         )
         self.use_past_feat_dynamic_real = use_past_feat_dynamic_real
         self.use_feat_dynamic_real = use_feat_dynamic_real
@@ -245,6 +251,7 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
                     output_field=FieldName.FEAT_TIME,
                     time_features=time_features_from_frequency_str(self.freq),
                     pred_length=self.prediction_length,
+                    dtype=self.dtype,
                 ),
             )
             dynamic_feat_fields.append(FieldName.FEAT_TIME)
@@ -307,7 +314,7 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
             chain.append(
                 SetField(
                     output_field=FieldName.FEAT_STATIC_CAT,
-                    value=np.array([0.0]),
+                    value=np.array([0], dtype=np.int32),
                 ),
             )
 
@@ -320,6 +327,7 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
                 train_sampler=TestSplitSampler(),
                 enc_len=self.context_length,
                 dec_len=self.prediction_length,
+                num_forking=self.num_forking,
                 encoder_series_fields=[
                     FieldName.OBSERVED_VALUES,
                     # RTS with past and future values which is never empty because added dummy constant variable
@@ -384,6 +392,7 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
             quantile_output=self.quantile_output,
             distr_output=self.distr_output,
             context_length=self.context_length,
+            num_forking=self.num_forking,
             cardinality=self.cardinality,
             embedding_dimension=self.embedding_dimension,
             scaling=self.scaling,
@@ -417,6 +426,7 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
             quantile_output=trained_network.quantile_output,
             distr_output=trained_network.distr_output,
             context_length=self.context_length,
+            num_forking=self.num_forking,
             cardinality=self.cardinality,
             embedding_dimension=self.embedding_dimension,
             scaling=self.scaling,

--- a/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
+++ b/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
@@ -110,6 +110,8 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
         Whether to automatically scale the target values. (default: False)
     scaling_decoder_dynamic_feature
         Whether to automatically scale the dynamic features for the decoder. (default: False)
+    num_forking
+        Decides how much forking to do in the decoder. 1 reduces to seq2seq and enc_len reduces to MQ-CNN
     """
 
     @validated()
@@ -138,6 +140,7 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
         trainer: Trainer = Trainer(),
         scaling: bool = False,
         scaling_decoder_dynamic_feature: bool = False,
+        num_forking: Optional[int] = None,
     ) -> None:
 
         assert (distr_output is None) or (quantiles is None)
@@ -190,7 +193,7 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
 
         if seed:
             np.random.seed(seed)
-            mx.random.seed(seed)
+            mx.random.seed(seed, trainer.ctx)
 
         # `use_static_feat` and `use_dynamic_feat` always True because network
         # always receives input; either from the input data or constants
@@ -235,6 +238,7 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
             trainer=trainer,
             scaling=scaling,
             scaling_decoder_dynamic_feature=scaling_decoder_dynamic_feature,
+            num_forking=num_forking,
         )
 
     @classmethod

--- a/src/gluonts/transform/feature.py
+++ b/src/gluonts/transform/feature.py
@@ -319,6 +319,7 @@ class AddTimeFeatures(MapTransformation):
         output_field: str,
         time_features: List[TimeFeature],
         pred_length: int,
+        dtype: DType = np.float32,
     ) -> None:
         self.date_features = time_features
         self.pred_length = pred_length
@@ -329,6 +330,7 @@ class AddTimeFeatures(MapTransformation):
         self._max_time_point: pd.Timestamp = None
         self._full_range_date_features: np.ndarray = None
         self._date_index: pd.DatetimeIndex = None
+        self.dtype = dtype
 
     def _update_cache(self, start: pd.Timestamp, length: int) -> None:
         end = shift_timestamp(start, length)
@@ -350,7 +352,7 @@ class AddTimeFeatures(MapTransformation):
         self._full_range_date_features = (
             np.vstack(
                 [feat(self.full_date_range) for feat in self.date_features]
-            )
+            ).astype(self.dtype)
             if self.date_features
             else None
         )

--- a/test/model/seq2seq/test_model.py
+++ b/test/model/seq2seq/test_model.py
@@ -30,6 +30,7 @@ def hyperparameters(dsinfo):
         learning_rate=1e-2,
         hybridize=True,
         context_length=dsinfo.prediction_length,
+        num_forking=1,
         num_batches_per_epoch=1,
         use_symbol_block_predictor=True,
     )
@@ -188,6 +189,7 @@ def test_backwards_compatibility():
     hps = {
         "freq": "D",
         "context_length": 5,
+        "num_forking": 4,
         "prediction_length": 3,
         "quantiles": [0.5, 0.1],
         "epochs": 3,

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -152,6 +152,7 @@ def test_AddTimeFeatures_empty_time_features(start, target, is_train: bool):
         output_field="myout",
         pred_length=pred_length,
         time_features=[],
+        dtype=np.float64,
     )
 
     assert_serializable(t)

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -125,6 +125,7 @@ def test_AddTimeFeatures(start, target, is_train: bool):
         output_field="myout",
         pred_length=pred_length,
         time_features=[time_feature.DayOfWeek(), time_feature.DayOfMonth()],
+        dtype=np.float64,
     )
 
     assert_serializable(t)
@@ -152,7 +153,6 @@ def test_AddTimeFeatures_empty_time_features(start, target, is_train: bool):
         output_field="myout",
         pred_length=pred_length,
         time_features=[],
-        dtype=np.float64,
     )
 
     assert_serializable(t)


### PR DESCRIPTION
*Issues:*
- Current forking copying of segments in the 3D forking decoder is slow
- This can dominate the computation for long prediction length and large number of RTS
- Time is spent in creating batches rather than training
- Can test less forking and interpolate from seq2seq and MQC(R)NN estimators

*Description of changes:*
- Can use `num_forking` hp to interpolate from the `seq2seq` (`num_forking = 1`)  to full `MQ-C(R)NN` (`num_forking = context_length`)
- Added `num_forking` parameter to decide the amount of forking we want which defaults to `self.enc_len = context_length`
- Transpose operation moved to the beginning so we can take advantage of row-major caching and do one operation rather than within the loop
- Use `as_strides()` for the contiguous memory views instead of copies
- See https://arxiv.org/abs/1711.11053 for details on the forking decoder
-Fixed issue with `dtype` was not being passed to all methods and target and observed_values arrays were of the default single precision `np.float32` but the dynamic feature arrays were of double precision `np.float64`
-- Passed `dtype` to `TimeFeature` class
-- Fixed dummy variable for `feat_static_cat` to default to `int.32` type
-- Need to pass `dtype` to `np.zeros` in `_transform.py`
-- Fixed backwards compatible issue with passing `dynamic_feat` to `ProcessDataEntry` to put in the correct format
-- Also passed `past_feat_dynamic_real` to `ProcessDataEntry` to put in the correct format

*TODO:*
- Can optimize the forking future by looking at the LHS of `as_strided` namely `forking_dec_field[skip:]`. It would be faster to access this by reference instead of the copy
- Potentially could use `memoryview` here to directly work with the `forking_dec_field` buffer


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
