### PR TITLE
Fix scaling for MQ-(C|R)NN when distribution outputs are used

### DIFF
--- a/src/gluonts/model/seq2seq/_forking_estimator.py
+++ b/src/gluonts/model/seq2seq/_forking_estimator.py
@@ -23,15 +23,14 @@ from gluonts.dataset.field_names import FieldName
 from gluonts.model.estimator import GluonEstimator
 from gluonts.model.forecast import Quantile
 from gluonts.model.forecast_generator import QuantileForecastGenerator
-from gluonts.mx.model.forecast_generator import DistributionForecastGenerator
 from gluonts.model.predictor import Predictor
-from gluonts.mx.model.predictor import RepresentableBlockPredictor
-
 from gluonts.mx.block.decoder import Seq2SeqDecoder
 from gluonts.mx.block.enc2dec import FutureFeatIntegratorEnc2Dec
 from gluonts.mx.block.encoder import Seq2SeqEncoder
 from gluonts.mx.block.quantile_output import QuantileOutput
 from gluonts.mx.distribution import DistributionOutput
+from gluonts.mx.model.forecast_generator import DistributionForecastGenerator
+from gluonts.mx.model.predictor import RepresentableBlockPredictor
 from gluonts.mx.trainer import Trainer
 from gluonts.support.util import copy_parameters
 from gluonts.time_feature import time_features_from_frequency_str
@@ -125,13 +124,15 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
     trainer
         trainer (default: Trainer())
     scaling
-        Whether to automatically scale the target values. (default: False)
+        Whether to automatically scale the target values. (default: True)
     scaling_decoder_dynamic_feature
         Whether to automatically scale the dynamic features for the decoder. (default: False)
     dtype
         (default: np.float32)
     num_forking
-        Decides how much forking to do in the decoder. 1 reduces to seq2seq and enc_len reduces to MQ-C(R)NN
+        Decides how much forking to do in the decoder. 1 reduces to seq2seq and enc_len reduces to MQ-C(R)NN.
+    max_ts_len
+        Returns the length of the longest time series in the dataset to be used in bounding context_length.
     """
 
     @validated()
@@ -154,7 +155,7 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
         enable_encoder_dynamic_feature: bool = True,
         enable_decoder_dynamic_feature: bool = True,
         trainer: Trainer = Trainer(),
-        scaling: bool = False,
+        scaling: bool = True,
         scaling_decoder_dynamic_feature: bool = False,
         dtype: DType = np.float32,
         num_forking: Optional[int] = None,
@@ -409,6 +410,7 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
             cardinality=self.cardinality,
             embedding_dimension=self.embedding_dimension,
             scaling=self.scaling,
+            scaling_decoder_dynamic_feature=self.scaling_decoder_dynamic_feature,
             dtype=self.dtype,
         )
 
@@ -443,6 +445,7 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
             cardinality=self.cardinality,
             embedding_dimension=self.embedding_dimension,
             scaling=self.scaling,
+            scaling_decoder_dynamic_feature=self.scaling_decoder_dynamic_feature,
             dtype=self.dtype,
         )
 

--- a/src/gluonts/model/seq2seq/_forking_estimator.py
+++ b/src/gluonts/model/seq2seq/_forking_estimator.py
@@ -124,7 +124,7 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
     trainer
         trainer (default: Trainer())
     scaling
-        Whether to automatically scale the target values. (default: True)
+        Whether to automatically scale the target values. (default: False if quantile_output is used, True otherwise)
     scaling_decoder_dynamic_feature
         Whether to automatically scale the dynamic features for the decoder. (default: False)
     dtype
@@ -155,7 +155,7 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
         enable_encoder_dynamic_feature: bool = True,
         enable_decoder_dynamic_feature: bool = True,
         trainer: Trainer = Trainer(),
-        scaling: bool = True,
+        scaling: Optional[bool] = None,
         scaling_decoder_dynamic_feature: bool = False,
         dtype: DType = np.float32,
         num_forking: Optional[int] = None,
@@ -222,7 +222,9 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
         )
         self.enable_encoder_dynamic_feature = enable_encoder_dynamic_feature
         self.enable_decoder_dynamic_feature = enable_decoder_dynamic_feature
-        self.scaling = scaling
+        self.scaling = (
+            scaling if scaling is not None else (quantile_output is None)
+        )
         self.scaling_decoder_dynamic_feature = scaling_decoder_dynamic_feature
         self.dtype = dtype
 

--- a/src/gluonts/model/seq2seq/_forking_network.py
+++ b/src/gluonts/model/seq2seq/_forking_network.py
@@ -50,18 +50,18 @@ class ForkingSeq2SeqNetworkBase(gluon.HybridBlock):
         distribution output
     context_length: int,
         length of the encoding sequence.
-    num_forking: int,
-        decides how much forking to do in the decoder. 1 reduces to seq2seq and enc_len reduces to MQ-C(R)NN.
     cardinality: List[int],
         number of values of each categorical feature.
     embedding_dimension: List[int],
         dimension of the embeddings for categorical features.
     scaling
-        Whether to automatically scale the target values. (default: False)
+        Whether to automatically scale the target values. (default: True)
     scaling_decoder_dynamic_feature
         Whether to automatically scale the dynamic features for the decoder. (default: False)
     dtype
         (default: np.float32)
+    num_forking: int,
+        decides how much forking to do in the decoder. 1 reduces to seq2seq and enc_len reduces to MQ-C(R)NN.
     kwargs: dict
         dictionary of Gluon HybridBlock parameters
     """
@@ -77,7 +77,7 @@ class ForkingSeq2SeqNetworkBase(gluon.HybridBlock):
         embedding_dimension: List[int],
         distr_output: Optional[DistributionOutput] = None,
         quantile_output: Optional[QuantileOutput] = None,
-        scaling: bool = False,
+        scaling: bool = True,
         scaling_decoder_dynamic_feature: bool = False,
         dtype: DType = np.float32,
         num_forking: Optional[int] = None,
@@ -361,7 +361,7 @@ class ForkingSeq2SeqDistributionPredictionNetwork(ForkingSeq2SeqNetworkBase):
         -------
         distr_args: the parameters of distribution
         loc: an array of zeros with the same shape of scale
-        scale: 
+        scale:
         """
 
         dec_output, scale = self.get_decoder_network_output(

--- a/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
+++ b/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
@@ -107,7 +107,7 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
     trainer
         The GluonTS trainer to use for training. (default: Trainer())
     scaling
-        Whether to automatically scale the target values. (default: True)
+        Whether to automatically scale the target values. (default: False if quantile_output is used, True otherwise)
     scaling_decoder_dynamic_feature
         Whether to automatically scale the dynamic features for the decoder. (default: False)
     num_forking
@@ -140,7 +140,7 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
         quantiles: Optional[List[float]] = None,
         distr_output: Optional[DistributionOutput] = None,
         trainer: Trainer = Trainer(),
-        scaling: bool = True,
+        scaling: Optional[bool] = None,
         scaling_decoder_dynamic_feature: bool = False,
         num_forking: Optional[int] = None,
         max_ts_len: Optional[int] = None,
@@ -321,7 +321,7 @@ class MQRNNEstimator(ForkingSeq2SeqEstimator):
         trainer: Trainer = Trainer(),
         quantiles: Optional[List[float]] = None,
         distr_output: Optional[DistributionOutput] = None,
-        scaling: bool = True,
+        scaling: Optional[bool] = None,
         scaling_decoder_dynamic_feature: bool = False,
         num_forking: Optional[int] = None,
     ) -> None:

--- a/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
+++ b/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
@@ -107,11 +107,13 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
     trainer
         The GluonTS trainer to use for training. (default: Trainer())
     scaling
-        Whether to automatically scale the target values. (default: False)
+        Whether to automatically scale the target values. (default: True)
     scaling_decoder_dynamic_feature
         Whether to automatically scale the dynamic features for the decoder. (default: False)
     num_forking
-        Decides how much forking to do in the decoder. 1 reduces to seq2seq and enc_len reduces to MQ-CNN
+        Decides how much forking to do in the decoder. 1 reduces to seq2seq and enc_len reduces to MQ-CNN.
+    max_ts_len
+        Returns the length of the longest time series in the dataset to be used in bounding context_length.
     """
 
     @validated()
@@ -138,7 +140,7 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
         quantiles: Optional[List[float]] = None,
         distr_output: Optional[DistributionOutput] = None,
         trainer: Trainer = Trainer(),
-        scaling: bool = False,
+        scaling: bool = True,
         scaling_decoder_dynamic_feature: bool = False,
         num_forking: Optional[int] = None,
         max_ts_len: Optional[int] = None,
@@ -315,11 +317,11 @@ class MQRNNEstimator(ForkingSeq2SeqEstimator):
         prediction_length: int,
         freq: str,
         context_length: Optional[int] = None,
-        decoder_mlp_dim_seq: List[int] = None,
+        decoder_mlp_dim_seq: Optional[List[int]] = None,
         trainer: Trainer = Trainer(),
         quantiles: Optional[List[float]] = None,
         distr_output: Optional[DistributionOutput] = None,
-        scaling: bool = False,
+        scaling: bool = True,
         scaling_decoder_dynamic_feature: bool = False,
         num_forking: Optional[int] = None,
     ) -> None:

--- a/test/model/seq2seq/test_model.py
+++ b/test/model/seq2seq/test_model.py
@@ -64,7 +64,7 @@ def test_accuracy(
     )
 
     accuracy_test(
-        Estimator, hyperparameters, accuracy=0.20 if quantiles else 0.50
+        Estimator, hyperparameters, accuracy=0.20 if quantiles else 0.70
     )
 
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/gluon-ts/issues/1069

*Description of changes:*
- Updated default `scaling` for large to `True` to be used with `DistrOutput`
- Left default for `scaling_decoder_dynamic_feature` to be `False`
- Pass `scaling_decoder_dynamic_feature` to training and prediction networks
- Fix the shape of `loc` and `scale`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
