### PR TITLE
Move itertools to dedicated module, add caching utility

### DIFF
--- a/src/gluonts/dataset/loader.py
+++ b/src/gluonts/dataset/loader.py
@@ -23,20 +23,11 @@ import sys
 from queue import Empty
 
 from gluonts.dataset.common import DataEntry, DataBatch, Dataset
-from gluonts.dataset.util import MPWorkerInfo, batcher
+from gluonts.dataset.util import MPWorkerInfo, batcher, cycle
 from gluonts.transform import Transformation
 from gluonts.transform.dataset import TransformedDataset
 
 logger = logging.getLogger(__name__)
-
-
-class Cycle(Iterable):
-    def __init__(self, iterable: Iterable) -> None:
-        self.iterable = iterable
-
-    def __iter__(self):
-        while True:
-            yield from self.iterable
 
 
 class PseudoShuffledIterator(Iterator):
@@ -84,7 +75,7 @@ def construct_training_iterator(
     shuffle_buffer_length: Optional[int] = None,
 ) -> Iterator[DataEntry]:
     transformed_dataset = TransformedDataset(
-        Cycle(dataset), transform, is_train=True,
+        cycle(dataset), transform, is_train=True,
     )
 
     if shuffle_buffer_length is None:

--- a/src/gluonts/dataset/loader.py
+++ b/src/gluonts/dataset/loader.py
@@ -24,7 +24,7 @@ from queue import Empty
 
 from gluonts.dataset.common import DataEntry, DataBatch, Dataset
 from gluonts.dataset.util import MPWorkerInfo
-from gluonts.itertools import batcher, cycle, pseudo_shuffle
+from gluonts.itertools import batcher, cyclic, pseudo_shuffled
 from gluonts.transform import Transformation, TransformedDataset
 
 logger = logging.getLogger(__name__)
@@ -37,13 +37,13 @@ def construct_training_iterator(
     shuffle_buffer_length: Optional[int] = None,
 ) -> Iterator[DataEntry]:
     transformed_dataset = TransformedDataset(
-        cycle(dataset), transform, is_train=True,
+        cyclic(dataset), transform, is_train=True,
     )
 
     if shuffle_buffer_length is None:
         return iter(transformed_dataset)
     else:
-        return pseudo_shuffle(
+        return pseudo_shuffled(
             iter(transformed_dataset),
             shuffle_buffer_length=shuffle_buffer_length,
         )

--- a/src/gluonts/dataset/util.py
+++ b/src/gluonts/dataset/util.py
@@ -136,36 +136,6 @@ def to_pandas(instance: dict, freq: str = None) -> pd.Series:
     return pd.Series(target, index=index)
 
 
-def take(iterable: Iterable[T], n: int) -> Iterator[T]:
-    """Returns up to `n` elements from `iterable`.
-
-    This is similar to xs[:n], except that it works on `Iterable`s and possibly
-    consumes the given `iterable`.
-
-    >>> list(take(range(10), 5))
-    [0, 1, 2, 3, 4]
-    """
-    return itertools.islice(iterable, n)
-
-
-def batcher(iterable: Iterable[T], batch_size: int) -> Iterator[List[T]]:
-    """Groups elements from `iterable` into batches of size `batch_size`.
-
-    >>> list(batcher("ABCDEFG", 3))
-    [['A', 'B', 'C'], ['D', 'E', 'F'], ['G']]
-
-    Unlike the grouper proposed in the documentation of itertools, `batcher`
-    doesn't fill up missing values.
-    """
-    it: Iterator[T] = iter(iterable)
-
-    def get_batch():
-        return list(take(it, batch_size))
-
-    # has an empty list so that we have a 2D array for sure
-    return iter(get_batch, [])
-
-
 def dct_reduce(reduce_fn, dcts):
     """Similar to `reduce`, but applies reduce_fn to fields of dicts with the
     same name.
@@ -176,21 +146,3 @@ def dct_reduce(reduce_fn, dcts):
     keys = dcts[0].keys()
 
     return {key: reduce_fn([item[key] for item in dcts]) for key in keys}
-
-
-def shuffler(stream: Iterable[T], batch_size: int) -> Iterator[T]:
-    """Modifies a stream by shuffling items in windows.
-
-    It continously takes `batch_size`-elements from the stream and yields
-    elements from each batch  in random order."""
-
-    for batch in batcher(stream, batch_size):
-        random.shuffle(batch)
-        yield from batch
-
-
-def cycle(it):
-    """Like `itertools.cycle`, but does not store the data."""
-
-    while True:
-        yield from it

--- a/src/gluonts/itertools.py
+++ b/src/gluonts/itertools.py
@@ -18,7 +18,7 @@ import random
 T = TypeVar("T")
 
 
-def cycle(it):
+def cyclic(it):
     """Like `itertools.cycle`, but does not store the data."""
 
     while True:
@@ -43,7 +43,7 @@ def batcher(iterable: Iterable[T], batch_size: int) -> Iterator[List[T]]:
     return iter(get_batch, [])
 
 
-class cache(Iterable):
+class cached(Iterable):
     """
     An iterable wrapper, which caches values in a list the first time it is iterated.
 
@@ -69,7 +69,7 @@ class cache(Iterable):
             yield from self.cache
 
 
-def pseudo_shuffle(iterator: Iterator, shuffle_buffer_length: int):
+def pseudo_shuffled(iterator: Iterator, shuffle_buffer_length: int):
     """
     An iterator that yields item from a given iterator in a pseudo-shuffled order.
     """

--- a/src/gluonts/itertools.py
+++ b/src/gluonts/itertools.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
 from typing import Iterable, Iterator, List, TypeVar
 import itertools
 import random

--- a/src/gluonts/itertools.py
+++ b/src/gluonts/itertools.py
@@ -69,38 +69,16 @@ class cache(Iterable):
             yield from self.cache
 
 
-class pseudo_shuffle(Iterator):
+def pseudo_shuffle(iterator: Iterator, shuffle_buffer_length: int):
     """
-    An iterator that yields item from a wrapped iterator in a pseudo-shuffled order.
+    An iterator that yields item from a given iterator in a pseudo-shuffled order.
     """
+    shuffle_buffer = []
 
-    def __init__(self, iterator: Iterator, shuffle_buffer_length: int):
-        self.shuffle_buffer: list = []
-        self.shuffle_buffer_length = shuffle_buffer_length
-        self.iterator = iterator
+    for element in iterator:
+        shuffle_buffer.append(element)
+        if len(shuffle_buffer) >= shuffle_buffer_length:
+            yield shuffle_buffer.pop(random.randrange(len(shuffle_buffer)))
 
-    def __next__(self):
-        # If the buffer is empty, fill the buffer first.
-        if not self.shuffle_buffer:
-            self.shuffle_buffer = list(
-                itertools.islice(self.iterator, self.shuffle_buffer_length)
-            )
-
-        # If buffer still empty, means all elements used, return a signal of
-        # end of iterator
-        if not self.shuffle_buffer:
-            raise StopIteration
-
-        # Choose an element at a random index and yield it and fill it with
-        # the next element in the sequential generator
-        idx = random.randrange(len(self.shuffle_buffer))
-        next_sample = self.shuffle_buffer[idx]
-
-        # Replace the index with the next element in the iterator if the
-        # iterator has not finished. Delete the index otherwise.
-        try:
-            self.shuffle_buffer[idx] = next(self.iterator)
-        except StopIteration:
-            del self.shuffle_buffer[idx]
-
-        return next_sample
+    while shuffle_buffer:
+        yield shuffle_buffer.pop(random.randrange(len(shuffle_buffer)))

--- a/src/gluonts/itertools.py
+++ b/src/gluonts/itertools.py
@@ -44,6 +44,17 @@ def batcher(iterable: Iterable[T], batch_size: int) -> Iterator[List[T]]:
 
 
 class cache(Iterable):
+    """
+    An iterable wrapper, which caches values in a list the first time it is iterated.
+
+    The primary use-case for this is to avoid re-computing the element of the sequence,
+    in case the inner iterable does it on demand.
+
+    This should be used to wrap deterministic iterables, i.e. iterables where the data
+    generation process is not random, and that yield the same elements when iterated
+    multiple times.
+    """
+
     def __init__(self, iterable: Iterable) -> None:
         self.iterable = iterable
         self.cache = None

--- a/src/gluonts/itertools.py
+++ b/src/gluonts/itertools.py
@@ -1,0 +1,102 @@
+from typing import Iterable, Iterator, List, TypeVar
+import itertools
+import random
+
+T = TypeVar("T")
+
+
+def cycle(it):
+    """Like `itertools.cycle`, but does not store the data."""
+
+    while True:
+        yield from it
+
+
+def take(iterable: Iterable[T], n: int) -> Iterator[T]:
+    """Returns up to `n` elements from `iterable`.
+
+    This is similar to xs[:n], except that it works on `Iterable`s and possibly
+    consumes the given `iterable`.
+
+    >>> list(take(range(10), 5))
+    [0, 1, 2, 3, 4]
+    """
+    return itertools.islice(iterable, n)
+
+
+def batcher(iterable: Iterable[T], batch_size: int) -> Iterator[List[T]]:
+    """Groups elements from `iterable` into batches of size `batch_size`.
+
+    >>> list(batcher("ABCDEFG", 3))
+    [['A', 'B', 'C'], ['D', 'E', 'F'], ['G']]
+
+    Unlike the grouper proposed in the documentation of itertools, `batcher`
+    doesn't fill up missing values.
+    """
+    it: Iterator[T] = iter(iterable)
+
+    def get_batch():
+        return list(take(it, batch_size))
+
+    # has an empty list so that we have a 2D array for sure
+    return iter(get_batch, [])
+
+
+class _CachedIterable(Iterable):
+    def __init__(self, iterable: Iterable) -> None:
+        self.iterable = iterable
+        self.cache = None
+
+    def __iter__(self):
+        if self.cache is None:
+            self.cache = []
+            for element in self.iterable:
+                yield element
+                self.cache.append(element)
+        else:
+            yield from self.cache
+
+
+def cache(iterable: Iterable):
+    return _CachedIterable(iterable)
+
+
+class _PseudoShuffledIterator(Iterator):
+    """
+    An iterator that yields item from a wrapped iterator in a pseudo-shuffled order.
+    """
+
+    def __init__(self, iterator: Iterator, shuffle_buffer_length: int):
+        self.shuffle_buffer: List = []
+        self.shuffle_buffer_length = shuffle_buffer_length
+        self.iterator = iterator
+
+    def __next__(self):
+        # If the buffer is empty, fill the buffer first.
+        if not self.shuffle_buffer:
+            self.shuffle_buffer = list(
+                itertools.islice(self.iterator, self.shuffle_buffer_length)
+            )
+
+        # If buffer still empty, means all elements used, return a signal of
+        # end of iterator
+        if not self.shuffle_buffer:
+            raise StopIteration
+
+        # Choose an element at a random index and yield it and fill it with
+        # the next element in the sequential generator
+        idx = random.randrange(len(self.shuffle_buffer))
+        next_sample = self.shuffle_buffer[idx]
+
+        # Replace the index with the next element in the iterator if the
+        # iterator has not finished. Delete the index otherwise.
+        try:
+            self.shuffle_buffer[idx] = next(self.iterator)
+        except StopIteration:
+            del self.shuffle_buffer[idx]
+
+        return next_sample
+
+
+def pseudo_shuffle(iterator: Iterator, shuffle_buffer_length: int):
+    return _PseudoShuffledIterator(iterator, shuffle_buffer_length)

--- a/src/gluonts/itertools.py
+++ b/src/gluonts/itertools.py
@@ -25,18 +25,6 @@ def cycle(it):
         yield from it
 
 
-def take(iterable: Iterable[T], n: int) -> Iterator[T]:
-    """Returns up to `n` elements from `iterable`.
-
-    This is similar to xs[:n], except that it works on `Iterable`s and possibly
-    consumes the given `iterable`.
-
-    >>> list(take(range(10), 5))
-    [0, 1, 2, 3, 4]
-    """
-    return itertools.islice(iterable, n)
-
-
 def batcher(iterable: Iterable[T], batch_size: int) -> Iterator[List[T]]:
     """Groups elements from `iterable` into batches of size `batch_size`.
 
@@ -49,13 +37,13 @@ def batcher(iterable: Iterable[T], batch_size: int) -> Iterator[List[T]]:
     it: Iterator[T] = iter(iterable)
 
     def get_batch():
-        return list(take(it, batch_size))
+        return list(itertools.islice(it, batch_size))
 
     # has an empty list so that we have a 2D array for sure
     return iter(get_batch, [])
 
 
-class _CachedIterable(Iterable):
+class cache(Iterable):
     def __init__(self, iterable: Iterable) -> None:
         self.iterable = iterable
         self.cache = None
@@ -70,17 +58,13 @@ class _CachedIterable(Iterable):
             yield from self.cache
 
 
-def cache(iterable: Iterable):
-    return _CachedIterable(iterable)
-
-
-class _PseudoShuffledIterator(Iterator):
+class pseudo_shuffle(Iterator):
     """
     An iterator that yields item from a wrapped iterator in a pseudo-shuffled order.
     """
 
     def __init__(self, iterator: Iterator, shuffle_buffer_length: int):
-        self.shuffle_buffer: List = []
+        self.shuffle_buffer: list = []
         self.shuffle_buffer_length = shuffle_buffer_length
         self.iterator = iterator
 
@@ -109,7 +93,3 @@ class _PseudoShuffledIterator(Iterator):
             del self.shuffle_buffer[idx]
 
         return next_sample
-
-
-def pseudo_shuffle(iterator: Iterator, shuffle_buffer_length: int):
-    return _PseudoShuffledIterator(iterator, shuffle_buffer_length)

--- a/src/gluonts/shell/sagemaker/params.py
+++ b/src/gluonts/shell/sagemaker/params.py
@@ -19,7 +19,7 @@ from itertools import count
 # First-party imports
 from gluonts.core.serde import load_json, dump_json
 from gluonts.support.util import map_dct_values
-from gluonts.dataset.util import batcher
+from gluonts.itertools import batcher
 
 
 def decode_sagemaker_parameter(value: str) -> Union[list, dict, str]:

--- a/test/test_itertools.py
+++ b/test/test_itertools.py
@@ -16,13 +16,13 @@ from typing import Iterable
 import pytest
 
 from gluonts.dataset.artificial import constant_dataset
-from gluonts.itertools import pseudo_shuffle
+from gluonts.itertools import pseudo_shuffled
 
 
 @pytest.mark.parametrize("data", [range(20), constant_dataset()[1],])
-def test_pseudo_shuffle(data: Iterable) -> None:
+def test_pseudo_shuffled(data: Iterable) -> None:
     list_data = list(data)
-    shuffled_iter = pseudo_shuffle(iter(list_data), shuffle_buffer_length=5)
+    shuffled_iter = pseudo_shuffled(iter(list_data), shuffle_buffer_length=5)
     shuffled_data = list(shuffled_iter)
     assert len(shuffled_data) == len(list_data)
     assert all(d in shuffled_data for d in list_data)

--- a/test/test_itertools.py
+++ b/test/test_itertools.py
@@ -16,7 +16,7 @@ from typing import Iterable
 import pytest
 
 from gluonts.dataset.artificial import constant_dataset
-from gluonts.dataset.loader import pseudo_shuffle
+from gluonts.loader import pseudo_shuffle
 
 
 @pytest.mark.parametrize("data", [range(20), constant_dataset()[1],])

--- a/test/test_itertools.py
+++ b/test/test_itertools.py
@@ -16,7 +16,7 @@ from typing import Iterable
 import pytest
 
 from gluonts.dataset.artificial import constant_dataset
-from gluonts.loader import pseudo_shuffle
+from gluonts.itertools import pseudo_shuffle
 
 
 @pytest.mark.parametrize("data", [range(20), constant_dataset()[1],])

--- a/test/test_itertools.py
+++ b/test/test_itertools.py
@@ -16,15 +16,13 @@ from typing import Iterable
 import pytest
 
 from gluonts.dataset.artificial import constant_dataset
-from gluonts.dataset.loader import PseudoShuffledIterator
+from gluonts.dataset.loader import pseudo_shuffle
 
 
 @pytest.mark.parametrize("data", [range(20), constant_dataset()[1],])
-def test_shuffle_iter(data: Iterable) -> None:
+def test_pseudo_shuffle(data: Iterable) -> None:
     list_data = list(data)
-    shuffled_iter = PseudoShuffledIterator(
-        iter(list_data), shuffle_buffer_length=5
-    )
+    shuffled_iter = pseudo_shuffle(iter(list_data), shuffle_buffer_length=5)
     shuffled_data = list(shuffled_iter)
     assert len(shuffled_data) == len(list_data)
     assert all(d in shuffled_data for d in list_data)


### PR DESCRIPTION
* Move iterator utilities to a dedicated itertools module
* Remove `shuffle` (not used) introduce `pseudo_shuffle` instead (this is based on the mechanism we're using in the data loader, which is just as general)
* Add the `cache` util that caches an iterable so that the second pass through it is faster. This can be used to cache datasets or transformed datasets (as long as their iteration is deterministic, i.e. no instance splitting or other random transformations).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
