### PR TITLE
Fix FieldNames of Train/test splitter

### DIFF
--- a/src/gluonts/dataset/split/splitter.py
+++ b/src/gluonts/dataset/split/splitter.py
@@ -51,6 +51,7 @@ import pydantic
 
 # First-party imports
 from gluonts.dataset.common import DataEntry
+from gluonts.dataset.field_names import FieldName
 
 
 class TimeSeriesSlice(pydantic.BaseModel):
@@ -97,7 +98,7 @@ class TimeSeriesSlice(pydantic.BaseModel):
 
         return TimeSeriesSlice(
             target=pd.Series(item["target"], index=index),
-            item=item["item"],
+            item=item[FieldName.ITEM_ID],
             feat_static_cat=feat_static_cat,
             feat_static_real=feat_static_real,
             feat_dynamic_cat=feat_dynamic_cat,
@@ -106,21 +107,21 @@ class TimeSeriesSlice(pydantic.BaseModel):
 
     def to_data_entry(self) -> DataEntry:
         ret = {
-            "start": self.start,
-            "item": self.item,
-            "target": self.target.values,
+            FieldName.START: self.start,
+            FieldName.ITEM_ID: self.item,
+            FieldName.TARGET: self.target.values,
         }
 
         if self.feat_static_cat:
-            ret["feat_static_cat"] = self.feat_static_cat
+            ret[FieldName.FEAT_STATIC_CAT] = self.feat_static_cat
         if self.feat_static_real:
-            ret["feat_static_real"] = self.feat_static_real
+            ret[FieldName.FEAT_STATIC_REAL] = self.feat_static_real
         if self.feat_dynamic_cat:
-            ret["feat_dynamic_cat"] = [
+            ret[FieldName.FEAT_DYNAMIC_CAT] = [
                 cat.values.tolist() for cat in self.feat_dynamic_cat
             ]
         if self.feat_dynamic_real:
-            ret["feat_dynamic_real"] = [
+            ret[FieldName.FEAT_DYNAMIC_REAL] = [
                 real.values.tolist() for real in self.feat_dynamic_real
             ]
 

--- a/test/dataset/split/test_split.py
+++ b/test/dataset/split/test_split.py
@@ -14,6 +14,10 @@
 import pandas as pd
 
 from gluonts.dataset.split.splitter import TimeSeriesSlice
+from gluonts.dataset.repository.datasets import get_dataset
+from gluonts.dataset.split import DateSplitter
+from gluonts.dataset.field_names import FieldName
+import pandas as pd
 
 
 def make_series(data, start="2020", freq="D"):
@@ -33,3 +37,17 @@ def test_ts_slice_to_item():
     )
 
     sl.to_data_entry()
+
+
+def test_splitter():
+
+    dataset = get_dataset("m4_hourly")
+    prediction_length = dataset.metadata.prediction_length
+    splitter = DateSplitter(
+        prediction_length=prediction_length,
+        split_date=pd.Timestamp("1750-01-05 04:00:00", freq="h"),
+    )
+    train, validation = splitter.split(dataset.train)
+    assert len(train[1][0][FieldName.TARGET]) + prediction_length == len(
+        validation[1][0][FieldName.TARGET]
+    )

--- a/test/dataset/split/test_split.py
+++ b/test/dataset/split/test_split.py
@@ -17,7 +17,6 @@ from gluonts.dataset.split.splitter import TimeSeriesSlice
 from gluonts.dataset.repository.datasets import get_dataset
 from gluonts.dataset.split import DateSplitter
 from gluonts.dataset.field_names import FieldName
-import pandas as pd
 
 
 def make_series(data, start="2020", freq="D"):


### PR DESCRIPTION
*Issue:*
```python
from gluonts.dataset.repository.datasets import get_dataset
from gluonts.dataset.split import DateSplitter
import pandas as pd 

dataset = get_dataset("m4_hourly")
prediction_length = dataset.metadata.prediction_length
splitter = DateSplitter(
        prediction_length=prediction_length,
        split_date=pd.Timestamp('1750-01-05 04:00:00', freq="h")

    )
train, validation = splitter.split(dataset.train)

  File "/Users/piiverse/Projects/gts/gluon-ts/src/gluonts/dataset/split/splitter.py", line 100, in from_data_entry
    item=item["item"],
KeyError: 'item'
```


*Description of changes:*

- replaced hardcoded dataset keys with FieldNames
- added test case which fails on the current master




_P.S.:_

In spite of being easy to use and very useful, it seems like the dataset splitters are currently not popular. 
I think two tutorials could help:
- custom training loop with validation-early stopping
- using GluonTS with your own data

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
