### PR TITLE
Adding test_quantiles hyperparameter to the shell to specify the quan…

### DIFF
--- a/.github/workflows/test_release_win32_nightly.yml
+++ b/.github/workflows/test_release_win32_nightly.yml
@@ -29,7 +29,7 @@ jobs:
         cd gluon-ts
         python -m pip install --upgrade pip
         pip install -r requirements/requirements-mxnet.txt
-        pip install -r requirements/requirements-pytorch.txt --no-cache-dir
+        pip install -r requirements/requirements-pytorch.txt --no-cache-dir -f https://download.pytorch.org/whl/torch_stable.html
         pip install gluonts
         pip install -r requirements/requirements-test.txt
         pip install -r requirements/requirements-extras-sagemaker-sdk.txt

--- a/src/gluonts/shell/train.py
+++ b/src/gluonts/shell/train.py
@@ -90,7 +90,7 @@ def run_train_and_test(
     predictor.serialize(env.path.model)
 
     if "test" in env.datasets:
-        run_test(env, predictor, env.datasets["test"])
+        run_test(env, predictor, env.datasets["test"], env.hyperparameters)
 
 
 def run_train(
@@ -124,12 +124,15 @@ def run_train(
         )
     else:
         return forecaster.train(
-            training_data=train_dataset, validation_data=validation_dataset,
+            training_data=train_dataset, validation_data=validation_dataset
         )
 
 
 def run_test(
-    env: TrainEnv, predictor: Predictor, test_dataset: Dataset
+    env: TrainEnv,
+    predictor: Predictor,
+    test_dataset: Dataset,
+    hyperparameters: dict,
 ) -> None:
     len_original = maybe_len(test_dataset)
 
@@ -154,12 +157,27 @@ def run_test(
         dataset=test_dataset, predictor=predictor, num_samples=100
     )
 
+    test_quantiles = (
+        list(map(str, (hyperparameters["test_quantiles"])))
+        if "test_quantiles" in hyperparameters.keys()
+        else None
+    )
     if isinstance(predictor, RepresentableBlockPredictor) and isinstance(
         predictor.forecast_generator, QuantileForecastGenerator
     ):
-        quantiles = predictor.forecast_generator.quantiles
-        logger.info(f"Using quantiles `{quantiles}` for evaluation.")
-        evaluator = Evaluator(quantiles=quantiles)
+        predictor_quantiles = predictor.forecast_generator.quantiles
+        if test_quantiles is None:
+            test_quantiles = predictor_quantiles
+        elif not set(test_quantiles).issubset(set(predictor_quantiles)):
+            logger.warning(
+                f"Some of the evaluation quantiles `{test_quantiles}` are "
+                f"not in the computed quantile forecasts `{predictor_quantiles}`."
+            )
+            test_quantiles = predictor_quantiles
+
+    if test_quantiles is not None:
+        logger.info(f"Using quantiles `{test_quantiles}` for evaluation.")
+        evaluator = Evaluator(quantiles=test_quantiles)
     else:
         evaluator = Evaluator()
 

--- a/src/gluonts/shell/train.py
+++ b/src/gluonts/shell/train.py
@@ -22,6 +22,7 @@ from gluonts.core.serde import dump_code
 from gluonts.dataset.common import Dataset
 from gluonts.evaluation import Evaluator, backtest
 from gluonts.model.estimator import Estimator, GluonEstimator
+from gluonts.model.forecast import Quantile
 from gluonts.model.forecast_generator import QuantileForecastGenerator
 from gluonts.model.predictor import Predictor
 from gluonts.mx.model.predictor import RepresentableBlockPredictor
@@ -158,10 +159,14 @@ def run_test(
     )
 
     test_quantiles = (
-        list(map(str, (hyperparameters["test_quantiles"])))
+        [
+            Quantile.parse(quantile).name
+            for quantile in hyperparameters["test_quantiles"]
+        ]
         if "test_quantiles" in hyperparameters.keys()
         else None
     )
+
     if isinstance(predictor, RepresentableBlockPredictor) and isinstance(
         predictor.forecast_generator, QuantileForecastGenerator
     ):

--- a/test/shell/test_shell.py
+++ b/test/shell/test_shell.py
@@ -57,6 +57,8 @@ def train_env(listify_dataset) -> ContextManager[TrainEnv]:
         "num_prefetch": 4,
         "shuffle_buffer_length": 256,
         "epochs": 3,
+        "quantiles": [0.1, 0.25, 0.5, 0.75, 0.9],
+        "test_quantiles": [0.25, 0.75],
     }
     with testutil.temporary_train_env(hyperparameters, "constant") as env:
         yield env


### PR DESCRIPTION
…tiles for evaluation

*Description of changes:*
- Added `test_quantiles` hyperparameter to the shell to specify the quantiles for evaluation
- Checks that `test_quantiles` is a subset of the `quantiles` model hyperparameter in the `MQ-CNN` case

*Testing:*
- Updated `test_train_shell` in `test/shell/test_shell.py` with  `"quantiles": [0.1, 0.25, 0.5, 0.75, 0.9], "test_quantiles": [0.25, 0.75],` gives the following output:

```
[2020-10-17 19:59:44] [INFO] gluonts.shell.train #test_score (local, ND): 0.09176455073886447
[2020-10-17 19:59:44] [INFO] gluonts.shell.train #test_score (local, wQuantileLoss[0.25]): 0.07710879822434098
[2020-10-17 19:59:44] [INFO] gluonts.shell.train #test_score (local, wQuantileLoss[0.75]): 0.08335938387446934
[2020-10-17 19:59:44] [INFO] gluonts.shell.train #test_score (local, mean_absolute_QuantileLoss): 21.663204583339393
[2020-10-17 19:59:44] [INFO] gluonts.shell.train #test_score (local, mean_wQuantileLoss): 0.08023409104940515
[2020-10-17 19:59:44] [INFO] gluonts.shell.train #test_score (local, mean_wQuantileLoss_WAPE): 0.08407757761255825
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
