### PR TITLE
fix inflated discrete distribution tests

### DIFF
--- a/src/gluonts/evaluation/_base.py
+++ b/src/gluonts/evaluation/_base.py
@@ -319,12 +319,7 @@ class Evaluator:
                     target_fcst = median_fcst
 
                 try:
-                    val = {
-                        k: eval_fn(
-                            pred_target,
-                            target_fcst,
-                        )
-                    }
+                    val = {k: eval_fn(pred_target, target_fcst,)}
                 except:
                     val = {k: np.nan}
 

--- a/src/gluonts/model/tft/_estimator.py
+++ b/src/gluonts/model/tft/_estimator.py
@@ -56,7 +56,6 @@ def _default_feat_args(dims_or_cardinalities: List[int]):
     return [1]
 
 
-
 class TemporalFusionTransformerEstimator(GluonEstimator):
     @validated()
     def __init__(

--- a/src/gluonts/model/tpp/predictor.py
+++ b/src/gluonts/model/tpp/predictor.py
@@ -163,7 +163,9 @@ class PointProcessGluonPredictor(GluonPredictor):
         )
 
     def as_symbol_block_predictor(
-        self, batch: Optional[DataBatch] = None, dataset: Optional[Dataset] = None
+        self,
+        batch: Optional[DataBatch] = None,
+        dataset: Optional[Dataset] = None,
     ) -> SymbolBlockPredictor:
         raise NotImplementedError(
             "Point process models are currently not hybridizable"

--- a/src/gluonts/mx/distribution/__init__.py
+++ b/src/gluonts/mx/distribution/__init__.py
@@ -51,7 +51,11 @@ from .multivariate_gaussian import (
     MultivariateGaussianOutput,
 )
 from .nan_mixture import NanMixture, NanMixtureOutput
-from .neg_binomial import NegativeBinomial, NegativeBinomialOutput, ZeroInflatedNegativeBinomialOutput
+from .neg_binomial import (
+    NegativeBinomial,
+    NegativeBinomialOutput,
+    ZeroInflatedNegativeBinomialOutput,
+)
 from .piecewise_linear import (
     PiecewiseLinear,
     PiecewiseLinearOutput,

--- a/src/gluonts/mx/distribution/neg_binomial.py
+++ b/src/gluonts/mx/distribution/neg_binomial.py
@@ -28,6 +28,7 @@ from .distribution_output import DistributionOutput
 from .deterministic import DeterministicOutput
 from .mixture import MixtureDistributionOutput
 
+
 class NegativeBinomial(Distribution):
     r"""
     Negative binomial distribution, i.e. the distribution of the number of

--- a/src/gluonts/mx/distribution/poisson.py
+++ b/src/gluonts/mx/distribution/poisson.py
@@ -28,6 +28,7 @@ from .distribution_output import DistributionOutput
 from .deterministic import DeterministicOutput
 from .mixture import MixtureDistributionOutput
 
+
 class Poisson(Distribution):
     r"""
     Poisson distribution, i.e. the distribution of the number of

--- a/src/gluonts/mx/model/predictor.py
+++ b/src/gluonts/mx/model/predictor.py
@@ -134,7 +134,9 @@ class GluonPredictor(Predictor):
         self.prediction_net(*[batch[k] for k in self.input_names])
 
     def as_symbol_block_predictor(
-        self, batch: Optional[DataBatch] = None, dataset: Optional[Dataset] = None
+        self,
+        batch: Optional[DataBatch] = None,
+        dataset: Optional[Dataset] = None,
     ) -> "SymbolBlockPredictor":
         """
         Returns a variant of the current :class:`GluonPredictor` backed
@@ -241,7 +243,9 @@ class SymbolBlockPredictor(GluonPredictor):
     BlockType = mx.gluon.SymbolBlock
 
     def as_symbol_block_predictor(
-        self, batch: Optional[DataBatch] = None, dataset: Optional[Dataset] = None
+        self,
+        batch: Optional[DataBatch] = None,
+        dataset: Optional[Dataset] = None,
     ) -> "SymbolBlockPredictor":
         return self
 
@@ -327,7 +331,9 @@ class RepresentableBlockPredictor(GluonPredictor):
         )
 
     def as_symbol_block_predictor(
-        self, batch: Optional[DataBatch] = None, dataset: Optional[Dataset] = None
+        self,
+        batch: Optional[DataBatch] = None,
+        dataset: Optional[Dataset] = None,
     ) -> SymbolBlockPredictor:
 
         if batch is None:
@@ -335,7 +341,7 @@ class RepresentableBlockPredictor(GluonPredictor):
                 dataset,
                 transform=self.input_transform,
                 batch_size=self.batch_size,
-                stack_fn=partial(batchify, ctx=self.ctx, dtype=self.dtype)
+                stack_fn=partial(batchify, ctx=self.ctx, dtype=self.dtype),
             )
             batch = next(iter(data_loader))
 

--- a/src/gluonts/mx/trainer/_base.py
+++ b/src/gluonts/mx/trainer/_base.py
@@ -277,7 +277,9 @@ class Trainer:
 
                             if not np.isfinite(ndarray.sum(loss).asscalar()):
                                 logger.warning(
-                                    "Batch [%d] of Epoch[%d] gave NaN loss and it will be ignored", batch_no, epoch_no
+                                    "Batch [%d] of Epoch[%d] gave NaN loss and it will be ignored",
+                                    batch_no,
+                                    epoch_no,
                                 )
                             else:
                                 if is_training:

--- a/test/distribution/test_distribution_sampling.py
+++ b/test/distribution/test_distribution_sampling.py
@@ -300,4 +300,3 @@ def test_inflated_beta_sampling(
         np.histogram(samples.asnumpy())[0],
         rtol=0.08,
     )
-

--- a/test/distribution/test_mx_distribution_inference.py
+++ b/test/distribution/test_mx_distribution_inference.py
@@ -166,11 +166,13 @@ def maximum_likelihood_estimate_sgd(
         return [
             param.asnumpy() for param in arg_proj(mx.nd.array(np.ones((1, 1))))
         ]
-    
-    # alpha parameter of zero inflated Neg Bin was not returned using param[0]
-    ls = [[p.asnumpy() for p in param] for param in arg_proj(mx.nd.array(np.ones((1, 1))))]
-    return reduce(lambda x, y: x+y, ls)
 
+    # alpha parameter of zero inflated Neg Bin was not returned using param[0]
+    ls = [
+        [p.asnumpy() for p in param]
+        for param in arg_proj(mx.nd.array(np.ones((1, 1))))
+    ]
+    return reduce(lambda x, y: x + y, ls)
 
 
 @pytest.mark.parametrize("alpha, beta", [(3.75, 1.25)])
@@ -1152,27 +1154,26 @@ def test_genpareto_likelihood(xi: float, beta: float, hybridize: bool) -> None:
 
 
 @pytest.mark.timeout(120)
+@pytest.mark.flaky(reruns=4)
 @pytest.mark.parametrize("rate", [50.0])
 @pytest.mark.parametrize("zero_probability", [0.8, 0.2, 0.01])
 @pytest.mark.parametrize("hybridize", [False, True])
 def test_inflated_poisson_likelihood(
-    rate: float,
-    hybridize: bool,
-    zero_probability: float,
+    rate: float, hybridize: bool, zero_probability: float,
 ) -> None:
     """
     Test to check that maximizing the likelihood recovers the parameters
     """
     # generate samples
-    num_samples = 2000 # Required for convergence
-    
+    num_samples = 2000  # Required for convergence
+
     distr = ZeroInflatedPoissonOutput().distribution(
-        distr_args = [
-            mx.nd.array([[1-zero_probability, zero_probability]]),
+        distr_args=[
+            mx.nd.array([[1 - zero_probability, zero_probability]]),
             mx.nd.array([rate]),
-            mx.nd.array([0.])
+            mx.nd.array([0.0]),
         ]
-    ) 
+    )
     distr_output = ZeroInflatedPoissonOutput()
 
     samples = distr.sample(num_samples).squeeze()
@@ -1197,38 +1198,44 @@ def test_inflated_poisson_likelihood(
         np.abs(rate_hat - rate) < TOL * rate
     ), f"rate did not match: rate = {rate}, rate_hat = {rate_hat}"
 
+
 @pytest.mark.timeout(150)
+@pytest.mark.flaky(reruns=4)
 @pytest.mark.parametrize("mu", [5.0])
 @pytest.mark.parametrize("alpha", [0.05])
 @pytest.mark.parametrize("zero_probability", [0.3])
 @pytest.mark.parametrize("hybridize", [False, True])
 def test_inflated_neg_binomial_likelihood(
-    mu: float, 
-    alpha: float,
-    zero_probability: float,
-    hybridize: bool,
+    mu: float, alpha: float, zero_probability: float, hybridize: bool,
 ) -> None:
     """
     Test to check that maximizing the likelihood recovers the parameters
     """
-    
+
     # generate samples
-    num_samples = 2000 # Required for convergence
-    
+    num_samples = 2000  # Required for convergence
+
     distr = ZeroInflatedNegativeBinomialOutput().distribution(
-        distr_args = [
-            mx.nd.array([[1-zero_probability, zero_probability]]), # mixture probs
-            mx.nd.array([mu, alpha]), # loc, shape of Neg Bin
-            mx.nd.array([0.])
+        distr_args=[
+            mx.nd.array(
+                [[1 - zero_probability, zero_probability]]
+            ),  # mixture probs
+            mx.nd.array([mu, alpha]),  # loc, shape of Neg Bin
+            mx.nd.array([0.0]),
         ]
-    ) 
+    )
     distr_output = ZeroInflatedNegativeBinomialOutput()
 
     samples = distr.sample(num_samples).squeeze()
 
     init_biases = None
 
-    (_, zero_probability_hat),  mu_hat, alpha_hat, _ = maximum_likelihood_estimate_sgd(
+    (
+        (_, zero_probability_hat),
+        mu_hat,
+        alpha_hat,
+        _,
+    ) = maximum_likelihood_estimate_sgd(
         distr_output=distr_output,
         samples=samples,
         init_biases=init_biases,
@@ -1249,4 +1256,3 @@ def test_inflated_neg_binomial_likelihood(
     assert (
         np.abs(alpha_hat - alpha) < TOL * alpha
     ), f"alpha did not match: alpha = {alpha}, alpha_hat = {alpha_hat}"
-

--- a/test/distribution/test_mx_distribution_inference.py
+++ b/test/distribution/test_mx_distribution_inference.py
@@ -1154,7 +1154,7 @@ def test_genpareto_likelihood(xi: float, beta: float, hybridize: bool) -> None:
 
 
 @pytest.mark.timeout(120)
-@pytest.mark.flaky(max_runs=3, min_passes=1)
+@pytest.mark.flaky(max_runs=6, min_passes=1)
 @pytest.mark.parametrize("rate", [50.0])
 @pytest.mark.parametrize("zero_probability", [0.8, 0.2, 0.01])
 @pytest.mark.parametrize("hybridize", [False, True])
@@ -1200,7 +1200,7 @@ def test_inflated_poisson_likelihood(
 
 
 @pytest.mark.timeout(150)
-@pytest.mark.flaky(max_runs=3, min_passes=1)
+@pytest.mark.flaky(max_runs=6, min_passes=1)
 @pytest.mark.parametrize("mu", [5.0])
 @pytest.mark.parametrize("alpha", [0.05])
 @pytest.mark.parametrize("zero_probability", [0.3])

--- a/test/distribution/test_mx_distribution_inference.py
+++ b/test/distribution/test_mx_distribution_inference.py
@@ -1154,7 +1154,7 @@ def test_genpareto_likelihood(xi: float, beta: float, hybridize: bool) -> None:
 
 
 @pytest.mark.timeout(120)
-@pytest.mark.flaky(reruns=4)
+@pytest.mark.flaky(max_runs=3, min_passes=1)
 @pytest.mark.parametrize("rate", [50.0])
 @pytest.mark.parametrize("zero_probability", [0.8, 0.2, 0.01])
 @pytest.mark.parametrize("hybridize", [False, True])
@@ -1200,7 +1200,7 @@ def test_inflated_poisson_likelihood(
 
 
 @pytest.mark.timeout(150)
-@pytest.mark.flaky(reruns=4)
+@pytest.mark.flaky(max_runs=3, min_passes=1)
 @pytest.mark.parametrize("mu", [5.0])
 @pytest.mark.parametrize("alpha", [0.05])
 @pytest.mark.parametrize("zero_probability", [0.3])


### PR DESCRIPTION
*Description of changes:*
- added two rerun markers to tests as a quick fix, because the maximum likelihood inference of the inflated  discrete distributions is currently unstable. 

- all other changes got introduced by black, I have the right black version (19.10b0), so I don't get whats going on there...


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
