### PR TITLE
Remove input_names argument to trainer __call__

### DIFF
--- a/src/gluonts/mx/trainer/_base.py
+++ b/src/gluonts/mx/trainer/_base.py
@@ -182,6 +182,22 @@ class Trainer:
         train_iter: TrainDataLoader,
         validation_iter: Optional[ValidationDataLoader] = None,
     ) -> None:  # TODO: we may want to return some training information here
+        """
+        Train a network, given an iterable over training (and optionally validation) batches.
+
+        Parameters
+        ----------
+        net
+            Network to be trained. This a Gluon HybridBlock, assumed to produce a tensor
+            of loss values as output.
+        train_iter
+            An iterable over batches to be used for training. Batches are assumed to be
+            dictionaries, whose values are MXNet arrays that correspond to the network
+            inputs.
+        validation_iter
+            Similar to `train_iter` but the batches produced here are used to compute
+            validation metrics.
+        """
         is_validation_available = validation_iter is not None
         self.halt = False
 
@@ -251,6 +267,10 @@ class Trainer:
 
                     with tqdm(batch_iter) as it:
                         for batch_no, batch in enumerate(it, start=1):
+                            # `batch` here is expected to be a dictionary whose fields
+                            # should correspond 1-to-1 with the network inputs
+                            # see below how `batch.values()` is fed into the network
+
                             if self.halt:
                                 break
 

--- a/src/gluonts/mx/trainer/_base.py
+++ b/src/gluonts/mx/trainer/_base.py
@@ -179,7 +179,6 @@ class Trainer:
     def __call__(
         self,
         net: nn.HybridBlock,
-        input_names: List[str],
         train_iter: TrainDataLoader,
         validation_iter: Optional[ValidationDataLoader] = None,
     ) -> None:  # TODO: we may want to return some training information here
@@ -251,20 +250,18 @@ class Trainer:
                         self.avg_strategy.load_averaged_model(net)
 
                     with tqdm(batch_iter) as it:
-                        for batch_no, data_entry in enumerate(it, start=1):
+                        for batch_no, batch in enumerate(it, start=1):
                             if self.halt:
                                 break
 
-                            inputs = [data_entry[k] for k in input_names]
-
                             if first_forward:
                                 first_forward = False
-                                _ = net(*inputs)
+                                _ = net(*batch.values())
                                 if self.post_initialize_cb:
                                     self.post_initialize_cb(net)
 
                             with mx.autograd.record():
-                                output = net(*inputs)
+                                output = net(*batch.values())
 
                                 # network can returns several outputs, the first being always the loss
                                 # when having multiple outputs, the forward returns a list in the case of hybrid and a


### PR DESCRIPTION
*Description of changes:* This makes the `Trainer` interface easier to use e.g. for interactive usage.

Note: while this is a breaking change
1. existing estimators in the package are unaffected
2. any custom estimator that simply inherit from `GluonEstimator` (and do not customize how the `Trainer` is used) will also continue to work as before
3. previously trained and serialized predictors will continue to work (no change in how predictors work)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
