### PR TITLE
Using pad_to_size function to remove duplicate code in pad_arrays

### DIFF
--- a/src/gluonts/mx/batchify.py
+++ b/src/gluonts/mx/batchify.py
@@ -11,14 +11,14 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from typing import List, Optional, Union
-import functools
+from typing import List, Optional
 
 import numpy as np
 import mxnet as mx
 
 from gluonts.core.component import DType
 from gluonts.dataset.common import DataBatch
+from gluonts.support.util import pad_arrays
 
 
 # TODO: should the following contempate mxnet arrays or just numpy arrays?
@@ -33,34 +33,6 @@ def _is_stackable(arrays: List, axis: int = 0) -> bool:
     return True
 
 
-# TODO: should the following contempate mxnet arrays or just numpy arrays?
-def _pad_arrays(
-    data: List[Union[np.ndarray, mx.nd.NDArray]], axis: int = 0,
-) -> List[Union[np.ndarray, mx.nd.NDArray]]:
-    assert isinstance(data[0], (np.ndarray, mx.nd.NDArray))
-    is_mx = isinstance(data[0], mx.nd.NDArray)
-
-    # MxNet causes a segfault when persisting 0-length arrays. As such,
-    # we add a dummy pad of length 1 to 0-length dims.
-    max_len = max(1, functools.reduce(max, (x.shape[axis] for x in data)))
-    padded_data = []
-
-    for x in data:
-        # MxNet lacks the functionality to pad n-D arrays consistently.
-        # We fall back to numpy if x is an mx.nd.NDArray.
-        if is_mx:
-            x = x.asnumpy()
-
-        pad_size = max_len - x.shape[axis]
-        pad_lengths = [(0, 0)] * x.ndim
-        pad_lengths[axis] = (0, pad_size)
-        x_padded = np.pad(x, mode="constant", pad_width=pad_lengths)
-
-        padded_data.append(x_padded if not is_mx else mx.nd.array(x_padded))
-
-    return padded_data
-
-
 def stack(
     data,
     ctx: Optional[mx.context.Context] = None,
@@ -68,7 +40,7 @@ def stack(
     variable_length: bool = False,
 ):
     if variable_length and not _is_stackable(data):
-        data = _pad_arrays(data, axis=0)
+        data = pad_arrays(data, axis=0)
     if isinstance(data[0], mx.nd.NDArray):
         # TODO: think about using shared context NDArrays
         #  https://github.com/awslabs/gluon-ts/blob/42bee73409f801e7bca73245ca21cd877891437c/src/gluonts/dataset/parallelized_loader.py#L157

--- a/src/gluonts/support/util.py
+++ b/src/gluonts/support/util.py
@@ -12,7 +12,6 @@
 # permissions and limitations under the License.
 
 # Standard library imports
-import functools
 import inspect
 import os
 import signal
@@ -46,31 +45,6 @@ def pad_to_size(
     right_pad = (0, pad_length)
     pad_width[axis] = right_pad if is_right_pad else right_pad[::-1]
     return np.pad(x, mode="constant", pad_width=pad_width)
-
-
-# TODO: should the following contempate mxnet arrays or just numpy arrays?
-def pad_arrays(
-    data: List[Union[np.ndarray, mx.nd.NDArray]], axis: int = 0
-) -> List[Union[np.ndarray, mx.nd.NDArray]]:
-    assert isinstance(data[0], (np.ndarray, mx.nd.NDArray))
-    is_mx = isinstance(data[0], mx.nd.NDArray)
-
-    # MxNet causes a segfault when persisting 0-length arrays. As such,
-    # we add a dummy pad of length 1 to 0-length dims.
-    max_len = max(1, functools.reduce(max, (x.shape[axis] for x in data)))
-    padded_data = []
-
-    for x in data:
-        # MxNet lacks the functionality to pad n-D arrays consistently.
-        # We fall back to numpy if x is an mx.nd.NDArray.
-        if is_mx:
-            x = x.asnumpy()
-
-        x = pad_to_size(x, max_len, axis)
-
-        padded_data.append(x if not is_mx else mx.nd.array(x))
-
-    return padded_data
 
 
 class Timer:

--- a/src/gluonts/support/util.py
+++ b/src/gluonts/support/util.py
@@ -48,6 +48,31 @@ def pad_to_size(
     return np.pad(x, mode="constant", pad_width=pad_width)
 
 
+# TODO: should the following contempate mxnet arrays or just numpy arrays?
+def pad_arrays(
+    data: List[Union[np.ndarray, mx.nd.NDArray]], axis: int = 0
+) -> List[Union[np.ndarray, mx.nd.NDArray]]:
+    assert isinstance(data[0], (np.ndarray, mx.nd.NDArray))
+    is_mx = isinstance(data[0], mx.nd.NDArray)
+
+    # MxNet causes a segfault when persisting 0-length arrays. As such,
+    # we add a dummy pad of length 1 to 0-length dims.
+    max_len = max(1, functools.reduce(max, (x.shape[axis] for x in data)))
+    padded_data = []
+
+    for x in data:
+        # MxNet lacks the functionality to pad n-D arrays consistently.
+        # We fall back to numpy if x is an mx.nd.NDArray.
+        if is_mx:
+            x = x.asnumpy()
+
+        x = pad_to_size(x, max_len, axis)
+
+        padded_data.append(x if not is_mx else mx.nd.array(x))
+
+    return padded_data
+
+
 class Timer:
     """Context manager for measuring the time of enclosed code fragments."""
 

--- a/src/gluonts/testutil/dummy_datasets.py
+++ b/src/gluonts/testutil/dummy_datasets.py
@@ -19,6 +19,10 @@ from typing import List, Tuple
 from gluonts.dataset.common import ListDataset
 from gluonts.dataset.field_names import FieldName
 
+# Third-party imports
+import numpy as np
+import pandas as pd
+
 
 def make_dummy_datasets_with_features(
     num_ts: int = 5,
@@ -69,3 +73,34 @@ def make_dummy_datasets_with_features(
         ListDataset(data_iter=data_iter_train, freq=freq),
         ListDataset(data_iter=data_iter_test, freq=freq),
     )
+
+
+def get_dataset():
+
+    data_entry_list = [
+        {
+            "target": np.c_[
+                np.array([0.2, 0.7, 0.2, 0.5, 0.3, 0.3, 0.2, 0.1]),
+                np.array([0, 1, 2, 0, 1, 2, 2, 2]),
+            ].T,
+            "start": pd.Timestamp("2011-01-01 00:00:00", freq="H"),
+            "end": pd.Timestamp("2011-01-01 03:00:00", freq="H"),
+        },
+        {
+            "target": np.c_[
+                np.array([0.2, 0.1, 0.2, 0.5, 0.4]), np.array([0, 1, 2, 1, 1])
+            ].T,
+            "start": pd.Timestamp("2011-01-01 00:00:00", freq="H"),
+            "end": pd.Timestamp("2011-01-01 03:00:00", freq="H"),
+        },
+        {
+            "target": np.c_[
+                np.array([0.2, 0.7, 0.2, 0.5, 0.1, 0.2, 0.1]),
+                np.array([0, 1, 2, 0, 1, 0, 2]),
+            ].T,
+            "start": pd.Timestamp("2011-01-01 00:00:00", freq="H"),
+            "end": pd.Timestamp("2011-01-01 03:00:00", freq="H"),
+        },
+    ]
+
+    return ListDataset(data_entry_list, freq="H", one_dim_target=False)

--- a/test/dataset/test_variable_length.py
+++ b/test/dataset/test_variable_length.py
@@ -223,21 +223,3 @@ def test_variable_length_stack_zerosize(
     assert stacked.shape[0] == 5
     assert stacked.shape[1] == 1
     assert stacked.shape[2] == 2
-
-
-@pytest.mark.parametrize(
-    "array_type, multi_processing, axis",
-    itertools.product(["np", "mx"], [True, False], [0, 1]),
-)
-def test_pad_arrays_axis(pp_dataset, array_type, multi_processing, axis: int):
-    arrays = [
-        d["target"] if array_type == "np" else mx.nd.array(d["target"])
-        for d in list(iter(pp_dataset()))
-    ]
-    if axis == 0:
-        arrays = [x.T for x in arrays]
-
-    padded_arrays = _pad_arrays(arrays, axis)
-
-    assert all(a.shape[axis] == 8 for a in padded_arrays)
-    assert all(a.shape[1 - axis] == 2 for a in padded_arrays)

--- a/test/dataset/test_variable_length.py
+++ b/test/dataset/test_variable_length.py
@@ -226,9 +226,9 @@ def test_variable_length_stack_zerosize(
 
 
 @pytest.mark.parametrize(
-    "array_type, axis", itertools.product(["np", "mx"], [0, 1])
+    "array_type, multi_processing, axis", itertools.product(["np", "mx"], [True, False], [0, 1])
 )
-def test_pad_arrays_axis(array_type, axis: int):
+def test_pad_arrays_axis(array_type, multi_processing, axis: int):
     arrays = [
         d["target"] if array_type == "np" else mx.nd.array(d["target"])
         for d in list(iter(get_dataset()))

--- a/test/dataset/test_variable_length.py
+++ b/test/dataset/test_variable_length.py
@@ -17,7 +17,6 @@ from typing import Dict, Any
 # Third-party imports
 import mxnet as mx
 import numpy as np
-import pandas as pd
 import pytest
 
 # First-party imports
@@ -27,7 +26,8 @@ from gluonts.dataset.loader import (
     TrainDataLoader,
     InferenceDataLoader,
 )
-from gluonts.mx.batchify import batchify, stack, _pad_arrays
+from gluonts.mx.batchify import batchify, stack
+from gluonts.testutil.dummy_datasets import get_dataset
 from gluonts.transform import (
     ContinuousTimeInstanceSplitter,
     ContinuousTimeUniformSampler,
@@ -36,37 +36,6 @@ from gluonts.transform import (
 
 @pytest.fixture
 def pp_dataset():
-    def get_dataset():
-
-        data_entry_list = [
-            {
-                "target": np.c_[
-                    np.array([0.2, 0.7, 0.2, 0.5, 0.3, 0.3, 0.2, 0.1]),
-                    np.array([0, 1, 2, 0, 1, 2, 2, 2]),
-                ].T,
-                "start": pd.Timestamp("2011-01-01 00:00:00", freq="H"),
-                "end": pd.Timestamp("2011-01-01 03:00:00", freq="H"),
-            },
-            {
-                "target": np.c_[
-                    np.array([0.2, 0.1, 0.2, 0.5, 0.4]),
-                    np.array([0, 1, 2, 1, 1]),
-                ].T,
-                "start": pd.Timestamp("2011-01-01 00:00:00", freq="H"),
-                "end": pd.Timestamp("2011-01-01 03:00:00", freq="H"),
-            },
-            {
-                "target": np.c_[
-                    np.array([0.2, 0.7, 0.2, 0.5, 0.1, 0.2, 0.1]),
-                    np.array([0, 1, 2, 0, 1, 0, 2]),
-                ].T,
-                "start": pd.Timestamp("2011-01-01 00:00:00", freq="H"),
-                "end": pd.Timestamp("2011-01-01 03:00:00", freq="H"),
-            },
-        ]
-
-        return ListDataset(data_entry_list, freq="H", one_dim_target=False,)
-
     return get_dataset
 
 

--- a/test/dataset/test_variable_length.py
+++ b/test/dataset/test_variable_length.py
@@ -226,7 +226,8 @@ def test_variable_length_stack_zerosize(
 
 
 @pytest.mark.parametrize(
-    "array_type, multi_processing, axis", itertools.product(["np", "mx"], [True, False], [0, 1])
+    "array_type, multi_processing, axis",
+    itertools.product(["np", "mx"], [True, False], [0, 1]),
 )
 def test_pad_arrays_axis(array_type, multi_processing, axis: int):
     arrays = [

--- a/test/support/test_util.py
+++ b/test/support/test_util.py
@@ -21,8 +21,26 @@ import numpy as np
 import pytest
 
 # First-party imports
-from gluonts.support import util
 from gluonts.model.common import Tensor
+from gluonts.support import util
+from gluonts.testutil.dummy_datasets import get_dataset
+
+
+@pytest.mark.parametrize(
+    "array_type, axis", itertools.product(["np", "mx"], [0, 1])
+)
+def test_pad_arrays_axis(array_type, axis: int):
+    arrays = [
+        d["target"] if array_type == "np" else mx.nd.array(d["target"])
+        for d in list(iter(get_dataset()))
+    ]
+    if axis == 0:
+        arrays = [x.T for x in arrays]
+
+    padded_arrays = util.pad_arrays(arrays, axis)
+
+    assert all(a.shape[axis] == 8 for a in padded_arrays)
+    assert all(a.shape[1 - axis] == 2 for a in padded_arrays)
 
 
 @pytest.mark.parametrize("vec", [[[1, 2, 3, 4, 5], [10, 20, 30, 40, 50]]])

--- a/test/support/test_util.py
+++ b/test/support/test_util.py
@@ -23,24 +23,6 @@ import pytest
 # First-party imports
 from gluonts.model.common import Tensor
 from gluonts.support import util
-from gluonts.testutil.dummy_datasets import get_dataset
-
-
-@pytest.mark.parametrize(
-    "array_type, axis", itertools.product(["np", "mx"], [0, 1])
-)
-def test_pad_arrays_axis(array_type, axis: int):
-    arrays = [
-        d["target"] if array_type == "np" else mx.nd.array(d["target"])
-        for d in list(iter(get_dataset()))
-    ]
-    if axis == 0:
-        arrays = [x.T for x in arrays]
-
-    padded_arrays = util.pad_arrays(arrays, axis)
-
-    assert all(a.shape[axis] == 8 for a in padded_arrays)
-    assert all(a.shape[1 - axis] == 2 for a in padded_arrays)
 
 
 @pytest.mark.parametrize("vec", [[[1, 2, 3, 4, 5], [10, 20, 30, 40, 50]]])


### PR DESCRIPTION
*Description of changes:*
- Moved `pad_arrays` to `util.py`
- Used `pad_to_size` function to remove duplicate code and return before calling `nd.pad` if no padding is needed.
- Moved `get_dataset` to `testutil/dummy_datasets`
- Moved `test_pad_arrays_axis` to `test/util.py`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
