### PR TITLE
fix value_in_support of the MixtureDistributionOutput

### DIFF
--- a/src/gluonts/mx/distribution/mixture.py
+++ b/src/gluonts/mx/distribution/mixture.py
@@ -246,3 +246,7 @@ class MixtureDistributionOutput(DistributionOutput):
     @property
     def event_shape(self) -> Tuple:
         return self.distr_outputs[0].event_shape
+
+    @property
+    def value_in_support(self) -> float:
+        return self.distr_outputs[0].value_in_support


### PR DESCRIPTION
*Issue #, if available:*
related to #1066
*Description of changes:*
The `value_in_support` property of the `MixtureDistributionOutput` was previously defaulting to zero. Fixing this to allow for mixtures which do not cover zero.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
