### PR TITLE
Improved logging for batch-transform.

### DIFF
--- a/src/gluonts/shell/serve/app.py
+++ b/src/gluonts/shell/serve/app.py
@@ -18,7 +18,7 @@ import time
 import traceback
 import multiprocessing as mp
 from queue import Empty as QueueEmpty
-from typing import Callable, Iterable, List, Tuple
+from typing import Callable, Iterable, List, Tuple, NamedTuple
 
 from flask import Flask, Response, jsonify, request
 from pydantic import BaseModel
@@ -167,6 +167,11 @@ def make_predictions(predictor, dataset, configuration):
     return predictions
 
 
+class ScoredInstanceStat(NamedTuple):
+    amount: int
+    duration: float
+
+
 def batch_inference_invocations(
     predictor_factory, configuration, settings
 ) -> Callable[[], Response]:
@@ -174,6 +179,21 @@ def batch_inference_invocations(
 
     scored_instances = []
     last_scored = [time.time()]
+
+    def log_scored(when):
+        N = 60
+        diff = when - last_scored[0]
+        if diff > N:
+            scored_amount = sum(info.amount for info in scored_instances)
+            time_used = sum(info.duration for info in scored_instances)
+
+            logger.info(
+                f"Worker pid={os.getpid()}: scored {scored_amount} using on "
+                f"avg {round(time_used / scored_amount, 1)} s/ts over the "
+                f"last {round(diff)} seconds."
+            )
+            scored_instances.clear()
+            last_scored[0] = time.time()
 
     def invocations() -> Response:
         request_data = request.data.decode("utf8").strip()
@@ -187,6 +207,8 @@ def batch_inference_invocations(
             instances = []
 
         dataset = ListDataset(instances, predictor.freq)
+
+        start_time = time.time()
 
         if settings.gluonts_batch_timeout > 0:
             predictions = with_timeout(
@@ -212,16 +234,15 @@ def batch_inference_invocations(
         else:
             predictions = make_predictions(predictor, dataset, configuration)
 
-        scored_instances.append(len(predictions))
-        N = 60
-        diff = time.time() - last_scored[0]
-        if diff > N:
-            logger.info(
-                f"Worker {os.getpid()} Scored {sum(scored_instances)} in last "
-                f"{int(diff)} seconds."
+        end_time = time.time()
+
+        scored_instances.append(
+            ScoredInstanceStat(
+                amount=len(predictions), duration=end_time - start_time
             )
-            scored_instances.clear()
-            last_scored[0] = time.time()
+        )
+
+        log_scored(when=end_time)
 
         lines = list(map(json.dumps, map(jsonify_floats, predictions)))
         return Response("\n".join(lines), mimetype="application/jsonlines")

--- a/src/gluonts/shell/serve/app.py
+++ b/src/gluonts/shell/serve/app.py
@@ -177,7 +177,7 @@ def batch_inference_invocations(
 ) -> Callable[[], Response]:
     predictor = predictor_factory({"configuration": configuration.dict()})
 
-    scored_instances = []
+    scored_instances: List[ScoredInstanceStat] = []
     last_scored = [time.time()]
 
     def log_scored(when):


### PR DESCRIPTION
New format:

```
[2020-09-29 09:54:26] [INFO] gluonts.serve Worker pid=64229: scored 56 using on avg 1.1 s/ts over the last 60 seconds.
[2020-09-29 09:54:30] [INFO] gluonts.serve Worker pid=64227: scored 41 using on avg 0.8 s/ts over the last 97 seconds.
```