### PR TITLE
added dataset as argument to as_symbol_block_predictor

### DIFF
--- a/src/gluonts/model/rotbaum/_predictor.py
+++ b/src/gluonts/model/rotbaum/_predictor.py
@@ -282,7 +282,7 @@ class TreePredictor(GluonPredictor):
             return load_json(fp.read())
 
     def as_symbol_block_predictor(
-        self, batch: DataBatch = None, dataset: Dataset = None
+        self, batch: Optional[DataBatch] = None, dataset: Optional[Dataset] = None
     ) -> "SymbolBlockPredictor":
         return None
 

--- a/src/gluonts/model/rotbaum/_predictor.py
+++ b/src/gluonts/model/rotbaum/_predictor.py
@@ -282,7 +282,7 @@ class TreePredictor(GluonPredictor):
             return load_json(fp.read())
 
     def as_symbol_block_predictor(
-        self, batch: DataBatch
+        self, batch: DataBatch = None, dataset: Dataset = None
     ) -> "SymbolBlockPredictor":
         return None
 

--- a/src/gluonts/model/tpp/predictor.py
+++ b/src/gluonts/model/tpp/predictor.py
@@ -13,7 +13,7 @@
 
 # Standard library imports
 from pathlib import Path
-from typing import Iterator, List, Optional, cast, Callable
+from typing import Iterator, List, Optional, cast, Callable, Optional
 from functools import partial
 
 # Third-party imports
@@ -163,7 +163,7 @@ class PointProcessGluonPredictor(GluonPredictor):
         )
 
     def as_symbol_block_predictor(
-        self, batch: DataBatch = None, dataset: Dataset = None
+        self, batch: Optional[DataBatch] = None, dataset: Optional[Dataset] = None
     ) -> SymbolBlockPredictor:
         raise NotImplementedError(
             "Point process models are currently not hybridizable"

--- a/src/gluonts/model/tpp/predictor.py
+++ b/src/gluonts/model/tpp/predictor.py
@@ -163,7 +163,7 @@ class PointProcessGluonPredictor(GluonPredictor):
         )
 
     def as_symbol_block_predictor(
-        self, batch: DataBatch
+        self, batch: DataBatch = None, dataset: Dataset = None
     ) -> SymbolBlockPredictor:
         raise NotImplementedError(
             "Point process models are currently not hybridizable"

--- a/src/gluonts/mx/model/predictor.py
+++ b/src/gluonts/mx/model/predictor.py
@@ -134,18 +134,22 @@ class GluonPredictor(Predictor):
         self.prediction_net(*[batch[k] for k in self.input_names])
 
     def as_symbol_block_predictor(
-        self, batch: DataBatch
+        self, batch: DataBatch = None, dataset: Dataset = None
     ) -> "SymbolBlockPredictor":
         """
         Returns a variant of the current :class:`GluonPredictor` backed
         by a Gluon `SymbolBlock`. If the current predictor is already a
         :class:`SymbolBlockPredictor`, it just returns itself.
 
+        One of batch or datset must be set.
+
         Parameters
         ----------
         batch
             A batch of data to use for the required forward pass after the
             `hybridize()` call of the underlying network.
+        dataset
+            Dataset from which a batch is extracted if batch is not set.
 
         Returns
         -------
@@ -237,7 +241,7 @@ class SymbolBlockPredictor(GluonPredictor):
     BlockType = mx.gluon.SymbolBlock
 
     def as_symbol_block_predictor(
-        self, batch: DataBatch
+        self, batch: DataBatch = None, dataset: Dataset = None
     ) -> "SymbolBlockPredictor":
         return self
 
@@ -323,8 +327,18 @@ class RepresentableBlockPredictor(GluonPredictor):
         )
 
     def as_symbol_block_predictor(
-        self, batch: DataBatch
+        self, batch: DataBatch = None, dataset: Dataset = None
     ) -> SymbolBlockPredictor:
+
+        if batch is None:
+            data_loader = InferenceDataLoader(
+                dataset,
+                transform=self.input_transform,
+                batch_size=self.batch_size,
+                stack_fn=partial(batchify, ctx=self.ctx, dtype=self.dtype)
+            )
+            batch = next(iter(data_loader))
+
         with self.ctx:
             symbol_block_net = hybrid_block_to_symbol_block(
                 hb=self.prediction_net,

--- a/src/gluonts/mx/model/predictor.py
+++ b/src/gluonts/mx/model/predictor.py
@@ -134,7 +134,7 @@ class GluonPredictor(Predictor):
         self.prediction_net(*[batch[k] for k in self.input_names])
 
     def as_symbol_block_predictor(
-        self, batch: DataBatch = None, dataset: Dataset = None
+        self, batch: Optional[DataBatch] = None, dataset: Optional[Dataset] = None
     ) -> "SymbolBlockPredictor":
         """
         Returns a variant of the current :class:`GluonPredictor` backed
@@ -241,7 +241,7 @@ class SymbolBlockPredictor(GluonPredictor):
     BlockType = mx.gluon.SymbolBlock
 
     def as_symbol_block_predictor(
-        self, batch: DataBatch = None, dataset: Dataset = None
+        self, batch: Optional[DataBatch] = None, dataset: Optional[Dataset] = None
     ) -> "SymbolBlockPredictor":
         return self
 
@@ -327,7 +327,7 @@ class RepresentableBlockPredictor(GluonPredictor):
         )
 
     def as_symbol_block_predictor(
-        self, batch: DataBatch = None, dataset: Dataset = None
+        self, batch: Optional[DataBatch] = None, dataset: Optional[Dataset] = None
     ) -> SymbolBlockPredictor:
 
         if batch is None:


### PR DESCRIPTION
*Issue #, if available:*  #1133

*Description of changes:*
Added argument `dataset` to all `as_symbol_block_predictor` functions.
Did not want to remove `batch` argument to allow for backward compatibility.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
