### PR TITLE
Speed up and re-enable TFT test

### DIFF
--- a/test/model/tft/test_model.py
+++ b/test/model/tft/test_model.py
@@ -28,10 +28,9 @@ def hyperparameters():
     )
 
 
-@pytest.mark.skip("This times out frequently.")
 @pytest.mark.parametrize("hybridize", [True, False])
 def test_accuracy(accuracy_test, hyperparameters, hybridize):
-    hyperparameters.update(num_batches_per_epoch=200, hybridize=hybridize)
+    hyperparameters.update(num_batches_per_epoch=50, hybridize=hybridize)
     accuracy_test(
         TemporalFusionTransformerEstimator, hyperparameters, accuracy=0.4
     )


### PR DESCRIPTION
*Description of changes:* This test was disable because it would time out frequently; reducing the number of batches used to make it faster.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
