### PR TITLE
introduce functional api for data generation recipes

### DIFF
--- a/src/gluonts/dataset/artificial/_base.py
+++ b/src/gluonts/dataset/artificial/_base.py
@@ -14,7 +14,7 @@
 # Standard library imports
 import math
 import random
-from typing import Callable, List, NamedTuple, Optional, Tuple, Union
+from typing import Callable, List, NamedTuple, Optional, Tuple, Union, Dict
 
 # Third-party imports
 import numpy as np
@@ -642,7 +642,9 @@ class RecipeDataset(ArtificialDataset):
 
     def __init__(
         self,
-        recipe: Union[Callable, List[Tuple[str, Callable]]],
+        recipe: Union[
+            Callable, Dict[str, Callable], List[Tuple[str, Callable]]
+        ],
         metadata: MetaData,
         max_train_length: int,
         prediction_length: int,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Introduce a functional api for data generation recipes. I.e. you can write

```python
stddev = rcp.RandomUniform(low=0, high=1, shape=(1,))
x = rcp.RandomGaussian(stddev=stddev)
evaluate(dict(x=x), length=...)
```

Also add support for multiple return values (currently only used in in a test).

```python
a, b = SomeOperator(...)

evaluate(dict(
  a=a
))
```

This change is fully backwards compatible for now...

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
