### PR TITLE
Training History

### DIFF
--- a/src/gluonts/model/estimator.py
+++ b/src/gluonts/model/estimator.py
@@ -12,7 +12,7 @@
 # permissions and limitations under the License.
 
 # Standard library imports
-from typing import NamedTuple, Optional
+from typing import NamedTuple, Optional, Dict, List
 from functools import partial
 
 # Third-party imports
@@ -242,7 +242,7 @@ class GluonEstimator(Estimator):
         with self.trainer.ctx:
             trained_net = self.create_training_network()
 
-        self.trainer(
+        training_history = self.trainer(
             net=trained_net,
             input_names=get_hybrid_forward_input_names(trained_net),
             train_iter=training_data_loader,
@@ -252,10 +252,13 @@ class GluonEstimator(Estimator):
         with self.trainer.ctx:
             # ensure that the prediction network is created within the same MXNet
             # context as the one that was used during training
+            predictor = self.create_predictor(transformation, trained_net)
+            predictor.training_history = training_history
+
             return TrainOutput(
                 transformation=transformation,
                 trained_net=trained_net,
-                predictor=self.create_predictor(transformation, trained_net),
+                predictor=predictor,
             )
 
     def train(

--- a/src/gluonts/model/predictor.py
+++ b/src/gluonts/model/predictor.py
@@ -78,6 +78,7 @@ class Predictor:
         self.prediction_length = prediction_length
         self.freq = freq
         self.lead_time = lead_time
+        self.training_history = None
 
     def predict(self, dataset: Dataset, **kwargs) -> Iterator[Forecast]:
         """

--- a/src/gluonts/mx/trainer/_base.py
+++ b/src/gluonts/mx/trainer/_base.py
@@ -351,14 +351,18 @@ class Trainer:
 
                     epoch_loss = loop(epoch_no, train_iter)
 
-                    training_history["training_loss"].append(epoch_loss)
+                    training_history["training_loss"].append(
+                        loss_value(epoch_loss)
+                    )
 
                     if is_validation_available:
                         epoch_loss = loop(
                             epoch_no, validation_iter, is_training=False
                         )
 
-                        training_history["validation_loss"].append(epoch_loss)
+                        training_history["validation_loss"].append(
+                            loss_value(epoch_loss)
+                        )
 
                     # update average trigger
                     if isinstance(


### PR DESCRIPTION
*Issue*
#1124

*Description of changes:*
I think it should be possible for users to access the training history to monitor overfitting. This is a non breaking way to do that, however I am not sure if the predictor should own the history.

```python
from gluonts.dataset.repository.datasets import get_dataset
from gluonts.model.simple_feedforward import SimpleFeedForwardEstimator
from gluonts.model.deepar import DeepAREstimator
from gluonts.mx.trainer import Trainer
import random

dataset = get_dataset("m4_hourly", regenerate=True)

estimator = SimpleFeedForwardEstimator(
    num_hidden_dimensions = [20, 20],
    prediction_length=dataset.metadata.prediction_length,
    context_length=dataset.metadata.prediction_length*8,
    freq=dataset.metadata.freq,
    trainer=Trainer(epochs=2, learning_rate_decay_factor=0.99, patience=100)
)
n_time_series = len(dataset.train)
n_train_time_series = int(n_time_series*0.5)
dataset_train = list(dataset.train)
random.shuffle(dataset_train)
train_set = dataset_train[:n_train_time_series]
eval_set = dataset_train[n_train_time_series:]

predictor = estimator.train(train_set, validation_data=eval_set)

predictor.training_history

{'training_loss': [5.8661989498138425,
  5.025108561515808,
  4.730559797286987,
  4.819148554801941,
  4.586751465797424,
  4.538518929481507,
  4.649438915252685,
  4.6237060785293576,
  4.435682978630066,
  4.367659435272217],
 'validation_loss': [5.418155691011356,
  4.712160367232102,
  4.557879279641544,
  4.504928608231133,
  4.594020612849746,
  4.695075879778181,
  4.568878847977211,
  4.483525435890307,
  4.307454805116396,
  4.457428598403931]}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
