### PR TITLE
make train_sampler a parameter for most models

### DIFF
--- a/src/gluonts/model/lstnet/_estimator.py
+++ b/src/gluonts/model/lstnet/_estimator.py
@@ -31,6 +31,7 @@ from gluonts.transform import (
     ExpectedNumInstanceSampler,
     InstanceSplitter,
     Transformation,
+    InstanceSampler,
 )
 
 
@@ -89,6 +90,8 @@ class LSTNetEstimator(GluonEstimator):
         Number of RNN cells for each layer for skip part (default: 10)
     scaling
         Whether to automatically scale the target values (default: True)
+    train_sampler
+        Controls the sampling of windows during training.
     dtype
         Data type (default: np.float32)
     """
@@ -115,6 +118,7 @@ class LSTNetEstimator(GluonEstimator):
         skip_rnn_num_layers: int = 1,
         skip_rnn_num_cells: int = 10,
         scaling: bool = True,
+        train_sampler: InstanceSampler = ExpectedNumInstanceSampler(1.0),
         dtype: DType = np.float32,
     ) -> None:
         super().__init__(trainer=trainer, lead_time=lead_time, dtype=dtype)
@@ -135,6 +139,7 @@ class LSTNetEstimator(GluonEstimator):
         self.skip_rnn_num_layers = skip_rnn_num_layers
         self.skip_rnn_num_cells = skip_rnn_num_cells
         self.scaling = scaling
+        self.train_sampler = train_sampler
         self.dtype = dtype
 
     def create_transformation(self) -> Transformation:
@@ -153,7 +158,7 @@ class LSTNetEstimator(GluonEstimator):
                     is_pad_field=FieldName.IS_PAD,
                     start_field=FieldName.START,
                     forecast_start_field=FieldName.FORECAST_START,
-                    train_sampler=ExpectedNumInstanceSampler(num_instances=1),
+                    train_sampler=self.train_sampler,
                     time_series_fields=[FieldName.OBSERVED_VALUES],
                     past_length=self.context_length,
                     future_length=self.prediction_length,

--- a/src/gluonts/model/n_beats/_estimator.py
+++ b/src/gluonts/model/n_beats/_estimator.py
@@ -26,6 +26,7 @@ from gluonts.transform import (
     ExpectedNumInstanceSampler,
     InstanceSplitter,
     Transformation,
+    InstanceSampler,
 )
 
 from ._network import (
@@ -100,6 +101,8 @@ class NBEATSEstimator(GluonEstimator):
         Unlike other models in GluonTS this network does not use a distribution.
         One of the following: "sMAPE", "MASE" or "MAPE".
         The default value is "MAPE".
+    train_sampler
+        Controls the sampling of windows during training.
     kwargs
         Arguments passed to 'GluonEstimator'.
     """
@@ -123,6 +126,7 @@ class NBEATSEstimator(GluonEstimator):
         sharing: Optional[List[bool]] = None,
         stack_types: Optional[List[str]] = None,
         loss_function: Optional[str] = "MAPE",
+        train_sampler: InstanceSampler = ExpectedNumInstanceSampler(1.0),
         **kwargs,
     ) -> None:
         """
@@ -196,6 +200,7 @@ class NBEATSEstimator(GluonEstimator):
             validation_condition=lambda val: val in VALID_N_BEATS_STACK_TYPES,
             invalidation_message=f"Values of 'stack_types' should be one of {VALID_N_BEATS_STACK_TYPES}",
         )
+        self.train_sampler = train_sampler
 
     def _validate_nbeats_argument(
         self,
@@ -241,7 +246,7 @@ class NBEATSEstimator(GluonEstimator):
                     is_pad_field=FieldName.IS_PAD,
                     start_field=FieldName.START,
                     forecast_start_field=FieldName.FORECAST_START,
-                    train_sampler=ExpectedNumInstanceSampler(num_instances=1),
+                    train_sampler=self.train_sampler,
                     past_length=self.context_length,
                     future_length=self.prediction_length,
                     time_series_fields=[],

--- a/src/gluonts/model/wavenet/_estimator.py
+++ b/src/gluonts/model/wavenet/_estimator.py
@@ -47,6 +47,7 @@ from gluonts.transform import (
     SetFieldIfNotPresent,
     SimpleTransformation,
     VstackFeatures,
+    InstanceSampler,
 )
 
 
@@ -130,6 +131,8 @@ class WaveNetEstimator(GluonEstimator):
     num_parallel_samples
         Number of evaluation samples per time series to increase parallelism during inference.
         This is a model optimization that does not affect the accuracy (default: 200)
+    train_sampler
+        Controls the sampling of windows during training.
     """
 
     @validated()
@@ -156,6 +159,7 @@ class WaveNetEstimator(GluonEstimator):
         temperature: float = 1.0,
         act_type: str = "elu",
         num_parallel_samples: int = 200,
+        train_sampler: InstanceSampler = ExpectedNumInstanceSampler(1.0),
     ) -> None:
         """
         Model with Wavenet architecture and quantized target.
@@ -205,6 +209,7 @@ class WaveNetEstimator(GluonEstimator):
         self.temperature = temperature
         self.act_type = act_type
         self.num_parallel_samples = num_parallel_samples
+        self.train_sampler = train_sampler
 
         seasonality = (
             get_seasonality(
@@ -353,7 +358,7 @@ class WaveNetEstimator(GluonEstimator):
                     is_pad_field=FieldName.IS_PAD,
                     start_field=FieldName.START,
                     forecast_start_field=FieldName.FORECAST_START,
-                    train_sampler=ExpectedNumInstanceSampler(num_instances=1),
+                    train_sampler=self.train_sampler,
                     past_length=self.context_length,
                     future_length=pred_length,
                     output_NTC=False,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Make the `train_sampler` an argument for models. This allows us to configure the sampling strategy and to experiment with different strategies.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
