### PR TITLE
Fix num_batches_per_epoch in Trainer

### DIFF
--- a/src/gluonts/dataset/loader.py
+++ b/src/gluonts/dataset/loader.py
@@ -202,7 +202,6 @@ class TrainDataLoader(DataLoader):
         transform: Transformation,
         batch_size: int,
         stack_fn: Callable,
-        num_batches_per_epoch: int,
         num_workers: Optional[int] = None,
         num_prefetch: Optional[int] = None,
         shuffle_buffer_length: Optional[int] = None,
@@ -210,7 +209,6 @@ class TrainDataLoader(DataLoader):
     ) -> None:
         self.batch_size = batch_size
         self.stack_fn = stack_fn
-        self.num_batches_per_epoch = num_batches_per_epoch
         self.num_workers = win32_guard(num_workers)
         self.num_prefetch = num_prefetch
         self.shuffle_buffer_length = shuffle_buffer_length
@@ -234,13 +232,8 @@ class TrainDataLoader(DataLoader):
                 shuffle_buffer_length=shuffle_buffer_length,
             )
 
-    def __len__(self):
-        return self.num_batches_per_epoch
-
     def __iter__(self):
-        yield from itertools.islice(
-            self.batch_iterator, self.num_batches_per_epoch
-        )
+        yield from self.batch_iterator
 
 
 class ValidationDataLoader(DataLoader):

--- a/src/gluonts/model/wavenet/_estimator.py
+++ b/src/gluonts/model/wavenet/_estimator.py
@@ -288,7 +288,6 @@ class WaveNetEstimator(GluonEstimator):
             dataset=training_data,
             transform=transformation + SelectFields(input_names),
             batch_size=self.trainer.batch_size,
-            num_batches_per_epoch=self.trainer.num_batches_per_epoch,
             stack_fn=partial(batchify, ctx=self.trainer.ctx, dtype=self.dtype),
             num_workers=num_workers,
             num_prefetch=num_prefetch,

--- a/src/gluonts/mx/model/estimator.py
+++ b/src/gluonts/mx/model/estimator.py
@@ -130,7 +130,6 @@ class GluonEstimator(Estimator):
             dataset=training_data,
             transform=transformation + SelectFields(input_names),
             batch_size=self.trainer.batch_size,
-            num_batches_per_epoch=self.trainer.num_batches_per_epoch,
             stack_fn=partial(
                 batchify,
                 ctx=self.trainer.ctx,

--- a/src/gluonts/mx/trainer/_base.py
+++ b/src/gluonts/mx/trainer/_base.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+import itertools
 import logging
 import os
 import tempfile
@@ -261,7 +262,12 @@ class Trainer:
                     ):
                         self.avg_strategy.load_averaged_model(net)
 
-                    with tqdm(batch_iter) as it:
+                    with tqdm(
+                        itertools.islice(
+                            batch_iter, self.num_batches_per_epoch
+                        ),
+                        total=self.num_batches_per_epoch,
+                    ) as it:
                         for batch_no, batch in enumerate(it, start=1):
                             # `batch` here is expected to be a dictionary whose fields
                             # should correspond 1-to-1 with the network inputs

--- a/test/dataset/test_multiprocessing_loader.py
+++ b/test/dataset/test_multiprocessing_loader.py
@@ -16,9 +16,9 @@ import multiprocessing as mp
 import random
 import tempfile
 import time
-
 from collections import defaultdict
 from functools import partial
+from itertools import islice
 from pathlib import Path
 
 import numpy as np
@@ -214,8 +214,9 @@ def test_validation_loader_equivalence() -> None:
 def test_train_loader_goes_over_all_data(num_workers) -> None:
     batch_size = 4
     num_batches_per_epoch = 4
-
-    X = 3
+    num_time_series = batch_size * num_batches_per_epoch * 3
+    num_passes = 5
+    num_epochs = num_passes * 3
 
     simple_data = [
         {
@@ -223,11 +224,8 @@ def test_train_loader_goes_over_all_data(num_workers) -> None:
             "target": np.random.uniform(size=40).astype(float).tolist(),
             "item_id": i,
         }
-        for i in range(batch_size * num_batches_per_epoch * X)
+        for i in range(num_time_series)
     ]
-
-    num_passes = 5
-    num_epochs = X * num_passes
 
     def test_dataset(dataset):
         class ExactlyOneSampler(InstanceSampler):
@@ -253,13 +251,12 @@ def test_train_loader_goes_over_all_data(num_workers) -> None:
             batch_size=batch_size,
             stack_fn=partial(batchify, ctx=current_context()),
             num_workers=num_workers,
-            num_batches_per_epoch=num_batches_per_epoch,
         )
 
         item_ids = defaultdict(int)
 
         for epoch in range(num_epochs):
-            for batch in dl:
+            for batch in islice(dl, num_batches_per_epoch):
                 for item_id in batch["item_id"]:
                     item_ids[item_id] += 1
 
@@ -343,43 +340,32 @@ def test_training_loader_batch_size_hard_constraint() -> None:
         train_data_transformed_original,
     ) = get_dataset_and_transformation()
 
-    train_dataset_loader_01 = TrainDataLoader(
+    train_dataset_loader_1 = TrainDataLoader(
         dataset=list_dataset,
         transform=transformation,
         batch_size=BATCH_SIZE,
         stack_fn=partial(batchify, ctx=current_context()),
         num_workers=NUM_WORKERS_MP,  # This is the crucial difference
-        num_batches_per_epoch=30,
     )
 
-    train_dataset_loader_02 = TrainDataLoader(
+    train_dataset_loader_2 = TrainDataLoader(
         dataset=list_dataset,
         transform=transformation,
         batch_size=BATCH_SIZE,
         stack_fn=partial(batchify, ctx=current_context()),
         num_workers=NUM_WORKERS_MP,  # This is the crucial difference
-        num_batches_per_epoch=30,
         shuffle_buffer_length=3 * BATCH_SIZE,
     )
 
-    # multi-processed training dataset
-    mp_training_data_loader_result_01 = list(train_dataset_loader_01)
-
-    # multi-processed training dataset
-    mp_training_data_loader_result_02 = list(train_dataset_loader_02)
+    batches_1 = list(islice(train_dataset_loader_1, 30))
+    batches_2 = list(islice(train_dataset_loader_2, 30))
 
     assert all(
-        [
-            len(batch["item_id"]) == BATCH_SIZE
-            for batch in mp_training_data_loader_result_01
-        ]
+        [len(batch["item_id"]) == BATCH_SIZE for batch in batches_1]
     ), "Not every batch from training loader is right size."
 
     assert all(
-        [
-            len(batch["item_id"]) == BATCH_SIZE
-            for batch in mp_training_data_loader_result_02
-        ]
+        [len(batch["item_id"]) == BATCH_SIZE for batch in batches_2]
     ), "Not every batch from training loader is right size, with shuffling on."
 
 
@@ -404,28 +390,19 @@ def test_training_loader_soft_constraint_01() -> None:
 
     # CASE 01: EVERY TS VISITED AT LEAST ONCE
 
-    train_dataset_loader_01 = TrainDataLoader(
+    train_dataset_loader = TrainDataLoader(
         dataset=list_dataset,
         transform=transformation,
         batch_size=BATCH_SIZE,
         stack_fn=partial(batchify, ctx=current_context()),
         num_workers=NUM_WORKERS_MP,  # This is the crucial difference
-        num_batches_per_epoch=int(3 * exp_num_batches),
     )
 
-    # give all the workers a little time to get ready, so they can start at the same time
-    time.sleep(1.5)
-
-    # multi-processed training dataset
-    mp_training_data_loader_result_01 = list(train_dataset_loader_01)
-
-    # should contain an entry for every time series id
-    transformation_counts_01 = get_transformation_counts(
-        mp_training_data_loader_result_01
-    )
+    batches = list(islice(train_dataset_loader, int(3 * exp_num_batches)))
+    transformation_counts = get_transformation_counts(batches)
 
     assert all(
-        [k in transformation_counts_01 for k in range(CD_NUM_TIME_SERIES)]
+        [k in transformation_counts for k in range(CD_NUM_TIME_SERIES)]
     ), "Not every time series processed at least once."
 
 
@@ -445,25 +422,19 @@ def test_training_loader_soft_constraint_02() -> None:
 
     # CASE 02: NOT EVERY TS VISITED ONCE
 
-    train_dataset_loader_02 = TrainDataLoader(
+    train_dataset_loader = TrainDataLoader(
         dataset=list_dataset,
         transform=transformation,
         batch_size=BATCH_SIZE,
         stack_fn=partial(batchify, ctx=current_context()),
         num_workers=NUM_WORKERS_MP,  # This is the crucial difference
-        num_batches_per_epoch=int(0.5 * exp_num_batches),
     )
 
-    # multi-processed training dataset
-    mp_training_data_loader_result_02 = list(train_dataset_loader_02)
-
-    # should contain an entry for every time series id
-    transformation_counts_02 = get_transformation_counts(
-        mp_training_data_loader_result_02
-    )
+    batches = list(islice(train_dataset_loader, int(0.5 * exp_num_batches)))
+    transformation_counts = get_transformation_counts(batches)
 
     assert not all(
-        [k in transformation_counts_02 for k in range(CD_NUM_TIME_SERIES)]
+        [k in transformation_counts for k in range(CD_NUM_TIME_SERIES)]
     ), "It should not have been possible to process every time series once. "
 
 
@@ -481,25 +452,19 @@ def test_training_loader_soft_constraint_03() -> None:
 
     # CASE 03: ONE WORKER TRAVERSES ALL
 
-    train_dataset_loader_03 = TrainDataLoader(
+    train_dataset_loader = TrainDataLoader(
         dataset=list_dataset,
         transform=transformation,
         batch_size=BATCH_SIZE,
         stack_fn=partial(batchify, ctx=current_context()),
         num_workers=1,  # This is the crucial difference
-        num_batches_per_epoch=int(3 * exp_num_batches),
     )
 
-    # multi-processed training dataset
-    mp_training_data_loader_result_03 = list(train_dataset_loader_03)
-
-    # should contain an entry for every time series id
-    transformation_counts_03 = get_transformation_counts(
-        mp_training_data_loader_result_03
-    )
+    batches = list(islice(train_dataset_loader, int(3 * exp_num_batches)))
+    transformation_counts = get_transformation_counts(batches)
 
     assert all(
-        k in transformation_counts_03 for k in range(CD_NUM_TIME_SERIES)
+        k in transformation_counts for k in range(CD_NUM_TIME_SERIES)
     ), "One worker should be able to traverse all in one sweep, and should not deplete its iterator."
 
 

--- a/test/dataset/test_variable_length.py
+++ b/test/dataset/test_variable_length.py
@@ -12,7 +12,7 @@
 # permissions and limitations under the License.
 import itertools
 from functools import partial
-from typing import Any, Dict
+from typing import Any, Dict, Iterable
 
 import mxnet as mx
 import numpy as np
@@ -20,6 +20,7 @@ import pytest
 
 from gluonts.dataset.common import ListDataset
 from gluonts.dataset.loader import (
+    DataBatch,
     DataLoader,
     InferenceDataLoader,
     TrainDataLoader,
@@ -46,7 +47,7 @@ def loader_factory():
         context_interval_length: float,
         is_train: bool = True,
         override_args: dict = None,
-    ) -> DataLoader:
+    ) -> Iterable[DataBatch]:
 
         if override_args is None:
             override_args = {}
@@ -68,8 +69,8 @@ def loader_factory():
         kwargs.update(override_args)
 
         if is_train:
-            return TrainDataLoader(
-                num_batches_per_epoch=22, num_workers=None, **kwargs
+            return itertools.islice(
+                TrainDataLoader(num_workers=None, **kwargs), 22
             )
         else:
             return InferenceDataLoader(num_workers=None, **kwargs)

--- a/test/distribution/test_distribution_output_shapes.py
+++ b/test/distribution/test_distribution_output_shapes.py
@@ -11,6 +11,8 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# type: ignore
+
 
 import pytest
 from itertools import product

--- a/test/model/deepar/test_deepar_auxiliary_outputs.py
+++ b/test/model/deepar/test_deepar_auxiliary_outputs.py
@@ -51,7 +51,6 @@ def test_distribution():
         dataset=train_ds,
         transform=train_output.transformation,
         batch_size=batch_size,
-        num_batches_per_epoch=estimator.trainer.num_batches_per_epoch,
         stack_fn=partial(batchify, ctx=mx.cpu()),
     )
 


### PR DESCRIPTION
*Description of changes:* Before this, the `num_batches_per_epoch` is not really used in `Trainer`, but only stored for estimators to read (to configure the data loader). This is a bit confusing if one uses the `Trainer` class directly: `num_batches_per_epoch` can be set, but will not have any effect (only the one passed into the `TrainDataLoader` matters).

This PR proposes to make this clearer, as follows:
* Remove the `num_batches_per_epoch` argument to `TrainDataLoader`, which effectively becomes an endless iterator
* Enforce the epoch duration directly in the `Trainer`, by `islice`-ing `num_batches_per_epoch` batches from the data loader

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
