### PR TITLE
Fix rotbaum

### DIFF
--- a/src/gluonts/model/rotbaum/_estimator.py
+++ b/src/gluonts/model/rotbaum/_estimator.py
@@ -11,20 +11,17 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# Third-party imports
-from mxnet.gluon import HybridBlock
-
 # First-party imports
 from gluonts.core.component import validated
 from gluonts.dataset.common import Dataset
-from gluonts.model.estimator import GluonEstimator, Predictor, TrainOutput
+from gluonts.model.estimator import Estimator, Predictor
 from gluonts.transform import FilterTransformation, Transformation
 
 # Relative imports
 from ._predictor import TreePredictor
 
 
-class ThirdPartyEstimator(GluonEstimator):
+class ThirdPartyEstimator(Estimator):
     """
     An `Estimator` that uses an external fitting mechanism, thus eliminating
     the need for a Trainer. Differs from DummyEstimator in that DummyEstimator
@@ -46,22 +43,6 @@ class ThirdPartyEstimator(GluonEstimator):
         self, training_data: Dataset, validation_dataset=None
     ) -> Predictor:
         return self.predictor(training_data)
-
-    def train_model(self):
-        return TrainOutput(
-            transformation=self.create_transformation(),
-            trained_net=self.create_training_network(),
-            predictor=self.create_predictor(),
-        )
-
-    def create_predictor(self) -> Predictor:
-        return self.predictor
-
-    def create_transformation(self) -> Transformation:
-        return FilterTransformation(lambda x: True)
-
-    def create_training_network(self) -> HybridBlock:
-        return HybridBlock()
 
 
 class TreeEstimator(ThirdPartyEstimator):

--- a/src/gluonts/model/rotbaum/_estimator.py
+++ b/src/gluonts/model/rotbaum/_estimator.py
@@ -42,7 +42,7 @@ class ThirdPartyEstimator(Estimator):
     def train(
         self, training_data: Dataset, validation_dataset=None
     ) -> Predictor:
-        return self.predictor(training_data)
+        return self.predictor.train(training_data)
 
 
 class TreeEstimator(ThirdPartyEstimator):

--- a/src/gluonts/model/rotbaum/_predictor.py
+++ b/src/gluonts/model/rotbaum/_predictor.py
@@ -179,7 +179,7 @@ class TreePredictor(RepresentablePredictor):
             "If using the Evaluator class with a TreePredictor, set num_workers=0."
         )
 
-    def __call__(self, training_data):
+    def train(self, training_data):
         assert training_data
         assert self.freq is not None
         if next(iter(training_data))["start"].freq is not None:

--- a/src/gluonts/model/rotbaum/_predictor.py
+++ b/src/gluonts/model/rotbaum/_predictor.py
@@ -23,7 +23,6 @@ import pandas as pd
 from itertools import chain
 import concurrent.futures
 import logging
-import mxnet as mx
 
 # First-party imports
 import gluonts
@@ -33,7 +32,7 @@ from gluonts.core.serde import dump_json, load_json
 from gluonts.dataset.common import Dataset
 from gluonts.model.forecast import Forecast
 from gluonts.model.forecast_generator import log_once
-from gluonts.mx.model.predictor import GluonPredictor
+from gluonts.model.predictor import RepresentablePredictor
 from gluonts.support.pandas import forecast_start
 from gluonts.dataset.loader import DataBatch
 
@@ -101,7 +100,7 @@ class RotbaumForecast(Forecast):
         )
 
 
-class TreePredictor(GluonPredictor):
+class TreePredictor(RepresentablePredictor):
     """
     A predictor that uses a QRX model for each of the steps in the forecast
     horizon. (In other words, there's a total of prediction_length many
@@ -225,11 +224,6 @@ class TreePredictor(GluonPredictor):
 
         return self
 
-    @validated()
-    def train(self, training_data):
-        self.__call__(training_data)
-
-    @validated()
     def predict(
         self, dataset: Dataset, num_samples: Optional[int] = None
     ) -> Iterator[Forecast]:
@@ -258,37 +252,3 @@ class TreePredictor(GluonPredictor):
                 prediction_length=self.prediction_length,
                 freq=self.freq,
             )
-
-    def serialize(self, path: Path) -> None:
-
-        with (path / "type.txt").open("w") as fp:
-            fp.write(fqname_for(self.__class__))
-        with (path / "version.json").open("w") as fp:
-            json.dump(
-                {"model": self.__version__, "gluonts": gluonts.__version__}, fp
-            )
-        with (path / "predictor.json").open("w") as fp:
-            print(dump_json(self), file=fp)
-
-    def serialize_prediction_net(self, path: Path) -> None:
-        self.serialize(path)
-
-    @classmethod
-    def deserialize(
-        cls, path: Path, ctx: Optional[mx.Context] = None
-    ) -> "TreePredictor":
-
-        with (path / "predictor.json").open("r") as fp:
-            return load_json(fp.read())
-
-    def as_symbol_block_predictor(
-        self, batch: Optional[DataBatch] = None, dataset: Optional[Dataset] = None
-    ) -> "SymbolBlockPredictor":
-        return None
-
-    def __eq__(self, that):
-        """
-        Two RepresentablePredictor instances are considered equal if they
-        have the same constructor arguments.
-        """
-        return equals(self, that)


### PR DESCRIPTION
*Description of changes:* Since Rotbaum is not based on Gluon, there's no need to inherit from GluonEstimator and GluonPredictor.

Also removed the `__call__` method from `TreePredictor`, in favor of the more explicit `train`.

@zoolhasson I'm trying to add you as a reviewer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
