### PR TITLE
Masking edge case fix

### DIFF
--- a/src/gluonts/transform/feature.py
+++ b/src/gluonts/transform/feature.py
@@ -87,7 +87,7 @@ class MeanValueImputation(MissingValueImputation):
     """
 
     def __call__(self, values: np.ndarray) -> np.ndarray:
-        if len(values) == 1:
+        if len(values) == 1 or np.isnan(values).all():
             return DummyValueImputation()(values)
         nan_indices = np.where(np.isnan(values))
         values[nan_indices] = np.nanmean(values)
@@ -101,7 +101,7 @@ class LastValueImputation(MissingValueImputation):
     """
 
     def __call__(self, values: np.ndarray) -> np.ndarray:
-        if len(values) == 1:
+        if len(values) == 1 or np.isnan(values).all():
             return DummyValueImputation()(values)
         values = np.expand_dims(values, axis=0)
 
@@ -127,7 +127,7 @@ class CausalMeanValueImputation(MissingValueImputation):
     """
 
     def __call__(self, values: np.ndarray) -> np.ndarray:
-        if len(values) == 1:
+        if len(values) == 1 or np.isnan(values).all():
             return DummyValueImputation()(values)
         mask = np.isnan(values)
 
@@ -165,7 +165,7 @@ class RollingMeanValueImputation(MissingValueImputation):
         self.window_size = 1 if window_size < 1 else window_size
 
     def __call__(self, values: np.ndarray) -> np.ndarray:
-        if len(values) == 1:
+        if len(values) == 1 or np.isnan(values).all():
             return DummyValueImputation()(values)
         mask = np.isnan(values)
 

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -898,6 +898,7 @@ def test_AddObservedIndicator():
     array_values = [
         np.array([np.nan, 1.0, 1.0, np.nan, 2.0, np.nan, 1.0, np.nan]),
         np.array([np.nan]),
+        np.array([np.nan, np.nan, np.nan, np.nan, np.nan]),
         np.array([10.0]),
     ]
 
@@ -923,31 +924,37 @@ def test_AddObservedIndicator():
         "dummy_value": [
             np.array([0.0, 1.0, 1.0, 0.0, 2.0, 0.0, 1.0, 0.0]),
             np.array([0.0]),
+            np.array([0.0, 0.0, 0.0, 0.0, 0.0]),
             np.array([10.0]),
         ],
         "mean": [
             np.array([1.25, 1.0, 1.0, 1.25, 2.0, 1.25, 1.0, 1.25]),
             np.array([0.0]),
+            np.array([0.0, 0.0, 0.0, 0.0, 0.0]),
             np.array([10.0]),
         ],
         "causal_mean": [
             np.array([1.0, 1.0, 1.0, 1.0, 2.0, 1.2, 1.0, 9 / 7]),
             np.array([0.0]),
+            np.array([0.0, 0.0, 0.0, 0.0, 0.0]),
             np.array([10.0]),
         ],
         "last_value": [
             np.array([1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 1.0, 1.0]),
             np.array([0.0]),
+            np.array([0.0, 0.0, 0.0, 0.0, 0.0]),
             np.array([10.0]),
         ],
         "rolling_mean10": [
             np.array([1.0, 1.0, 1.0, 1.0, 2.0, 1.1, 1.0, 1.2]),
             np.array([0.0]),
+            np.array([0.0, 0.0, 0.0, 0.0, 0.0]),
             np.array([10.0]),
         ],
         "rolling_mean1": [
             np.array([1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 1.0, 1.0]),
             np.array([0.0]),
+            np.array([0.0, 0.0, 0.0, 0.0, 0.0]),
             np.array([10.0]),
         ],
     }
@@ -955,6 +962,7 @@ def test_AddObservedIndicator():
     expected_missindicators = [
         np.array([0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0]),
         np.array([0.0]),
+        np.array([0.0, 0.0, 0.0, 0.0, 0.0]),
         np.array([1.0]),
     ]
 


### PR DESCRIPTION
The missing value imputations methods break if the window is all `nan` values. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
