### PR TITLE
fix Gamma distribution's NaN gradients for zero inputs

### DIFF
--- a/src/gluonts/mx/distribution/gamma.py
+++ b/src/gluonts/mx/distribution/gamma.py
@@ -84,9 +84,12 @@ class Gamma(Distribution):
         altering the value in cases of x>0. 
         This is a known issue in pytorch as well https://github.com/pytorch/pytorch/issues/12986.
         """
+        # mask zeros to prevent NaN gradients for x==0
+        x_masked = F.where(x == 0, x.ones_like() * 0.5, x)
+
         return F.where(
             x > 0,
-            gamma_log_prob(F.abs(x), alpha, beta),
+            gamma_log_prob(F.abs(x_masked), alpha, beta),
             -np.inf * F.ones_like(x),
         )
 

--- a/test/distribution/test_mixture.py
+++ b/test/distribution/test_mixture.py
@@ -364,6 +364,11 @@ def test_inference_mixture_different_families(
             GammaOutput(),
         ),
         (
+            Gamma(alpha=mx.nd.array([0.9]), beta=mx.nd.array([2.0])),
+            mx.nd.array([0.0]),
+            GammaOutput(),
+        ),
+        (
             GenPareto(xi=mx.nd.array([1 / 3.0]), beta=mx.nd.array([1.0])),
             mx.nd.array([-1.0]),
             GenParetoOutput(),


### PR DESCRIPTION
*Issue #, if available:*
fix for #1066

*Description of changes:*
Added masking to prevent NaN gradients of the `Gamma` for `x=0`.
This is important for fitting mixture distributions such as: 
```python
mdo = MixtureDistributionOutput([GaussianOutput(), GammaOutput()]).
```
Example code:
```python
import mxnet as mx
from gluonts.mx.distribution import Gamma

a =mx.nd.array([1])
b =mx.nd.array([1])

a.attach_grad()
b.attach_grad()

with mx.autograd.record():
    loss = mx.nd.mean(Gamma(a,b).loss(x=mx.nd.array([0])))
    loss.backward()
 

print(a.grad)
print(b.grad)
```
will return
```python
[0.]
<NDArray 1 @cpu(0)>

[0.]
<NDArray 1 @cpu(0)>
```

instead of
```python
[nan]
<NDArray 1 @cpu(0)>

[0.]
<NDArray 1 @cpu(0)>

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
