### PR TITLE
Align `num_workers` convention between loader and evaluator

### DIFF
--- a/src/gluonts/dataset/loader.py
+++ b/src/gluonts/dataset/loader.py
@@ -181,14 +181,14 @@ class DataLoader(Iterable[DataBatch]):
     pass
 
 
-def win32_guard(num_worker: Optional[int]) -> Optional[int]:
-    if sys.platform == "win32":
+def win32_guard(num_workers: Optional[int]) -> Optional[int]:
+    if num_workers and sys.platform == "win32":
         logger.warning(
             "Multiprocessing is not supported on Windows, "
             "num_workers will be set to None."
         )
         return None
-    return num_worker
+    return num_workers
 
 
 class TrainDataLoader(DataLoader):
@@ -212,7 +212,7 @@ class TrainDataLoader(DataLoader):
         self.num_prefetch = num_prefetch
         self.shuffle_buffer_length = shuffle_buffer_length
 
-        if self.num_workers is None:
+        if not self.num_workers:
             iterator = construct_training_iterator(
                 dataset,
                 transform=transform,


### PR DESCRIPTION
*Description of changes:* this aligns the convention between data loader and evaluator with respect to the `num_workers` parameter: `0` or `None` means "no workers" (i.e. only main process is processing), while values larger than `0` cause subprocesses to be spawned.

Minor related fixes/simplifications are included.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
