### PR TITLE
Added quantile function based on cdf bisection

### DIFF
--- a/src/gluonts/mx/distribution/__init__.py
+++ b/src/gluonts/mx/distribution/__init__.py
@@ -83,6 +83,7 @@ __all__ = [
     "ZeroInflatedBetaOutput",
     "OneInflatedBeta",
     "OneInflatedBetaOutput",
+    "GenParetoOutput",
     "GenPareto",
     "GaussianOutput",
     "Gaussian",

--- a/src/gluonts/mx/distribution/binned.py
+++ b/src/gluonts/mx/distribution/binned.py
@@ -71,7 +71,7 @@ class Binned(Distribution):
         return getF(self.bin_log_probs)
 
     @property
-    def support(self) -> Tuple[Tensor, Tensor]:
+    def support_min_max(self) -> Tuple[Tensor, Tensor]:
         F = self.F
         return (
             F.broadcast_minimum(

--- a/src/gluonts/mx/distribution/deterministic.py
+++ b/src/gluonts/mx/distribution/deterministic.py
@@ -42,7 +42,10 @@ class Deterministic(Distribution):
     @validated()
     def __init__(self, value: Tensor) -> None:
         self.value = value
-        self.F = getF(value)
+
+    @property
+    def F(self):
+        return getF(self.value)
 
     @property
     def batch_shape(self) -> Tuple:

--- a/src/gluonts/mx/distribution/distribution.py
+++ b/src/gluonts/mx/distribution/distribution.py
@@ -297,8 +297,8 @@ class Distribution:
 
         try:
             support_lb, support_ub = self.support_min_max
-            support_lb = F.broadcast_minimum(
-                F.broadcast_maximum(
+            support_lb = F.broadcast_maximum(
+                F.broadcast_minimum(
                     support_lb,
                     F.ones(self.batch_shape) * local_max_support_val,
                 ),

--- a/src/gluonts/mx/distribution/distribution.py
+++ b/src/gluonts/mx/distribution/distribution.py
@@ -23,7 +23,7 @@ from mxnet import autograd
 from gluonts.model.common import Tensor
 
 
-MAX_SUPPORT_VAL = 1e16
+MAX_SUPPORT_VAL = np.finfo(np.float64).max
 
 
 def nans_like(x: Tensor) -> Tensor:
@@ -89,7 +89,7 @@ class Distribution:
         raise NotImplementedError()
 
     @property
-    def support(self) -> Tuple[Tensor, Tensor]:
+    def support_min_max(self) -> Tuple[Tensor, Tensor]:
         raise NotImplementedError()
 
     def log_prob(self, x: Tensor) -> Tensor:
@@ -286,6 +286,76 @@ class Distribution:
         """
         raise NotImplementedError()
 
+    def _tensor_cdf_bisection(
+        self, level: Tensor, tol=1e-6, max_iter=120
+    ) -> Tensor:
+        r"""
+        Returns a Tensor of shape (len(level), *batch_size) with the corresponding quantiles.
+        """
+        F = self.F
+        local_max_support_val = min(1e16, MAX_SUPPORT_VAL)
+
+        try:
+            support_lb, support_ub = self.support_min_max
+            support_lb = F.broadcast_minimum(
+                F.broadcast_maximum(
+                    support_lb,
+                    F.ones(self.batch_shape) * local_max_support_val,
+                ),
+                F.ones(self.batch_shape) * -local_max_support_val,
+            )
+            support_ub = F.broadcast_maximum(
+                F.broadcast_minimum(
+                    support_ub,
+                    F.ones(self.batch_shape) * local_max_support_val,
+                ),
+                F.ones(self.batch_shape) * -local_max_support_val,
+            )
+
+            upper_bound = F.broadcast_like(
+                support_lb.expand_dims(axis=0), level, lhs_axes=0, rhs_axes=0
+            )
+            lower_bound = F.broadcast_like(
+                support_ub.expand_dims(axis=0), level, lhs_axes=0, rhs_axes=0
+            )
+        except NotImplementedError:
+            # default to R if not defined
+            upper_bound = (
+                F.ones((len(level), *self.batch_shape)) * local_max_support_val
+            )
+            lower_bound = (
+                F.ones((len(level), *self.batch_shape))
+                * -local_max_support_val
+            )
+
+        for _ in range(self.all_dim):
+            level = level.expand_dims(axis=-1)
+
+        q = 0.5 * F.broadcast_add(upper_bound, lower_bound)
+        val = self.cdf(q) - level
+
+        cnt = 0
+        while F.sum(F.abs(val) > tol) > 0 and cnt < max_iter:
+            mask_g = F.greater(val, tol)
+            mask_l = F.lesser(val, -tol)
+            mask_done = F.lesser_equal(F.abs(val), tol)
+
+            upper_bound = (
+                F.broadcast_mul(q, mask_g)
+                + F.broadcast_mul(upper_bound, mask_l)
+                + F.broadcast_mul(q, mask_done)
+            )
+            lower_bound = (
+                F.broadcast_mul(q, mask_l)
+                + F.broadcast_mul(lower_bound, mask_g)
+                + F.broadcast_mul(q, mask_done)
+            )
+
+            q = 0.5 * F.broadcast_add(upper_bound, lower_bound)
+            val = self.cdf(q) - level
+            cnt += 1
+        return q
+
     def quantile(self, level: Tensor) -> Tensor:
         r"""
 
@@ -308,65 +378,7 @@ class Distribution:
             where DISTRIBUTION_SHAPE is the shape of the underlying distribution.
         """
 
-        def _tensor_cdf_bisection(
-            level: Tensor, tol=1e-6, max_iter=120,
-        ) -> Tensor:
-            r"""
-            Returns a Tensor of shape (len(level), *batch_size) with the corresponding quantiles.
-            """
-            try:
-                support_lb, support_ub = self.support
-                upper_bound = F.broadcast_like(
-                    support_lb.expand_dims(axis=0),
-                    level,
-                    lhs_axes=0,
-                    rhs_axes=0,
-                )
-                lower_bound = F.broadcast_like(
-                    support_ub.expand_dims(axis=0),
-                    level,
-                    lhs_axes=0,
-                    rhs_axes=0,
-                )
-            except:
-                # default to R if not defined
-                upper_bound = (
-                    F.ones((len(level), *self.batch_shape)) * MAX_SUPPORT_VAL
-                )
-                lower_bound = (
-                    F.ones((len(level), *self.batch_shape)) * -MAX_SUPPORT_VAL
-                )
-
-            for _ in range(self.all_dim):
-                level = level.expand_dims(axis=-1)
-
-            q = 0.5 * F.broadcast_add(upper_bound, lower_bound)
-            val = self.cdf(q) - level
-
-            cnt = 0
-            while F.sum(F.abs(val) > tol) > 0 and cnt < max_iter:
-                mask_g = F.greater(val, tol)
-                mask_l = F.lesser(val, -tol)
-                mask_done = F.lesser_equal(F.abs(val), tol)
-
-                upper_bound = (
-                    F.broadcast_mul(q, mask_g)
-                    + F.broadcast_mul(upper_bound, mask_l)
-                    + F.broadcast_mul(q, mask_done)
-                )
-                lower_bound = (
-                    F.broadcast_mul(q, mask_l)
-                    + F.broadcast_mul(lower_bound, mask_g)
-                    + F.broadcast_mul(q, mask_done)
-                )
-
-                q = 0.5 * F.broadcast_add(upper_bound, lower_bound)
-                val = self.cdf(q) - level
-                cnt += 1
-            return q
-
-        F = self.F
-        return _tensor_cdf_bisection(level)
+        return self._tensor_cdf_bisection(level)
 
     def __getitem__(self, item):
         sliced_distr = self.__class__(

--- a/src/gluonts/mx/distribution/genpareto.py
+++ b/src/gluonts/mx/distribution/genpareto.py
@@ -44,16 +44,18 @@ class GenPareto(Distribution):
         Tensor containing the xi shape parameters, of shape `(*batch_shape, *event_shape)`.
     beta
         Tensor containing the beta scale parameters, of shape `(*batch_shape, *event_shape)`.
-    F
     """
 
     is_reparameterizable = False
 
     @validated()
-    def __init__(self, xi: Tensor, beta: Tensor, F=None) -> None:
+    def __init__(self, xi: Tensor, beta: Tensor) -> None:
         self.xi = xi
         self.beta = beta
-        self.F = F if F else getF(xi)  # assuming xi and beta of same type
+
+    @property
+    def F(self):
+        return getF(self.xi)
 
     @property
     def batch_shape(self) -> Tuple:

--- a/src/gluonts/mx/distribution/genpareto.py
+++ b/src/gluonts/mx/distribution/genpareto.py
@@ -59,7 +59,7 @@ class GenPareto(Distribution):
         return getF(self.xi)
 
     @property
-    def support(self) -> Tuple[Tensor, Tensor]:
+    def support_min_max(self) -> Tuple[Tensor, Tensor]:
         F = self.F
         return (
             F.zeros(self.batch_shape),

--- a/src/gluonts/mx/distribution/genpareto.py
+++ b/src/gluonts/mx/distribution/genpareto.py
@@ -32,6 +32,7 @@ from gluonts.mx.distribution.distribution import (
 )
 from gluonts.mx.distribution import uniform, box_cox_transform
 from gluonts.mx.distribution.distribution_output import DistributionOutput
+from gluonts.mx.distribution.distribution import MAX_SUPPORT_VAL
 
 
 class GenPareto(Distribution):
@@ -56,6 +57,14 @@ class GenPareto(Distribution):
     @property
     def F(self):
         return getF(self.xi)
+
+    @property
+    def support(self) -> Tuple[Tensor, Tensor]:
+        F = self.F
+        return (
+            F.zeros(self.batch_shape),
+            F.ones(self.batch_shape) * MAX_SUPPORT_VAL,
+        )
 
     @property
     def batch_shape(self) -> Tuple:

--- a/src/gluonts/mx/distribution/mixture.py
+++ b/src/gluonts/mx/distribution/mixture.py
@@ -99,13 +99,13 @@ class MixtureDistribution(Distribution):
         return getF(self.mixture_probs)
 
     @property
-    def support(self) -> Tuple[Tensor, Tensor]:
+    def support_min_max(self) -> Tuple[Tensor, Tensor]:
         F = self.F
         try:
             lb = F.ones(self.batch_shape) * MAX_SUPPORT_VAL
             ub = F.ones(self.batch_shape) * -MAX_SUPPORT_VAL
             for c in self.components:
-                c_lb, c_ub = c.support
+                c_lb, c_ub = c.support_min_max
                 lb = F.broadcast_minimum(lb, c_lb)
                 ub = F.broadcast_maximum(ub, c_ub)
             return lb, ub

--- a/src/gluonts/mx/distribution/mixture.py
+++ b/src/gluonts/mx/distribution/mixture.py
@@ -101,16 +101,13 @@ class MixtureDistribution(Distribution):
     @property
     def support_min_max(self) -> Tuple[Tensor, Tensor]:
         F = self.F
-        try:
-            lb = F.ones(self.batch_shape) * MAX_SUPPORT_VAL
-            ub = F.ones(self.batch_shape) * -MAX_SUPPORT_VAL
-            for c in self.components:
-                c_lb, c_ub = c.support_min_max
-                lb = F.broadcast_minimum(lb, c_lb)
-                ub = F.broadcast_maximum(ub, c_ub)
-            return lb, ub
-        except NotImplementedError:
-            raise NotImplementedError()
+        lb = F.ones(self.batch_shape) * MAX_SUPPORT_VAL
+        ub = F.ones(self.batch_shape) * -MAX_SUPPORT_VAL
+        for c in self.components:
+            c_lb, c_ub = c.support_min_max
+            lb = F.broadcast_minimum(lb, c_lb)
+            ub = F.broadcast_maximum(ub, c_ub)
+        return lb, ub
 
     def __getitem__(self, item):
         mp = _index_tensor(self.mixture_probs, item)

--- a/src/gluonts/mx/distribution/mixture.py
+++ b/src/gluonts/mx/distribution/mixture.py
@@ -77,12 +77,18 @@ class MixtureDistribution(Distribution):
                                     the axis)."""
 
             expected_shape = self.batch_shape + (len(components),)
-            assert len(expected_shape) == len(mixture_probs.shape), (
+
+            # fix edge case: if batch_shape == (1,) the mixture_probs shape is squeezed to (k,)
+            # reshape it to (1, k)
+            if self.batch_shape == (1,):
+                self.mixture_probs = self.mixture_probs.reshape(1, -1)
+
+            assert len(expected_shape) == len(self.mixture_probs.shape), (
                 assertion_message
                 + " Maybe you need to expand the shape of mixture_probs at the zeroth axis."
             )
             for expected_dim, given_dim in zip(
-                expected_shape, mixture_probs.shape
+                expected_shape, self.mixture_probs.shape
             ):
                 assert (
                     expected_dim == given_dim

--- a/src/gluonts/mx/distribution/transformed_distribution.py
+++ b/src/gluonts/mx/distribution/transformed_distribution.py
@@ -52,8 +52,12 @@ class TransformedDistribution(Distribution):
         self._batch_shape: Optional[Tuple] = None
 
     @property
-    def support(self) -> Tuple[Tensor, Tensor]:
-        return self.base_distribution.support
+    def support_min_max(self) -> Tuple[Tensor, Tensor]:
+        lb, ub = self.base_distribution.support_min_max
+        for t in self.transforms:
+            lb = t.f(lb)
+            ub = t.f(ub)
+        return lb, ub
 
     def _slice_bijection(
         self, trans: bij.Bijection, item: Any

--- a/src/gluonts/mx/distribution/transformed_distribution.py
+++ b/src/gluonts/mx/distribution/transformed_distribution.py
@@ -52,11 +52,18 @@ class TransformedDistribution(Distribution):
         self._batch_shape: Optional[Tuple] = None
 
     @property
+    def F(self):
+        return self.base_distribution.F
+
+    @property
     def support_min_max(self) -> Tuple[Tensor, Tensor]:
+        F = self.F
         lb, ub = self.base_distribution.support_min_max
         for t in self.transforms:
-            lb = t.f(lb)
-            ub = t.f(ub)
+            _lb = t.f(lb)
+            _ub = t.f(ub)
+            lb = F.minimum(_lb, _ub)
+            ub = F.maximum(_lb, _ub)
         return lb, ub
 
     def _slice_bijection(

--- a/src/gluonts/mx/distribution/transformed_distribution.py
+++ b/src/gluonts/mx/distribution/transformed_distribution.py
@@ -51,6 +51,10 @@ class TransformedDistribution(Distribution):
         self._event_shape: Optional[Tuple] = None
         self._batch_shape: Optional[Tuple] = None
 
+    @property
+    def support(self) -> Tuple[Tensor, Tensor]:
+        return self.base_distribution.support
+
     def _slice_bijection(
         self, trans: bij.Bijection, item: Any
     ) -> bij.Bijection:

--- a/test/distribution/test_default_quantile_method.py
+++ b/test/distribution/test_default_quantile_method.py
@@ -17,10 +17,20 @@ import mxnet as mx
 
 # First-party imports
 from gluonts.mx.distribution.gaussian import Gaussian
+from gluonts.mx.distribution.uniform import Uniform
 from gluonts.mx.distribution.mixture import MixtureDistribution
 
 
+# In these tests we can use only distributions that have a cdf method but do not have a quantile method.
+# The mixture distribution satisfies these conditions. The components of the mixture should have a cdf method.
+
+
 def test_quantile() -> None:
+    r"""
+    Tests if the quantiles of a single Gaussian and the quantiles of the mixture of two Gaussians
+    identical to the first are equal. The quantiles of the single Gaussian are given by the
+    Gaussian.quantile() method while the quantiles of the mixture from the Distribution.quantile() method.
+    """
     mu = mx.nd.array(
         [[1, 10, 100, 1000, 10000], [-1, -10, -100, -1000, -10000]]
     )
@@ -47,3 +57,46 @@ def test_quantile() -> None:
         np.abs(gau_quantiles.asnumpy() / mix_quantiles.asnumpy() - 1)
     )
     assert relative_error < 1e-4
+
+
+def test_inverse_quantile() -> None:
+    r"""
+    Tests CDF(Q(x)) == x.
+    """
+    mu = mx.nd.array([1])
+    sigma = mx.nd.array([0.1])
+    uni_bound = mx.nd.array([1])
+    mixture_probs = mx.nd.array([[0.3, 0.7]])
+
+    levels = mx.nd.array([0.01, 0.1, 0.5, 0.9, 0.99])
+
+    mix_gau = MixtureDistribution(
+        mixture_probs=mixture_probs,
+        components=[Gaussian(mu, sigma), Gaussian(mu, sigma)],
+    )
+    mix_uni = MixtureDistribution(
+        mixture_probs=mixture_probs,
+        components=[
+            Uniform(uni_bound, 3 * uni_bound),
+            Uniform(uni_bound, 3 * uni_bound),
+        ],
+    )
+    mix_gau_uni = MixtureDistribution(
+        mixture_probs=mixture_probs,
+        components=[Gaussian(mu, sigma), Uniform(uni_bound, 3 * uni_bound)],
+    )
+
+    gau_res = mix_gau.cdf(mix_gau.quantile(levels))
+    uni_res = mix_uni.cdf(mix_uni.quantile(levels))
+    gau_uni_res = mix_gau_uni.cdf(mix_gau_uni.quantile(levels))
+
+    assert (
+        np.max(gau_res.asnumpy() / levels.asnumpy().reshape(-1, 1) - 1) < 1e-4
+    )
+    assert (
+        np.max(uni_res.asnumpy() / levels.asnumpy().reshape(-1, 1) - 1) < 1e-4
+    )
+    assert (
+        np.max(gau_uni_res.asnumpy() / levels.asnumpy().reshape(-1, 1) - 1)
+        < 1e-4
+    )

--- a/test/distribution/test_default_quantile_method.py
+++ b/test/distribution/test_default_quantile_method.py
@@ -1,6 +1,21 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# Third-party imports
 import numpy as np
 import mxnet as mx
 
+# First-party imports
 from gluonts.mx.distribution.gaussian import Gaussian
 from gluonts.mx.distribution.mixture import MixtureDistribution
 

--- a/test/distribution/test_default_quantile_method.py
+++ b/test/distribution/test_default_quantile_method.py
@@ -1,0 +1,34 @@
+import numpy as np
+import mxnet as mx
+
+from gluonts.mx.distribution.gaussian import Gaussian
+from gluonts.mx.distribution.mixture import MixtureDistribution
+
+
+def test_quantile() -> None:
+    mu = mx.nd.array(
+        [[1, 10, 100, 1000, 10000], [-1, -10, -100, -1000, -10000]]
+    )
+    sigma = mx.nd.array([[1.0, 2.0, 3.0, 4.0, 5.0]] * 2)
+
+    gau = Gaussian(mu, sigma)
+
+    mixture_probs = mx.nd.broadcast_like(
+        mx.nd.array([[0.5, 0.5]]).expand_dims(axis=0),
+        mu,
+        lhs_axes=(0, 1),
+        rhs_axes=(0, 1),
+    )
+    mix = MixtureDistribution(
+        mixture_probs=mixture_probs,
+        components=[Gaussian(mu, sigma), Gaussian(mu, sigma)],
+    )
+
+    quantiles = mx.nd.array([0.1, 0.5, 0.9])
+    gau_quantiles = gau.quantile(quantiles)
+    mix_quantiles = mix.quantile(quantiles)
+
+    relative_error = np.max(
+        np.abs(gau_quantiles.asnumpy() / mix_quantiles.asnumpy() - 1)
+    )
+    assert relative_error < 1e-4

--- a/test/distribution/test_mx_distribution_inference.py
+++ b/test/distribution/test_mx_distribution_inference.py
@@ -1153,7 +1153,6 @@ def test_genpareto_likelihood(xi: float, beta: float, hybridize: bool) -> None:
     ), f"beta did not match: beta = {beta}, beta_hat = {beta_hat}"
 
 
-@pytest.mark.skip("this test fails when run locally")
 @pytest.mark.timeout(120)
 @pytest.mark.flaky(max_runs=6, min_passes=1)
 @pytest.mark.parametrize("rate", [50.0])

--- a/test/distribution/test_mx_distribution_inference.py
+++ b/test/distribution/test_mx_distribution_inference.py
@@ -1153,6 +1153,7 @@ def test_genpareto_likelihood(xi: float, beta: float, hybridize: bool) -> None:
     ), f"beta did not match: beta = {beta}, beta_hat = {beta_hat}"
 
 
+@pytest.mark.skip("this test fails when run locally")
 @pytest.mark.timeout(120)
 @pytest.mark.flaky(max_runs=6, min_passes=1)
 @pytest.mark.parametrize("rate", [50.0])


### PR DESCRIPTION
- Added quantile function based on cdf bisection.
- Added a test that ensures we get the correct quantiles.

This method is used as the default in the `Distribution` class unless it is overwritten by the corresponding subclasses. It requires a cdf method. 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
