### PR TITLE
Refactor multiprocessing batcher to work with spawn method

### DIFF
--- a/src/gluonts/dataset/util.py
+++ b/src/gluonts/dataset/util.py
@@ -12,6 +12,7 @@
 # permissions and limitations under the License.
 
 # Standard library imports
+import multiprocessing
 import itertools
 import logging
 import os
@@ -33,23 +34,19 @@ import pandas as pd
 T = TypeVar("T")
 
 
-# Each process has its own copy, so other processes can't interfere
-class MPWorkerInfo(object):
+class MPWorkerInfo:
     """Contains the current worker information."""
 
     worker_process = False
-    num_workers = 1
-    worker_id = 0
+    num_workers = None
+    worker_id = None
 
     @classmethod
-    def set_worker_info(
-        cls, num_workers: int, worker_id: int, worker_process: bool
-    ):
-        cls.num_workers, cls.worker_id, cls.worker_process = (
-            num_workers,
-            worker_id,
-            worker_process,
-        )
+    def set_worker_info(cls, num_workers: int, worker_id: int):
+        cls.worker_process = True
+        cls.num_workers = num_workers
+        cls.worker_id = worker_id
+        multiprocessing.current_process().name = f"worker_{worker_id}"
 
 
 class DataLoadingBounds(NamedTuple):
@@ -64,6 +61,9 @@ def get_bounds_for_mp_data_loading(dataset_len: int) -> DataLoadingBounds:
     """
     if not MPWorkerInfo.worker_process:
         return DataLoadingBounds(0, dataset_len)
+
+    assert MPWorkerInfo.num_workers is not None
+    assert MPWorkerInfo.worker_id is not None
 
     segment_size = int(dataset_len / MPWorkerInfo.num_workers)
     lower = MPWorkerInfo.worker_id * segment_size


### PR DESCRIPTION
*Issue #, if available:* This aims at fixing #1054

*Description of changes:* Apparently, to solve #1054 one needs to explicitly set the process start method to "spawn" on Linux platforms. However, the current way the multiprocess batching logic works does not allow that, because a generator is being passed to the spawned processes, which isn't allowed.

This PR fixes it so that all details (dataset, transformation, other options) are passed on to the processes, and each one of them constructs the generator on its own. So now the following works on a Linux platform with GPU:

```python
import multiprocessing
multiprocessing.set_start_method("spawn", force=True)

import mxnet as mx

from gluonts.dataset.repository.datasets import get_dataset
from gluonts.model.simple_feedforward import SimpleFeedForwardEstimator
from gluonts.trainer import Trainer

dataset = get_dataset("electricity", regenerate=False)

estimator = SimpleFeedForwardEstimator(freq="H", prediction_length=24, trainer=Trainer(epochs=3, ctx=mx.gpu()))

predictor = estimator.train(dataset.train, num_workers=2)
```

**Note:** the `multiprocessing.set_start_method` is invoked at the beginning of the snippet, and not within any of the modules imported from gluonts. I was not able to get it working from any of the imported modules. Ideally one could, somewhere in gluonts, do

```python
import sys
import multiprocessing
if sys.platform == "unix":  # the guard is to prevent set_start_method being called on macOS, where it gives issues
    multiprocessing.set_start_method("spawn", force=True)
```

to get everything to work automagically. Suggestions are welcome here.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
