### PR TITLE
Improved NaN conditionals within log_prob() to handle samples outside distribution support

### DIFF
--- a/src/gluonts/mx/distribution/gamma.py
+++ b/src/gluonts/mx/distribution/gamma.py
@@ -68,11 +68,26 @@ class Gamma(Distribution):
         F = self.F
         alpha, beta = self.alpha, self.beta
 
-        return (
-            alpha * F.log(beta)
-            - F.gammaln(alpha)
-            + (alpha - 1) * F.log(x)
-            - beta * x
+        def gamma_log_prob(x, alpha, beta):
+            return (
+                alpha * F.log(beta)
+                - F.gammaln(alpha)
+                + (alpha - 1) * F.log(x)
+                - beta * x
+            )
+
+        """
+        The gamma_log_prob(x) above returns NaNs for x<=0. Wherever there are NaN in either of the F.where() conditional
+        vectors, then F.where() returns NaN at that entry as well, due to its indicator function multiplication: 
+        1*f(x) + np.nan*0 = nan, since np.nan*0 return nan. 
+        Therefore replacing gamma_log_prob(x) with gamma_log_prob(abs(x) mitigates nan returns in cases of x<=0 without 
+        altering the value in cases of x>0. 
+        This is a known issue in pytorch as well https://github.com/pytorch/pytorch/issues/12986.
+        """
+        return F.where(
+            x > 0,
+            gamma_log_prob(F.abs(x), alpha, beta),
+            -np.inf * F.ones_like(x),
         )
 
     @property

--- a/test/distribution/test_mixture.py
+++ b/test/distribution/test_mixture.py
@@ -20,11 +20,16 @@ import pytest
 from gluonts.gluonts_tqdm import tqdm
 from gluonts.model.common import Tensor, NPArrayLike
 from gluonts.mx.distribution.distribution import Distribution
+from gluonts.mx.distribution.distribution_output import DistributionOutput
 from gluonts.mx.distribution import (
+    Gamma,
     Gaussian,
+    GenPareto,
     StudentT,
     MixtureDistribution,
+    GammaOutput,
     GaussianOutput,
+    GenParetoOutput,
     StudentTOutput,
     LaplaceOutput,
     MultivariateGaussianOutput,
@@ -93,6 +98,10 @@ mx.random.seed(35120171)
             mx.nd.random_uniform(shape=SHAPE),
         ),
         (
+<<<<<<< HEAD
+            Gaussian(mu=mx.nd.array([0.0]), sigma=mx.nd.array([1e-3 + 0.2]),),
+            Gaussian(mu=mx.nd.array([1.0]), sigma=mx.nd.array([1e-3 + 0.1]),),
+=======
             Gaussian(
                 mu=mx.nd.array([0.]),
                 sigma=mx.nd.array([1e-3 + 0.2]),
@@ -101,6 +110,7 @@ mx.random.seed(35120171)
                 mu=mx.nd.array([1.]),
                 sigma=mx.nd.array([1e-3 + 0.1]),
             ),
+>>>>>>> fa2d57e8bb9c65dd88f3f480c0922da2c9f419a6
             mx.nd.array([0.2]),
         ),
         # TODO: add a multivariate case here
@@ -260,3 +270,146 @@ def test_mixture_inference() -> None:
     # pl.plot(EXPECTED_HIST)
     # pl.show()
     assert diff(obtained_hist, EXPECTED_HIST) < 0.5
+
+
+def fit_mixture_distribution(
+    x: Tensor,
+    mdo: MixtureDistributionOutput,
+    variate_dimensionality: int = 1,
+    epochs: int = 1_000,
+):
+    args_proj = mdo.get_args_proj()
+    args_proj.initialize()
+    args_proj.hybridize()
+
+    input = mx.nd.ones((variate_dimensionality, 1))
+
+    trainer = mx.gluon.Trainer(
+        args_proj.collect_params(), "sgd", {"learning_rate": 0.02}
+    )
+
+    t = tqdm(list(range(epochs)))
+    for _ in t:
+        with mx.autograd.record():
+            distr_args = args_proj(input)
+            d = mdo.distribution(distr_args)
+            loss = d.loss(x).mean()
+        loss.backward()
+        loss_value = loss.asnumpy()
+        t.set_postfix({"loss": loss_value})
+        trainer.step(1)
+
+    distr_args = args_proj(input)
+    d = mdo.distribution(distr_args)
+    return d
+
+
+@pytest.mark.parametrize(
+    "mixture_distribution, mixture_distribution_output, epochs",
+    [
+        (
+            MixtureDistribution(
+                mixture_probs=mx.nd.array([[0.6, 0.4]]),
+                components=[
+                    Gaussian(mu=mx.nd.array([-1.0]), sigma=mx.nd.array([0.2])),
+                    Gamma(alpha=mx.nd.array([2.0]), beta=mx.nd.array([0.5])),
+                ],
+            ),
+            MixtureDistributionOutput([GaussianOutput(), GammaOutput()]),
+            2_000,
+        ),
+        (
+            MixtureDistribution(
+                mixture_probs=mx.nd.array([[0.7, 0.3]]),
+                components=[
+                    Gaussian(mu=mx.nd.array([-1.0]), sigma=mx.nd.array([0.2])),
+                    GenPareto(xi=mx.nd.array([0.6]), beta=mx.nd.array([1.0])),
+                ],
+            ),
+            MixtureDistributionOutput([GaussianOutput(), GenParetoOutput()]),
+            2_000,
+        ),
+    ],
+)
+@pytest.mark.parametrize("serialize_fn", serialize_fn_list)
+@pytest.mark.skip("Skip test that takes long time to run")
+def test_inference_mixture_different_families(
+    mixture_distribution: MixtureDistribution,
+    mixture_distribution_output: MixtureDistributionOutput,
+    epochs: int,
+    serialize_fn,
+) -> None:
+    # First sample from mixture distribution and then confirm the MLE are close to true parameters
+    num_samples = 10_000
+    samples = mixture_distribution.sample(num_samples=num_samples)
+    variate_dimensionality = (
+        mixture_distribution.components[0].args[0].shape[0]
+    )
+    fitted_dist = fit_mixture_distribution(
+        samples,
+        mixture_distribution_output,
+        variate_dimensionality,
+        epochs=epochs,
+    )
+
+    assert np.allclose(
+        fitted_dist.mixture_probs.asnumpy(),
+        mixture_distribution.mixture_probs.asnumpy(),
+        atol=1e-1,
+    ), f"Mixing probability estimates {fitted_dist.mixture_probs.asnumpy()} too far from {mixture_distribution.mixture_probs.asnumpy()}"
+    for ci, c in enumerate(mixture_distribution.components):
+        for ai, a in enumerate(c.args):
+            assert np.allclose(
+                fitted_dist.components[ci].args[ai].asnumpy(),
+                a.asnumpy(),
+                atol=1e-1,
+            ), f"Parameter {ai} estimate {fitted_dist.components[ci].args[ai].asnumpy()} too far from {c}"
+
+
+@pytest.mark.parametrize(
+    "distribution, values_outside_support, distribution_output",
+    [
+        (
+            Gamma(alpha=mx.nd.array([0.9]), beta=mx.nd.array([2.0])),
+            mx.nd.array([-1.0]),
+            GammaOutput(),
+        ),
+        (
+            GenPareto(xi=mx.nd.array([1 / 3.0]), beta=mx.nd.array([1.0])),
+            mx.nd.array([-1.0]),
+            GenParetoOutput(),
+        ),
+    ],
+)
+def test_mixture_logprob(
+    distribution: Distribution,
+    values_outside_support: Tensor,
+    distribution_output: DistributionOutput,
+) -> None:
+
+    assert np.all(
+        ~np.isnan(distribution.log_prob(values_outside_support).asnumpy())
+    ), f"{distribution} should return -inf log_probs instead of NaNs"
+
+    p = 0.5
+    gaussian = Gaussian(mu=mx.nd.array([0]), sigma=mx.nd.array([2.0]))
+    mixture = MixtureDistribution(
+        mixture_probs=mx.nd.array([[p, 1 - p]]),
+        components=[gaussian, distribution],
+    )
+    lp = mixture.log_prob(values_outside_support)
+    assert np.allclose(
+        lp.asnumpy(),
+        np.log(p) + gaussian.log_prob(values_outside_support).asnumpy(),
+        atol=1e-6,
+    ), f"log_prob(x) should be equal to log(p)+gaussian.log_prob(x)"
+
+    fit_mixture = fit_mixture_distribution(
+        values_outside_support,
+        MixtureDistributionOutput([GaussianOutput(), distribution_output]),
+        variate_dimensionality=1,
+        epochs=3,
+    )
+    for ci, c in enumerate(fit_mixture.components):
+        for ai, a in enumerate(c.args):
+            assert ~np.isnan(a.asnumpy()), f"NaN gradients led to {c}"

--- a/test/distribution/test_mixture.py
+++ b/test/distribution/test_mixture.py
@@ -98,10 +98,6 @@ mx.random.seed(35120171)
             mx.nd.random_uniform(shape=SHAPE),
         ),
         (
-<<<<<<< HEAD
-            Gaussian(mu=mx.nd.array([0.0]), sigma=mx.nd.array([1e-3 + 0.2]),),
-            Gaussian(mu=mx.nd.array([1.0]), sigma=mx.nd.array([1e-3 + 0.1]),),
-=======
             Gaussian(
                 mu=mx.nd.array([0.]),
                 sigma=mx.nd.array([1e-3 + 0.2]),
@@ -110,7 +106,6 @@ mx.random.seed(35120171)
                 mu=mx.nd.array([1.]),
                 sigma=mx.nd.array([1e-3 + 0.1]),
             ),
->>>>>>> fa2d57e8bb9c65dd88f3f480c0922da2c9f419a6
             mx.nd.array([0.2]),
         ),
         # TODO: add a multivariate case here


### PR DESCRIPTION
*Issue #1056*

*Description of changes:* Gamma's log_prob(x) now returns -inf for x<=0 instead of NaNs, similarly with genpareto's log_prob(x) for x<0. Wherever there are NaN in either of the F.where() conditional vectors, then F.where() returns NaN at that entry as well, due to its indicator function multiplication: 1f(x) + np.nan0 = nan, since np.nan*0 return nan.
Therefore replacing log_prob(x) with log_prob(abs(x)) mitigates NaN returns and NaN gradients in cases of x<=0, without altering the value in cases of x>0. This is a known issue in pytorch as well pytorch/pytorch#12986.

Two corresponding pytests are also added.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
