### PR TITLE
Ignore NaN values during training and throw a warning (training got stuck before)

### DIFF
--- a/src/gluonts/mx/trainer/_base.py
+++ b/src/gluonts/mx/trainer/_base.py
@@ -275,27 +275,25 @@ class Trainer:
                                 else:
                                     loss = output
 
-
                             if not np.isfinite(ndarray.sum(loss).asscalar()):
                                 logger.warning(
-                                    "Epoch[%d] gave nan loss and will be skipped", epoch_no
+                                    "Batch [%d] of Epoch[%d] gave NaN loss and it will be ignored", batch_no, epoch_no
                                 )
-                                return epoch_loss
+                            else:
+                                if is_training:
+                                    loss.backward()
+                                    trainer.step(batch_size)
 
-                            if is_training:
-                                loss.backward()
-                                trainer.step(batch_size)
+                                    # iteration averaging in training
+                                    if isinstance(
+                                        self.avg_strategy,
+                                        IterationAveragingStrategy,
+                                    ):
+                                        self.avg_strategy.apply(net)
 
-                                # iteration averaging in training
-                                if isinstance(
-                                    self.avg_strategy,
-                                    IterationAveragingStrategy,
-                                ):
-                                    self.avg_strategy.apply(net)
+                                epoch_loss.update(None, preds=loss)
 
-                            epoch_loss.update(None, preds=loss)
                             lv = loss_value(epoch_loss)
-
                             it.set_postfix(
                                 ordered_dict={
                                     "epoch": f"{epoch_no + 1}/{self.epochs}",

--- a/src/gluonts/mx/trainer/_base.py
+++ b/src/gluonts/mx/trainer/_base.py
@@ -32,6 +32,7 @@ from gluonts.dataset.loader import TrainDataLoader, ValidationDataLoader
 from gluonts.gluonts_tqdm import tqdm
 from gluonts.mx.context import get_mxnet_context
 from gluonts.support.util import HybridContext
+from mxnet.metric import ndarray
 
 # Relative imports
 from . import learning_rate_scheduler as lrs
@@ -274,7 +275,8 @@ class Trainer:
                                 else:
                                     loss = output
 
-                            if not np.isfinite(np.ndarray.sum(loss).asscalar()):
+
+                            if not np.isfinite(ndarray.sum(loss).asscalar()):
                                 logger.warning(
                                     "Epoch[%d] gave nan loss and will be skipped", epoch_no
                                 )

--- a/src/gluonts/mx/trainer/_base.py
+++ b/src/gluonts/mx/trainer/_base.py
@@ -274,6 +274,12 @@ class Trainer:
                                 else:
                                     loss = output
 
+                            if not np.isfinite(np.ndarray.sum(loss).asscalar()):
+                                logger.warning(
+                                    "Epoch[%d] gave nan loss and will be skipped", epoch_no
+                                )
+                                return epoch_loss
+
                             if is_training:
                                 loss.backward()
                                 trainer.step(batch_size)
@@ -287,12 +293,6 @@ class Trainer:
 
                             epoch_loss.update(None, preds=loss)
                             lv = loss_value(epoch_loss)
-
-                            if not np.isfinite(lv):
-                                logger.warning(
-                                    "Epoch[%d] gave nan loss", epoch_no
-                                )
-                                return epoch_loss
 
                             it.set_postfix(
                                 ordered_dict={


### PR DESCRIPTION
### Issue
Before this change, the parameters of the model where updated even when the loss was NaN. The check for the NaN value was only at the end of the epoch and resulted in a warning. An error was thrown only if a NaN loss value was found in the first epoch with a suggestion of reducing the initial learning rate, otherwise the training would continue resulting in undesired behaviour, like training getting stuck and freezing the CPU, which I experienced firsthand.

### Change
I changed the code to throw a warning and ignore NaNs during training. With this change, the training does not get stuck anymore, although the previously thrown error now triggers only when ALL the batches of the first epoch give NaNs.

### Comments
I think there should probably be a parameter to select the appropriate behaviour when encountering NaNs during training (warning or error). It might be that some samples taken from the time-series are just unlucky and ignoring them gives still good results. This is what I experienced in my experimental setup.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
