### PR TITLE
Fix edge case for `cyclic`

### DIFF
--- a/src/gluonts/itertools.py
+++ b/src/gluonts/itertools.py
@@ -21,8 +21,13 @@ T = TypeVar("T")
 def cyclic(it):
     """Like `itertools.cycle`, but does not store the data."""
 
+    at_least_one = False
     while True:
-        yield from it
+        for el in it:
+            at_least_one = True
+            yield el
+        if not at_least_one:
+            break
 
 
 def batcher(iterable: Iterable[T], batch_size: int) -> Iterator[List[T]]:

--- a/test/test_itertools.py
+++ b/test/test_itertools.py
@@ -11,12 +11,22 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from typing import Iterable
+from typing import Iterable, List
+import itertools
 
 import pytest
 
 from gluonts.dataset.artificial import constant_dataset
-from gluonts.itertools import pseudo_shuffled
+from gluonts.itertools import pseudo_shuffled, cyclic
+
+
+@pytest.mark.parametrize(
+    "data, n, expected", [([1, 2, 3], 7, [1, 2, 3, 1, 2, 3, 1]), ([], 4, [])]
+)
+def test_cyclic(data: Iterable, n: int, expected: List) -> None:
+    cyclic_data = cyclic(data)
+    actual = list(itertools.islice(cyclic_data, n))
+    assert actual == expected
 
 
 @pytest.mark.parametrize("data", [range(20), constant_dataset()[1],])


### PR DESCRIPTION
*Issue #, if available:* fixes #1157 

*Description of changes:* `cyclic` would result in an infinite loop when given an empty iterable, causing worker processes to hang when `num_workers > len(dataset)`. This fixes it and adds a test.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
