### PR TITLE
Add piecewise linear quantile function output with fixed knots

### DIFF
--- a/src/gluonts/mx/distribution/__init__.py
+++ b/src/gluonts/mx/distribution/__init__.py
@@ -55,6 +55,7 @@ from .neg_binomial import NegativeBinomial, NegativeBinomialOutput
 from .piecewise_linear import (
     PiecewiseLinear,
     PiecewiseLinearOutput,
+    FixedKnotsPiecewiseLinearOutput,
     TransformedPiecewiseLinear,
 )
 from .poisson import Poisson, PoissonOutput

--- a/src/gluonts/mx/distribution/distribution_output.py
+++ b/src/gluonts/mx/distribution/distribution_output.py
@@ -71,7 +71,7 @@ class ArgProj(gluon.HybridBlock):
         self.domain_map = domain_map
 
     # noinspection PyMethodOverriding,PyPep8Naming
-    def hybrid_forward(self, F, x: Tensor) -> Tuple[Tensor]:
+    def hybrid_forward(self, F, x: Tensor, **kwargs) -> Tuple[Tensor]:
         params_unbounded = [proj(x) for proj in self.proj]
 
         return self.domain_map(*params_unbounded)

--- a/src/gluonts/mx/distribution/piecewise_linear.py
+++ b/src/gluonts/mx/distribution/piecewise_linear.py
@@ -381,10 +381,13 @@ class FixedKnotsArgProj(ArgProj):
             )
 
     # noinspection PyMethodOverriding,PyPep8Naming
-    def hybrid_forward(self, F, x: Tensor, knot_spacings: Tensor) -> Tuple[Tensor]:
+    def hybrid_forward(self, F, x: Tensor, **kwargs) -> Tuple[Tensor]:
         params_unbounded = [proj(x) for proj in self.proj]
+        knot_spacings = kwargs["knot_spacings"]
 
-        ks_proj = F.broadcast_add(params_unbounded[0].zeros_like(), knot_spacings)
+        ks_proj = F.broadcast_add(
+            params_unbounded[0].zeros_like(), knot_spacings
+        )
 
         return self.domain_map(*params_unbounded, ks_proj)
 
@@ -410,7 +413,9 @@ class FixedKnotsPiecewiseLinearOutput(PiecewiseLinearOutput):
     distr_cls: type = PiecewiseLinear
 
     @validated()
-    def __init__(self, quantile_levels: Union[List[float], np.ndarray],) -> None:
+    def __init__(
+        self, quantile_levels: Union[List[float], np.ndarray],
+    ) -> None:
         assert all(
             [0 < q < 1 for q in quantile_levels]
         ), "Quantiles must be strictly between 0 and 1."
@@ -439,7 +444,9 @@ class FixedKnotsPiecewiseLinearOutput(PiecewiseLinearOutput):
     def domain_map(cls, F, gamma, slopes, knot_spacings):
         # we use the super method only to compute intercepts and slopes
         # TODO: computations on knot spacings could be avoided here
-        gamma_out, slopes_out, _ = super().domain_map(F, gamma, slopes, knot_spacings)
+        gamma_out, slopes_out, _ = super().domain_map(
+            F, gamma, slopes, knot_spacings
+        )
 
         return gamma_out, slopes_out, knot_spacings
 

--- a/src/gluonts/mx/distribution/piecewise_linear.py
+++ b/src/gluonts/mx/distribution/piecewise_linear.py
@@ -12,10 +12,11 @@
 # permissions and limitations under the License.
 
 # Standard library imports
-from typing import Dict, List, Optional, Tuple, cast
+from typing import Dict, List, Optional, Tuple, cast, Union
 
 # Third-party imports
 import numpy as np
+import mxnet as mx
 
 # First-party imports
 from gluonts.core.component import validated
@@ -24,7 +25,7 @@ from gluonts.support import util
 
 from .bijection import AffineTransformation, Bijection
 from .distribution import Distribution, getF
-from .distribution_output import DistributionOutput
+from .distribution_output import DistributionOutput, ArgProj
 from .transformed_distribution import TransformedDistribution
 
 
@@ -368,6 +369,79 @@ class PiecewiseLinearOutput(DistributionOutput):
     @property
     def event_shape(self) -> Tuple:
         return ()
+
+
+class FixedKnotsArgProj(ArgProj):
+    def __init__(self, knot_spacings: mx.nd.NDArray, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.num_pieces = len(knot_spacings)
+        with self.name_scope():
+            self.knot_spacings = self.params.get_constant(
+                "knot_spacings", knot_spacings
+            )
+
+    # noinspection PyMethodOverriding,PyPep8Naming
+    def hybrid_forward(self, F, x: Tensor, knot_spacings: Tensor) -> Tuple[Tensor]:
+        params_unbounded = [proj(x) for proj in self.proj]
+
+        ks_proj = F.broadcast_add(params_unbounded[0].zeros_like(), knot_spacings)
+
+        return self.domain_map(*params_unbounded, ks_proj)
+
+
+class FixedKnotsPiecewiseLinearOutput(PiecewiseLinearOutput):
+    """
+    A simple extension of PiecewiseLinearOutput that "fixes" the knot
+    positions in the quantile function representation. That is, instead
+    of initializing with the number of pieces, the quantiles are provided
+    directly at initialization.
+
+    Parameters
+    ----------
+    quantile_levels
+        Points along the domain of the quantile function (i.e., in the interval [0,1])
+        where the knots of the piecewise linear approximation will be fixed, provided
+        in sorted order (ascending).
+
+        For more information on the piecewise linear quantile function, refer to
+        :code:`gluonts.distribution.PiecewiseLinear`.
+    """
+
+    distr_cls: type = PiecewiseLinear
+
+    @validated()
+    def __init__(self, quantile_levels: Union[List[float], np.ndarray],) -> None:
+        assert all(
+            [0 < q < 1 for q in quantile_levels]
+        ), "Quantiles must be strictly between 0 and 1."
+
+        assert np.all(
+            np.diff(quantile_levels) > 0
+        ), "Quantiles must be in increasing order, with quantile each specified once"
+
+        super().__init__(num_pieces=len(quantile_levels) + 1,)
+
+        # store the "knot spacings" instead of quantiles. see PiecewiseLinear
+        # for more information
+        self.knot_spacings = np.diff(np.r_[0, quantile_levels, 1])
+        self.args_dim: Dict[str, int] = {"gamma": 1, "slopes": self.num_pieces}
+
+    def get_args_proj(self, prefix: Optional[str] = None) -> ArgProj:
+        return FixedKnotsArgProj(
+            knot_spacings=mx.nd.array(self.knot_spacings),
+            args_dim=self.args_dim,
+            domain_map=mx.gluon.nn.HybridLambda(self.domain_map),
+            prefix=prefix,
+            dtype=self.dtype,
+        )
+
+    @classmethod
+    def domain_map(cls, F, gamma, slopes, knot_spacings):
+        # we use the super method only to compute intercepts and slopes
+        # TODO: computations on knot spacings could be avoided here
+        gamma_out, slopes_out, _ = super().domain_map(F, gamma, slopes, knot_spacings)
+
+        return gamma_out, slopes_out, knot_spacings
 
 
 # Need to inherit from PiecewiseLinear to get the overwritten loss method.

--- a/test/distribution/test_mixture.py
+++ b/test/distribution/test_mixture.py
@@ -98,14 +98,8 @@ mx.random.seed(35120171)
             mx.nd.random_uniform(shape=SHAPE),
         ),
         (
-            Gaussian(
-                mu=mx.nd.array([0.]),
-                sigma=mx.nd.array([1e-3 + 0.2]),
-            ),
-            Gaussian(
-                mu=mx.nd.array([1.]),
-                sigma=mx.nd.array([1e-3 + 0.1]),
-            ),
+            Gaussian(mu=mx.nd.array([0.0]), sigma=mx.nd.array([1e-3 + 0.2]),),
+            Gaussian(mu=mx.nd.array([1.0]), sigma=mx.nd.array([1e-3 + 0.1]),),
             mx.nd.array([0.2]),
         ),
         # TODO: add a multivariate case here

--- a/test/distribution/test_piecewise_linear.py
+++ b/test/distribution/test_piecewise_linear.py
@@ -17,7 +17,7 @@ import pytest
 import mxnet as mx
 import numpy as np
 
-from gluonts.mx.distribution import PiecewiseLinear, PiecewiseLinearOutput
+from gluonts.mx.distribution import PiecewiseLinear, PiecewiseLinearOutput, FixedKnotsPiecewiseLinearOutput
 from gluonts.testutil import empirical_cdf
 from gluonts.core.serde import dump_json, load_json
 
@@ -186,3 +186,33 @@ def test_robustness():
     # check that 0 <= crps
     crps_x = distr.crps(x)
     assert mx.nd.min(crps_x).asscalar() >= 0.0
+
+
+def test_fkpwl_distr_output_same_as_pl():
+    x = mx.nd.array([[0.1, 0.5], [0.3, 0.99], [0.2, 0.6]])
+
+    gamma = mx.nd.array([0.0, 2.0])
+    slopes = mx.nd.array([[0.1, 0.5, 0.9], [2.0, 0.1, 5.0]])
+    knot_spacings = mx.nd.array([[0.1, 0.5, 0.4], [0.1, 0.5, 0.4]])
+
+    pl_output = PiecewiseLinearOutput(num_pieces=3)
+    pl_dist = pl_output.distribution([gamma, slopes, knot_spacings])
+
+    fkpl = FixedKnotsPiecewiseLinearOutput([0.1, 0.6],).distribution(
+        [gamma, slopes, knot_spacings]
+    )
+
+    assert np.allclose(pl_dist.crps(x).asnumpy(), fkpl.crps(x).asnumpy(),)
+
+
+def test_fkpwl_distr_args_correct():
+    x = mx.nd.array([[0.1, 0.5], [0.3, 0.99], [0.2, 0.6]])
+
+    knot_spacings = mx.nd.array([[0.1, 0.5, 0.4], [0.1, 0.5, 0.4], [0.1, 0.5, 0.4]])
+
+    fkpl_proj = FixedKnotsPiecewiseLinearOutput([0.1, 0.6],).get_args_proj()
+
+    fkpl_proj.initialize()
+    _, _, ks = fkpl_proj(x)
+
+    assert np.allclose(ks.asnumpy(), knot_spacings.asnumpy())

--- a/test/distribution/test_piecewise_linear.py
+++ b/test/distribution/test_piecewise_linear.py
@@ -17,7 +17,11 @@ import pytest
 import mxnet as mx
 import numpy as np
 
-from gluonts.mx.distribution import PiecewiseLinear, PiecewiseLinearOutput, FixedKnotsPiecewiseLinearOutput
+from gluonts.mx.distribution import (
+    PiecewiseLinear,
+    PiecewiseLinearOutput,
+    FixedKnotsPiecewiseLinearOutput,
+)
 from gluonts.testutil import empirical_cdf
 from gluonts.core.serde import dump_json, load_json
 
@@ -208,7 +212,9 @@ def test_fkpwl_distr_output_same_as_pl():
 def test_fkpwl_distr_args_correct():
     x = mx.nd.array([[0.1, 0.5], [0.3, 0.99], [0.2, 0.6]])
 
-    knot_spacings = mx.nd.array([[0.1, 0.5, 0.4], [0.1, 0.5, 0.4], [0.1, 0.5, 0.4]])
+    knot_spacings = mx.nd.array(
+        [[0.1, 0.5, 0.4], [0.1, 0.5, 0.4], [0.1, 0.5, 0.4]]
+    )
 
     fkpl_proj = FixedKnotsPiecewiseLinearOutput([0.1, 0.6],).get_args_proj()
 


### PR DESCRIPTION
*Description of changes:* This adds the extension to the `PiecewiseLinearOutput` class which uses a fixed set of interpolation knots. Mainly authored by @canerturkmen 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
