### PR TITLE
Simplify data loader, deprecate Trainer's batch_size

### DIFF
--- a/docs/examples/basic_forecasting_tutorial/tutorial.md
+++ b/docs/examples/basic_forecasting_tutorial/tutorial.md
@@ -365,9 +365,10 @@ class MyEstimator(GluonEstimator):
         freq: str,
         context_length: int,
         prediction_length: int,
-        trainer: Trainer = Trainer()
+        batch_size: int = 32,
+        trainer: Trainer = Trainer(),
     ) -> None:
-        super().__init__(trainer=trainer)
+        super().__init__(trainer=trainer, batch_size=batch_size)
         self.context_length = context_length
         self.prediction_length = prediction_length
         self.freq = freq

--- a/docs/examples/extended_forecasting_tutorial/extended_tutorial.md
+++ b/docs/examples/extended_forecasting_tutorial/extended_tutorial.md
@@ -848,9 +848,10 @@ class MyEstimator(GluonEstimator):
         context_length: int,
         freq: str,
         num_cells: int,
+        batch_size: int = 32,
         trainer: Trainer = Trainer()
     ) -> None:
-        super().__init__(trainer=trainer)
+        super().__init__(trainer=trainer, batch_size=batch_size)
         self.prediction_length = prediction_length
         self.context_length = context_length
         self.freq = freq
@@ -1059,9 +1060,10 @@ class MyProbEstimator(GluonEstimator):
             distr_output: DistributionOutput,
             num_cells: int,
             num_sample_paths: int = 100,
+            batch_size: int = 32,
             trainer: Trainer = Trainer()
     ) -> None:
-        super().__init__(trainer=trainer)
+        super().__init__(trainer=trainer, batch_size=batch_size)
         self.prediction_length = prediction_length
         self.context_length = context_length
         self.freq = freq
@@ -1298,9 +1300,10 @@ class MyProbEstimator(GluonEstimator):
             num_cells: int,
             num_sample_paths: int = 100,
             scaling: bool = True,
+            batch_size: int = 32,
             trainer: Trainer = Trainer()
     ) -> None:
-        super().__init__(trainer=trainer)
+        super().__init__(trainer=trainer, batch_size=batch_size)
         self.prediction_length = prediction_length
         self.context_length = context_length
         self.freq = freq
@@ -1652,9 +1655,10 @@ class MyProbRNNEstimator(GluonEstimator):
             num_layers: int,
             num_sample_paths: int = 100,
             scaling: bool = True,
+            batch_size: int = 32,
             trainer: Trainer = Trainer()
     ) -> None:
-        super().__init__(trainer=trainer)
+        super().__init__(trainer=trainer, batch_size=batch_size)
         self.prediction_length = prediction_length
         self.context_length = context_length
         self.freq = freq

--- a/src/gluonts/dataset/loader.py
+++ b/src/gluonts/dataset/loader.py
@@ -30,37 +30,14 @@ from gluonts.transform import Transformation, TransformedDataset
 logger = logging.getLogger(__name__)
 
 
-def construct_training_iterator(
-    dataset: Dataset,
-    *,
-    transform: Transformation,
-    shuffle_buffer_length: Optional[int] = None,
-) -> Iterator[DataEntry]:
-    transformed_dataset = TransformedDataset(
-        cyclic(dataset),
-        transform,
-        is_train=True,
-    )
-
-    if shuffle_buffer_length is None:
-        return iter(transformed_dataset)
-    else:
-        return pseudo_shuffled(
-            iter(transformed_dataset),
-            shuffle_buffer_length=shuffle_buffer_length,
-        )
-
-
 class MultiProcessBatcher(Iterator):
     def __init__(
         self,
         dataset: Dataset,
-        transform: Transformation,
         batch_size: int,
         stack_fn: Callable,
         num_workers: int,
         max_queue_size: Optional[int] = None,
-        shuffle_buffer_length: Optional[int] = None,
         decode_fn: Callable = lambda x: x,
     ):
         assert num_workers >= 1
@@ -89,8 +66,6 @@ class MultiProcessBatcher(Iterator):
                     worker_id,
                     num_workers,
                     dataset,
-                    transform,
-                    shuffle_buffer_length,
                     batch_size,
                     stack_fn,
                     self.batch_queue,
@@ -108,8 +83,6 @@ class MultiProcessBatcher(Iterator):
         worker_id: int,
         num_workers: int,
         dataset,
-        transform,
-        shuffle_buffer_length: int,
         batch_size: int,
         stack_fn: Callable,
         batch_queue: mp.Queue,
@@ -121,13 +94,7 @@ class MultiProcessBatcher(Iterator):
             worker_id=worker_id,
         )
 
-        data_iterator = construct_training_iterator(
-            dataset,
-            transform=transform,
-            shuffle_buffer_length=shuffle_buffer_length,
-        )
-
-        for batch in batcher(data_iterator, batch_size):
+        for batch in batcher(dataset, batch_size):
             stacked_batch = stack_fn(batch)
             try:
                 if terminate_event.is_set():
@@ -180,10 +147,6 @@ class MultiProcessBatcher(Iterator):
             p.join()
 
 
-class DataLoader(Iterable[DataBatch]):
-    pass
-
-
 def win32_guard(num_workers: Optional[int]) -> Optional[int]:
     if num_workers and sys.platform == "win32":
         logger.warning(
@@ -194,99 +157,106 @@ def win32_guard(num_workers: Optional[int]) -> Optional[int]:
     return num_workers
 
 
-class TrainDataLoader(DataLoader):
+class DataLoader(Iterable[DataBatch]):
     def __init__(
         self,
-        dataset: Dataset,
+        data_iterable: Iterable[DataEntry],
         *,
-        transform: Transformation,
         batch_size: int,
         stack_fn: Callable,
         num_workers: Optional[int] = None,
         num_prefetch: Optional[int] = None,
-        shuffle_buffer_length: Optional[int] = None,
         decode_fn: Callable = lambda x: x,
     ) -> None:
+        self.data_iterable = data_iterable
         self.batch_size = batch_size
         self.stack_fn = stack_fn
         self.num_workers = win32_guard(num_workers)
         self.num_prefetch = num_prefetch
-        self.shuffle_buffer_length = shuffle_buffer_length
+        self.decode_fn = decode_fn
 
-        if not self.num_workers:
-            iterator = construct_training_iterator(
-                dataset,
-                transform=transform,
-                shuffle_buffer_length=shuffle_buffer_length,
-            )
-            self.batch_iterator = map(stack_fn, batcher(iterator, batch_size))
-        else:
-            self.batch_iterator = MultiProcessBatcher(
-                dataset,
-                transform=transform,
-                batch_size=batch_size,
-                stack_fn=stack_fn,
-                decode_fn=decode_fn,
+    def __iter__(self):
+        batch_iterator = (
+            map(self.stack_fn, batcher(self.data_iterable, self.batch_size))
+            if not self.num_workers
+            else MultiProcessBatcher(
+                self.data_iterable,
+                batch_size=self.batch_size,
+                stack_fn=self.stack_fn,
+                decode_fn=self.decode_fn,
                 num_workers=self.num_workers,
-                max_queue_size=num_prefetch,
-                shuffle_buffer_length=shuffle_buffer_length,
+                max_queue_size=self.num_prefetch,
             )
-
-    def __iter__(self):
-        yield from self.batch_iterator
-
-
-class ValidationDataLoader(DataLoader):
-    def __init__(
-        self,
-        dataset: Dataset,
-        *,
-        transform: Transformation,
-        batch_size: int,
-        stack_fn: Callable,
-        # FIXME: the following aren't used
-        num_workers: Optional[int] = None,
-        num_prefetch: Optional[int] = None,
-        shuffle_buffer_length: Optional[int] = None,
-    ) -> None:
-        self.transformed_dataset = TransformedDataset(
-            dataset,
-            transform,
-            is_train=True,
-        )
-        self.batch_size = batch_size
-        self.stack_fn = stack_fn
-
-    def __iter__(self):
-        yield from map(
-            self.stack_fn,
-            batcher(self.transformed_dataset, self.batch_size),
         )
 
+        return batch_iterator
 
-class InferenceDataLoader(DataLoader):
-    def __init__(
-        self,
-        dataset: Dataset,
-        *,
-        transform: Transformation,
-        batch_size: int,
-        stack_fn: Callable,
-        # FIXME: the following aren't used
-        num_workers: Optional[int] = None,
-        num_prefetch: Optional[int] = None,
-        shuffle_buffer_length: Optional[int] = None,
-    ) -> None:
-        self.transformed_dataset = TransformedDataset(
-            dataset,
-            transform,
-            is_train=False,
-        )
-        self.batch_size = batch_size
-        self.stack_fn = stack_fn
 
-    def __iter__(self):
-        yield from map(
-            self.stack_fn,
-            batcher(self.transformed_dataset, self.batch_size),
+# TODO: the following are for backward compatibility, and could eventually be removed
+
+
+def TrainDataLoader(
+    dataset: Dataset,
+    *,
+    transform: Transformation,
+    batch_size: int,
+    stack_fn: Callable,
+    num_workers: Optional[int] = None,
+    num_prefetch: Optional[int] = None,
+    shuffle_buffer_length: Optional[int] = None,
+    decode_fn: Callable = lambda x: x,
+):
+    transformed_dataset = TransformedDataset(
+        cyclic(dataset), transform, is_train=True
+    )
+    data_iterable = (
+        pseudo_shuffled(
+            transformed_dataset, shuffle_buffer_length=shuffle_buffer_length
         )
+        if shuffle_buffer_length is not None
+        else transformed_dataset
+    )
+    return iter(
+        DataLoader(
+            data_iterable=data_iterable,
+            batch_size=batch_size,
+            stack_fn=stack_fn,
+            num_workers=num_workers,
+            num_prefetch=num_prefetch,
+            decode_fn=decode_fn,
+        )
+    )
+
+
+def ValidationDataLoader(
+    dataset: Dataset,
+    *,
+    transform: Transformation,
+    batch_size: int,
+    stack_fn: Callable,
+    num_workers: Optional[int] = None,
+    num_prefetch: Optional[int] = None,
+    shuffle_buffer_length: Optional[int] = None,
+):
+    return DataLoader(
+        data_iterable=TransformedDataset(dataset, transform, is_train=True),
+        batch_size=batch_size,
+        stack_fn=stack_fn,
+    )
+
+
+def InferenceDataLoader(
+    dataset: Dataset,
+    *,
+    transform: Transformation,
+    batch_size: int,
+    stack_fn: Callable,
+    num_workers: Optional[int] = None,
+    num_prefetch: Optional[int] = None,
+    shuffle_buffer_length: Optional[int] = None,
+):
+    return DataLoader(
+        data_iterable=TransformedDataset(dataset, transform, is_train=False),
+        batch_size=batch_size,
+        stack_fn=stack_fn,
+    )

--- a/src/gluonts/dataset/loader.py
+++ b/src/gluonts/dataset/loader.py
@@ -24,7 +24,7 @@ from typing import Callable, Iterable, Iterator, List, Optional
 
 from gluonts.dataset.common import DataBatch, DataEntry, Dataset
 from gluonts.dataset.util import MPWorkerInfo
-from gluonts.itertools import batcher, cyclic, iterable_slice, pseudo_shuffled
+from gluonts.itertools import batcher, Cyclic, IterableSlice, PseudoShuffled
 from gluonts.transform import Transformation, TransformedDataset
 
 logger = logging.getLogger(__name__)
@@ -208,10 +208,10 @@ def TrainDataLoader(
     decode_fn: Callable = lambda x: x,
 ):
     transformed_dataset = TransformedDataset(
-        cyclic(dataset), transform, is_train=True
+        Cyclic(dataset), transform, is_train=True
     )
     data_iterable = (
-        pseudo_shuffled(
+        PseudoShuffled(
             transformed_dataset, shuffle_buffer_length=shuffle_buffer_length
         )
         if shuffle_buffer_length is not None
@@ -228,7 +228,7 @@ def TrainDataLoader(
     return (
         iter(data_loader)
         if num_batches_per_epoch is None
-        else iterable_slice(iter(data_loader), num_batches_per_epoch)
+        else IterableSlice(iter(data_loader), num_batches_per_epoch)
     )
 
 

--- a/src/gluonts/itertools.py
+++ b/src/gluonts/itertools.py
@@ -13,7 +13,7 @@
 
 import itertools
 import random
-from typing import Iterable, Iterator, List, TypeVar
+from typing import Iterable, Iterator, List, Optional, TypeVar
 
 T = TypeVar("T")
 
@@ -78,6 +78,15 @@ class cyclic(Iterable):
                 yield el
             if not at_least_one:
                 break
+
+
+class iterable_slice(Iterable):
+    def __init__(self, iterable: Iterable, length: Optional[int]) -> None:
+        self.iterable = iterable
+        self.length = length
+
+    def __iter__(self):
+        return itertools.islice(self.iterable, self.length)
 
 
 class pseudo_shuffled(Iterable):

--- a/src/gluonts/itertools.py
+++ b/src/gluonts/itertools.py
@@ -74,13 +74,13 @@ class cached(Iterable):
             yield from self.cache
 
 
-def pseudo_shuffled(iterator: Iterator, shuffle_buffer_length: int):
+def pseudo_shuffled(iterable: Iterable, shuffle_buffer_length: int):
     """
-    An iterator that yields item from a given iterator in a pseudo-shuffled order.
+    An iterator that yields item from a given iterable in a pseudo-shuffled order.
     """
     shuffle_buffer = []
 
-    for element in iterator:
+    for element in iterable:
         shuffle_buffer.append(element)
         if len(shuffle_buffer) >= shuffle_buffer_length:
             yield shuffle_buffer.pop(random.randrange(len(shuffle_buffer)))

--- a/src/gluonts/itertools.py
+++ b/src/gluonts/itertools.py
@@ -18,7 +18,7 @@ from typing import Iterable, Iterator, List, Optional, TypeVar
 T = TypeVar("T")
 
 
-class cyclic(Iterable):
+class Cyclic(Iterable):
     """
     Like `itertools.cycle`, but does not store the data.
     """
@@ -54,7 +54,7 @@ def batcher(iterable: Iterable[T], batch_size: int) -> Iterator[List[T]]:
     return iter(get_batch, [])
 
 
-class cached(Iterable):
+class Cached(Iterable):
     """
     An iterable wrapper, which caches values in a list the first time it is iterated.
 
@@ -80,7 +80,7 @@ class cached(Iterable):
             yield from self.cache
 
 
-class pseudo_shuffled(Iterable):
+class PseudoShuffled(Iterable):
     """
     Yields items from a given iterable in a pseudo-shuffled order.
     """
@@ -101,7 +101,7 @@ class pseudo_shuffled(Iterable):
             yield shuffle_buffer.pop(random.randrange(len(shuffle_buffer)))
 
 
-class iterable_slice(Iterable):
+class IterableSlice(Iterable):
     """
     An iterable version of `itertools.islice`, i.e. one that can be iterated
     over multiple times.

--- a/src/gluonts/itertools.py
+++ b/src/gluonts/itertools.py
@@ -102,6 +102,11 @@ class pseudo_shuffled(Iterable):
 
 
 class iterable_slice(Iterable):
+    """
+    An iterable version of `itertools.islice`, i.e. one that can be iterated
+    over multiple times.
+    """
+
     def __init__(self, iterable: Iterable, length: Optional[int]) -> None:
         self.iterable = iterable
         self.length = length

--- a/src/gluonts/itertools.py
+++ b/src/gluonts/itertools.py
@@ -18,18 +18,6 @@ from typing import Iterable, Iterator, List, TypeVar
 T = TypeVar("T")
 
 
-def cyclic(it):
-    """Like `itertools.cycle`, but does not store the data."""
-
-    at_least_one = False
-    while True:
-        for el in it:
-            at_least_one = True
-            yield el
-        if not at_least_one:
-            break
-
-
 def batcher(iterable: Iterable[T], batch_size: int) -> Iterator[List[T]]:
     """Groups elements from `iterable` into batches of size `batch_size`.
 
@@ -74,16 +62,40 @@ class cached(Iterable):
             yield from self.cache
 
 
-def pseudo_shuffled(iterable: Iterable, shuffle_buffer_length: int):
+class cyclic(Iterable):
     """
-    An iterator that yields item from a given iterable in a pseudo-shuffled order.
+    Like `itertools.cycle`, but does not store the data.
     """
-    shuffle_buffer = []
 
-    for element in iterable:
-        shuffle_buffer.append(element)
-        if len(shuffle_buffer) >= shuffle_buffer_length:
+    def __init__(self, iterable: Iterable) -> None:
+        self.iterable = iterable
+
+    def __iter__(self):
+        at_least_one = False
+        while True:
+            for el in self.iterable:
+                at_least_one = True
+                yield el
+            if not at_least_one:
+                break
+
+
+class pseudo_shuffled(Iterable):
+    """
+    Yields items from a given iterable in a pseudo-shuffled order.
+    """
+
+    def __init__(self, iterable: Iterable, shuffle_buffer_length: int) -> None:
+        self.iterable = iterable
+        self.shuffle_buffer_length = shuffle_buffer_length
+
+    def __iter__(self):
+        shuffle_buffer = []
+
+        for element in self.iterable:
+            shuffle_buffer.append(element)
+            if len(shuffle_buffer) >= self.shuffle_buffer_length:
+                yield shuffle_buffer.pop(random.randrange(len(shuffle_buffer)))
+
+        while shuffle_buffer:
             yield shuffle_buffer.pop(random.randrange(len(shuffle_buffer)))
-
-    while shuffle_buffer:
-        yield shuffle_buffer.pop(random.randrange(len(shuffle_buffer)))

--- a/src/gluonts/itertools.py
+++ b/src/gluonts/itertools.py
@@ -18,6 +18,24 @@ from typing import Iterable, Iterator, List, Optional, TypeVar
 T = TypeVar("T")
 
 
+class cyclic(Iterable):
+    """
+    Like `itertools.cycle`, but does not store the data.
+    """
+
+    def __init__(self, iterable: Iterable) -> None:
+        self.iterable = iterable
+
+    def __iter__(self):
+        at_least_one = False
+        while True:
+            for el in self.iterable:
+                at_least_one = True
+                yield el
+            if not at_least_one:
+                break
+
+
 def batcher(iterable: Iterable[T], batch_size: int) -> Iterator[List[T]]:
     """Groups elements from `iterable` into batches of size `batch_size`.
 
@@ -62,33 +80,6 @@ class cached(Iterable):
             yield from self.cache
 
 
-class cyclic(Iterable):
-    """
-    Like `itertools.cycle`, but does not store the data.
-    """
-
-    def __init__(self, iterable: Iterable) -> None:
-        self.iterable = iterable
-
-    def __iter__(self):
-        at_least_one = False
-        while True:
-            for el in self.iterable:
-                at_least_one = True
-                yield el
-            if not at_least_one:
-                break
-
-
-class iterable_slice(Iterable):
-    def __init__(self, iterable: Iterable, length: Optional[int]) -> None:
-        self.iterable = iterable
-        self.length = length
-
-    def __iter__(self):
-        return itertools.islice(self.iterable, self.length)
-
-
 class pseudo_shuffled(Iterable):
     """
     Yields items from a given iterable in a pseudo-shuffled order.
@@ -108,3 +99,12 @@ class pseudo_shuffled(Iterable):
 
         while shuffle_buffer:
             yield shuffle_buffer.pop(random.randrange(len(shuffle_buffer)))
+
+
+class iterable_slice(Iterable):
+    def __init__(self, iterable: Iterable, length: Optional[int]) -> None:
+        self.iterable = iterable
+        self.length = length
+
+    def __iter__(self):
+        return itertools.islice(self.iterable, self.length)

--- a/src/gluonts/model/canonical/_estimator.py
+++ b/src/gluonts/model/canonical/_estimator.py
@@ -52,6 +52,7 @@ class CanonicalEstimator(GluonEstimator):
         cardinality: List[int] = list([1]),
         embedding_dimension: int = 10,
         distr_output: DistributionOutput = StudentTOutput(),
+        batch_size: int = 32,
     ) -> None:
         super().__init__(trainer=trainer)
 
@@ -65,6 +66,7 @@ class CanonicalEstimator(GluonEstimator):
         self.embedding_dimensions = [embedding_dimension for _ in cardinality]
         self.model = model
         self.is_sequential = is_sequential
+        self.batch_size = batch_size
 
     def create_transformation(self) -> Transformation:
         return Chain(
@@ -123,7 +125,7 @@ class CanonicalEstimator(GluonEstimator):
         return RepresentableBlockPredictor(
             input_transform=transformation,
             prediction_net=prediction_net,
-            batch_size=self.trainer.batch_size,
+            batch_size=self.batch_size,
             freq=self.freq,
             prediction_length=self.prediction_length,
             ctx=self.trainer.ctx,

--- a/src/gluonts/model/canonical/_estimator.py
+++ b/src/gluonts/model/canonical/_estimator.py
@@ -54,7 +54,7 @@ class CanonicalEstimator(GluonEstimator):
         distr_output: DistributionOutput = StudentTOutput(),
         batch_size: int = 32,
     ) -> None:
-        super().__init__(trainer=trainer)
+        super().__init__(trainer=trainer, batch_size=batch_size)
 
         # TODO: error checking
         self.freq = freq
@@ -66,7 +66,6 @@ class CanonicalEstimator(GluonEstimator):
         self.embedding_dimensions = [embedding_dimension for _ in cardinality]
         self.model = model
         self.is_sequential = is_sequential
-        self.batch_size = batch_size
 
     def create_transformation(self) -> Transformation:
         return Chain(

--- a/src/gluonts/model/deep_factor/_estimator.py
+++ b/src/gluonts/model/deep_factor/_estimator.py
@@ -96,6 +96,7 @@ class DeepFactorEstimator(GluonEstimator):
         cardinality: List[int] = list([1]),
         embedding_dimension: int = 10,
         distr_output: DistributionOutput = StudentTOutput(),
+        batch_size: int = 32,
     ) -> None:
         super().__init__(trainer=trainer)
 
@@ -123,6 +124,7 @@ class DeepFactorEstimator(GluonEstimator):
         assert (
             num_parallel_samples > 0
         ), "The value of `num_parallel_samples` should be > 0"
+        assert batch_size > 0, "The value of `batch_size` should be > 0"
 
         self.freq = freq
         self.context_length = (
@@ -133,6 +135,7 @@ class DeepFactorEstimator(GluonEstimator):
         self.num_parallel_samples = num_parallel_samples
         self.cardinality = cardinality
         self.embedding_dimensions = [embedding_dimension for _ in cardinality]
+        self.batch_size = batch_size
 
         self.global_model = RNNModel(
             mode=cell_type,
@@ -204,7 +207,7 @@ class DeepFactorEstimator(GluonEstimator):
         return RepresentableBlockPredictor(
             input_transform=transformation,
             prediction_net=prediction_net,
-            batch_size=self.trainer.batch_size,
+            batch_size=self.batch_size,
             freq=self.freq,
             prediction_length=self.prediction_length,
             ctx=self.trainer.ctx,

--- a/src/gluonts/model/deep_factor/_estimator.py
+++ b/src/gluonts/model/deep_factor/_estimator.py
@@ -98,7 +98,7 @@ class DeepFactorEstimator(GluonEstimator):
         distr_output: DistributionOutput = StudentTOutput(),
         batch_size: int = 32,
     ) -> None:
-        super().__init__(trainer=trainer)
+        super().__init__(trainer=trainer, batch_size=batch_size)
 
         assert (
             prediction_length > 0
@@ -124,7 +124,6 @@ class DeepFactorEstimator(GluonEstimator):
         assert (
             num_parallel_samples > 0
         ), "The value of `num_parallel_samples` should be > 0"
-        assert batch_size > 0, "The value of `batch_size` should be > 0"
 
         self.freq = freq
         self.context_length = (
@@ -135,7 +134,6 @@ class DeepFactorEstimator(GluonEstimator):
         self.num_parallel_samples = num_parallel_samples
         self.cardinality = cardinality
         self.embedding_dimensions = [embedding_dimension for _ in cardinality]
-        self.batch_size = batch_size
 
         self.global_model = RNNModel(
             mode=cell_type,

--- a/src/gluonts/model/deep_factor/_estimator.py
+++ b/src/gluonts/model/deep_factor/_estimator.py
@@ -77,6 +77,8 @@ class DeepFactorEstimator(GluonEstimator):
     distr_output
         Distribution to use to evaluate observations and sample predictions
         (default: StudentTOutput()).
+    batch_size
+        The size of the batches to be used training and prediction.
     """
 
     @validated()

--- a/src/gluonts/model/deepar/_estimator.py
+++ b/src/gluonts/model/deepar/_estimator.py
@@ -154,6 +154,7 @@ class DeepAREstimator(GluonEstimator):
         dtype: DType = np.float32,
         alpha: float = 0.0,
         beta: float = 0.0,
+        batch_size: int = 32,
     ) -> None:
         super().__init__(trainer=trainer, dtype=dtype)
 
@@ -189,6 +190,7 @@ class DeepAREstimator(GluonEstimator):
         ), "The value of `num_parallel_samples` should be > 0"
         assert alpha >= 0, "The value of `alpha` should be >= 0"
         assert beta >= 0, "The value of `beta` should be >= 0"
+        assert batch_size > 0, "The value of `batch_size` should be > 0"
 
         self.freq = freq
         self.context_length = (
@@ -239,6 +241,7 @@ class DeepAREstimator(GluonEstimator):
 
         self.alpha = alpha
         self.beta = beta
+        self.batch_size = batch_size
 
     @classmethod
     def derive_auto_fields(cls, train_iter):
@@ -382,7 +385,7 @@ class DeepAREstimator(GluonEstimator):
         return RepresentableBlockPredictor(
             input_transform=transformation,
             prediction_net=prediction_network,
-            batch_size=self.trainer.batch_size,
+            batch_size=self.batch_size,
             freq=self.freq,
             prediction_length=self.prediction_length,
             ctx=self.trainer.ctx,

--- a/src/gluonts/model/deepar/_estimator.py
+++ b/src/gluonts/model/deepar/_estimator.py
@@ -156,7 +156,7 @@ class DeepAREstimator(GluonEstimator):
         beta: float = 0.0,
         batch_size: int = 32,
     ) -> None:
-        super().__init__(trainer=trainer, dtype=dtype)
+        super().__init__(trainer=trainer, batch_size=batch_size, dtype=dtype)
 
         assert (
             prediction_length > 0
@@ -190,7 +190,6 @@ class DeepAREstimator(GluonEstimator):
         ), "The value of `num_parallel_samples` should be > 0"
         assert alpha >= 0, "The value of `alpha` should be >= 0"
         assert beta >= 0, "The value of `beta` should be >= 0"
-        assert batch_size > 0, "The value of `batch_size` should be > 0"
 
         self.freq = freq
         self.context_length = (
@@ -241,7 +240,6 @@ class DeepAREstimator(GluonEstimator):
 
         self.alpha = alpha
         self.beta = beta
-        self.batch_size = batch_size
 
     @classmethod
     def derive_auto_fields(cls, train_iter):

--- a/src/gluonts/model/deepar/_estimator.py
+++ b/src/gluonts/model/deepar/_estimator.py
@@ -125,6 +125,8 @@ class DeepAREstimator(GluonEstimator):
         The scaling coefficient of the activation regularization
     beta
         The scaling coefficient of the temporal activation regularization
+    batch_size
+        The size of the batches to be used training and prediction.
     """
 
     @validated()

--- a/src/gluonts/model/deepstate/_estimator.py
+++ b/src/gluonts/model/deepstate/_estimator.py
@@ -171,6 +171,7 @@ class DeepStateEstimator(GluonEstimator):
         noise_std_bounds: ParameterBounds = ParameterBounds(1e-6, 1.0),
         prior_cov_bounds: ParameterBounds = ParameterBounds(1e-6, 1.0),
         innovation_bounds: ParameterBounds = ParameterBounds(1e-6, 0.01),
+        batch_size: int = 32,
     ) -> None:
         super().__init__(trainer=trainer)
 
@@ -198,6 +199,7 @@ class DeepStateEstimator(GluonEstimator):
             np.isfinite(p.lower) and np.isfinite(p.upper) and p.lower > 0
             for p in [noise_std_bounds, prior_cov_bounds, innovation_bounds]
         ), "All parameter bounds should be finite, and lower bounds should be positive"
+        assert batch_size > 0, "The value of `batch_size` should be > 0"
 
         self.freq = freq
         self.past_length = (
@@ -239,6 +241,7 @@ class DeepStateEstimator(GluonEstimator):
         self.noise_std_bounds = noise_std_bounds
         self.prior_cov_bounds = prior_cov_bounds
         self.innovation_bounds = innovation_bounds
+        self.batch_size = batch_size
 
     def create_transformation(self) -> Transformation:
         remove_field_names = [
@@ -356,7 +359,7 @@ class DeepStateEstimator(GluonEstimator):
         return RepresentableBlockPredictor(
             input_transform=transformation,
             prediction_net=prediction_network,
-            batch_size=self.trainer.batch_size,
+            batch_size=self.batch_size,
             freq=self.freq,
             prediction_length=self.prediction_length,
             ctx=self.trainer.ctx,

--- a/src/gluonts/model/deepstate/_estimator.py
+++ b/src/gluonts/model/deepstate/_estimator.py
@@ -143,6 +143,8 @@ class DeepStateEstimator(GluonEstimator):
     innovation_bounds
         Lower and upper bounds for the standard deviation of the observation
         noise
+    batch_size
+        The size of the batches to be used training and prediction.
     """
 
     @validated()

--- a/src/gluonts/model/deepstate/_estimator.py
+++ b/src/gluonts/model/deepstate/_estimator.py
@@ -173,7 +173,7 @@ class DeepStateEstimator(GluonEstimator):
         innovation_bounds: ParameterBounds = ParameterBounds(1e-6, 0.01),
         batch_size: int = 32,
     ) -> None:
-        super().__init__(trainer=trainer)
+        super().__init__(trainer=trainer, batch_size=batch_size)
 
         assert (
             prediction_length > 0
@@ -199,7 +199,6 @@ class DeepStateEstimator(GluonEstimator):
             np.isfinite(p.lower) and np.isfinite(p.upper) and p.lower > 0
             for p in [noise_std_bounds, prior_cov_bounds, innovation_bounds]
         ), "All parameter bounds should be finite, and lower bounds should be positive"
-        assert batch_size > 0, "The value of `batch_size` should be > 0"
 
         self.freq = freq
         self.past_length = (
@@ -241,7 +240,6 @@ class DeepStateEstimator(GluonEstimator):
         self.noise_std_bounds = noise_std_bounds
         self.prior_cov_bounds = prior_cov_bounds
         self.innovation_bounds = innovation_bounds
-        self.batch_size = batch_size
 
     def create_transformation(self) -> Transformation:
         remove_field_names = [

--- a/src/gluonts/model/deepvar/_estimator.py
+++ b/src/gluonts/model/deepvar/_estimator.py
@@ -193,6 +193,8 @@ class DeepVAREstimator(GluonEstimator):
         Set maximum length for conditioning the marginal transformation
     use_marginal_transformation
         Whether marginal (empirical cdf, gaussian ppf) transformation is used.
+    batch_size
+        The size of the batches to be used training and prediction.
     """
 
     @validated()

--- a/src/gluonts/model/deepvar/_estimator.py
+++ b/src/gluonts/model/deepvar/_estimator.py
@@ -218,6 +218,7 @@ class DeepVAREstimator(GluonEstimator):
         time_features: Optional[List[TimeFeature]] = None,
         conditioning_length: int = 200,
         use_marginal_transformation=False,
+        batch_size: int = 32,
         **kwargs,
     ) -> None:
         super().__init__(trainer=trainer, **kwargs)
@@ -240,6 +241,7 @@ class DeepVAREstimator(GluonEstimator):
         assert (
             embedding_dimension > 0
         ), "The value of `embedding_dimension` should be > 0"
+        assert batch_size > 0, "The value of `batch_size` should be > 0"
 
         self.freq = freq
         self.context_length = (
@@ -280,6 +282,7 @@ class DeepVAREstimator(GluonEstimator):
         self.history_length = self.context_length + max(self.lags_seq)
         self.pick_incomplete = pick_incomplete
         self.scaling = scaling
+        self.batch_size = batch_size
 
         if self.use_marginal_transformation:
             self.output_transform: Optional[
@@ -404,7 +407,7 @@ class DeepVAREstimator(GluonEstimator):
         return RepresentableBlockPredictor(
             input_transform=transformation,
             prediction_net=prediction_network,
-            batch_size=self.trainer.batch_size,
+            batch_size=self.batch_size,
             freq=self.freq,
             prediction_length=self.prediction_length,
             ctx=self.trainer.ctx,

--- a/src/gluonts/model/deepvar/_estimator.py
+++ b/src/gluonts/model/deepvar/_estimator.py
@@ -241,7 +241,6 @@ class DeepVAREstimator(GluonEstimator):
         assert (
             embedding_dimension > 0
         ), "The value of `embedding_dimension` should be > 0"
-        assert batch_size > 0, "The value of `batch_size` should be > 0"
 
         self.freq = freq
         self.context_length = (
@@ -282,7 +281,6 @@ class DeepVAREstimator(GluonEstimator):
         self.history_length = self.context_length + max(self.lags_seq)
         self.pick_incomplete = pick_incomplete
         self.scaling = scaling
-        self.batch_size = batch_size
 
         if self.use_marginal_transformation:
             self.output_transform: Optional[

--- a/src/gluonts/model/gp_forecaster/_estimator.py
+++ b/src/gluonts/model/gp_forecaster/_estimator.py
@@ -89,6 +89,8 @@ class GaussianProcessEstimator(GluonEstimator):
     num_parallel_samples
         Number of evaluation samples per time series to increase parallelism during inference.
         This is a model optimization that does not affect the accuracy (default: 100).
+    batch_size
+        The size of the batches to be used training and prediction.
     """
 
     @validated()

--- a/src/gluonts/model/gp_forecaster/_estimator.py
+++ b/src/gluonts/model/gp_forecaster/_estimator.py
@@ -107,6 +107,7 @@ class GaussianProcessEstimator(GluonEstimator):
         sample_noise: bool = True,
         time_features: Optional[List[TimeFeature]] = None,
         num_parallel_samples: int = 100,
+        batch_size: int = 32,
     ) -> None:
         self.float_type = dtype
         super().__init__(trainer=trainer, dtype=self.float_type)
@@ -121,6 +122,7 @@ class GaussianProcessEstimator(GluonEstimator):
         assert (
             num_parallel_samples > 0
         ), "The value of `num_parallel_samples` should be > 0"
+        assert batch_size > 0, "The value of `batch_size` should be > 0"
 
         self.freq = freq
         self.prediction_length = prediction_length
@@ -139,6 +141,7 @@ class GaussianProcessEstimator(GluonEstimator):
             else time_features_from_frequency_str(self.freq)
         )
         self.num_parallel_samples = num_parallel_samples
+        self.batch_size = batch_size
 
     def create_transformation(self) -> Transformation:
         return Chain(
@@ -207,7 +210,7 @@ class GaussianProcessEstimator(GluonEstimator):
         return RepresentableBlockPredictor(
             input_transform=transformation,
             prediction_net=prediction_network,
-            batch_size=self.trainer.batch_size,
+            batch_size=self.batch_size,
             freq=self.freq,
             prediction_length=self.prediction_length,
             ctx=self.trainer.ctx,

--- a/src/gluonts/model/gp_forecaster/_estimator.py
+++ b/src/gluonts/model/gp_forecaster/_estimator.py
@@ -122,7 +122,6 @@ class GaussianProcessEstimator(GluonEstimator):
         assert (
             num_parallel_samples > 0
         ), "The value of `num_parallel_samples` should be > 0"
-        assert batch_size > 0, "The value of `batch_size` should be > 0"
 
         self.freq = freq
         self.prediction_length = prediction_length
@@ -141,7 +140,6 @@ class GaussianProcessEstimator(GluonEstimator):
             else time_features_from_frequency_str(self.freq)
         )
         self.num_parallel_samples = num_parallel_samples
-        self.batch_size = batch_size
 
     def create_transformation(self) -> Transformation:
         return Chain(

--- a/src/gluonts/model/gpvar/_estimator.py
+++ b/src/gluonts/model/gpvar/_estimator.py
@@ -123,6 +123,8 @@ class GPVAREstimator(GluonEstimator):
         model
     train_sampler
         Controls the sampling of windows during training.
+    batch_size
+        The size of the batches to be used training and prediction.
     """
 
     @validated()

--- a/src/gluonts/model/gpvar/_estimator.py
+++ b/src/gluonts/model/gpvar/_estimator.py
@@ -150,6 +150,7 @@ class GPVAREstimator(GluonEstimator):
         conditioning_length: int = 100,
         use_marginal_transformation: bool = False,
         train_sampler: InstanceSampler = ExpectedNumInstanceSampler(1.0),
+        batch_size: int = 32,
     ) -> None:
         super().__init__(trainer=trainer)
 
@@ -165,6 +166,7 @@ class GPVAREstimator(GluonEstimator):
             num_parallel_samples > 0
         ), "The value of `num_eval_samples` should be > 0"
         assert dropout_rate >= 0, "The value of `dropout_rate` should be >= 0"
+        assert batch_size > 0, "The value of `batch_size` should be > 0"
 
         if distr_output is not None:
             self.distr_output = distr_output
@@ -187,6 +189,7 @@ class GPVAREstimator(GluonEstimator):
         self.cell_type = cell_type
         self.num_parallel_samples = num_parallel_samples
         self.dropout_rate = dropout_rate
+        self.batch_size = batch_size
 
         self.lags_seq = (
             lags_seq
@@ -331,7 +334,7 @@ class GPVAREstimator(GluonEstimator):
         return RepresentableBlockPredictor(
             input_transform=transformation,
             prediction_net=prediction_network,
-            batch_size=self.trainer.batch_size,
+            batch_size=self.batch_size,
             freq=self.freq,
             prediction_length=self.prediction_length,
             ctx=self.trainer.ctx,

--- a/src/gluonts/model/gpvar/_estimator.py
+++ b/src/gluonts/model/gpvar/_estimator.py
@@ -152,7 +152,7 @@ class GPVAREstimator(GluonEstimator):
         train_sampler: InstanceSampler = ExpectedNumInstanceSampler(1.0),
         batch_size: int = 32,
     ) -> None:
-        super().__init__(trainer=trainer)
+        super().__init__(trainer=trainer, batch_size=batch_size)
 
         assert (
             prediction_length > 0
@@ -166,7 +166,6 @@ class GPVAREstimator(GluonEstimator):
             num_parallel_samples > 0
         ), "The value of `num_eval_samples` should be > 0"
         assert dropout_rate >= 0, "The value of `dropout_rate` should be >= 0"
-        assert batch_size > 0, "The value of `batch_size` should be > 0"
 
         if distr_output is not None:
             self.distr_output = distr_output
@@ -189,7 +188,6 @@ class GPVAREstimator(GluonEstimator):
         self.cell_type = cell_type
         self.num_parallel_samples = num_parallel_samples
         self.dropout_rate = dropout_rate
-        self.batch_size = batch_size
 
         self.lags_seq = (
             lags_seq

--- a/src/gluonts/model/lstnet/_estimator.py
+++ b/src/gluonts/model/lstnet/_estimator.py
@@ -119,6 +119,7 @@ class LSTNetEstimator(GluonEstimator):
         skip_rnn_num_cells: int = 10,
         scaling: bool = True,
         train_sampler: InstanceSampler = ExpectedNumInstanceSampler(1.0),
+        batch_size: int = 32,
         dtype: DType = np.float32,
     ) -> None:
         super().__init__(trainer=trainer, lead_time=lead_time, dtype=dtype)
@@ -140,6 +141,7 @@ class LSTNetEstimator(GluonEstimator):
         self.skip_rnn_num_cells = skip_rnn_num_cells
         self.scaling = scaling
         self.train_sampler = train_sampler
+        self.batch_size = batch_size
         self.dtype = dtype
 
     def create_transformation(self) -> Transformation:
@@ -219,7 +221,7 @@ class LSTNetEstimator(GluonEstimator):
         return RepresentableBlockPredictor(
             input_transform=transformation,
             prediction_net=prediction_network,
-            batch_size=self.trainer.batch_size,
+            batch_size=self.batch_size,
             freq=self.freq,
             prediction_length=self.prediction_length,
             lead_time=self.lead_time,

--- a/src/gluonts/model/lstnet/_estimator.py
+++ b/src/gluonts/model/lstnet/_estimator.py
@@ -141,7 +141,6 @@ class LSTNetEstimator(GluonEstimator):
         self.skip_rnn_num_cells = skip_rnn_num_cells
         self.scaling = scaling
         self.train_sampler = train_sampler
-        self.batch_size = batch_size
         self.dtype = dtype
 
     def create_transformation(self) -> Transformation:

--- a/src/gluonts/model/lstnet/_estimator.py
+++ b/src/gluonts/model/lstnet/_estimator.py
@@ -92,6 +92,8 @@ class LSTNetEstimator(GluonEstimator):
         Whether to automatically scale the target values (default: True)
     train_sampler
         Controls the sampling of windows during training.
+    batch_size
+        The size of the batches to be used training and prediction.
     dtype
         Data type (default: np.float32)
     """

--- a/src/gluonts/model/n_beats/_estimator.py
+++ b/src/gluonts/model/n_beats/_estimator.py
@@ -147,7 +147,6 @@ class NBEATSEstimator(GluonEstimator):
         assert (
             loss_function is None or loss_function in VALID_LOSS_FUNCTIONS
         ), f"The loss function has to be one of the following: {VALID_LOSS_FUNCTIONS}."
-        assert batch_size > 0, "The value of `batch_size` should be > 0"
 
         self.freq = freq
         self.prediction_length = prediction_length
@@ -159,7 +158,6 @@ class NBEATSEstimator(GluonEstimator):
         # num_stacks has to be handled separately because other arguments have to match its length
         self.num_stacks = num_stacks
         self.loss_function = loss_function
-        self.batch_size = batch_size
 
         self.widths = self._validate_nbeats_argument(
             argument_value=widths,

--- a/src/gluonts/model/n_beats/_estimator.py
+++ b/src/gluonts/model/n_beats/_estimator.py
@@ -127,6 +127,7 @@ class NBEATSEstimator(GluonEstimator):
         stack_types: Optional[List[str]] = None,
         loss_function: Optional[str] = "MAPE",
         train_sampler: InstanceSampler = ExpectedNumInstanceSampler(1.0),
+        batch_size: int = 32,
         **kwargs,
     ) -> None:
         """
@@ -146,6 +147,7 @@ class NBEATSEstimator(GluonEstimator):
         assert (
             loss_function is None or loss_function in VALID_LOSS_FUNCTIONS
         ), f"The loss function has to be one of the following: {VALID_LOSS_FUNCTIONS}."
+        assert batch_size > 0, "The value of `batch_size` should be > 0"
 
         self.freq = freq
         self.prediction_length = prediction_length
@@ -157,6 +159,7 @@ class NBEATSEstimator(GluonEstimator):
         # num_stacks has to be handled separately because other arguments have to match its length
         self.num_stacks = num_stacks
         self.loss_function = loss_function
+        self.batch_size = batch_size
 
         self.widths = self._validate_nbeats_argument(
             argument_value=widths,
@@ -293,7 +296,7 @@ class NBEATSEstimator(GluonEstimator):
         return RepresentableBlockPredictor(
             input_transform=transformation,
             prediction_net=prediction_network,
-            batch_size=self.trainer.batch_size,
+            batch_size=self.batch_size,
             freq=self.freq,
             prediction_length=self.prediction_length,
             ctx=self.trainer.ctx,

--- a/src/gluonts/model/n_beats/_estimator.py
+++ b/src/gluonts/model/n_beats/_estimator.py
@@ -103,6 +103,8 @@ class NBEATSEstimator(GluonEstimator):
         The default value is "MAPE".
     train_sampler
         Controls the sampling of windows during training.
+    batch_size
+        The size of the batches to be used training and prediction.
     kwargs
         Arguments passed to 'GluonEstimator'.
     """

--- a/src/gluonts/model/san/_estimator.py
+++ b/src/gluonts/model/san/_estimator.py
@@ -79,7 +79,7 @@ class SelfAttentionEstimator(GluonEstimator):
         train_sampler: InstanceSampler = ExpectedNumInstanceSampler(100),
         batch_size: int = 32,
     ):
-        super().__init__(trainer=trainer)
+        super().__init__(trainer=trainer, batch_size=batch_size)
         self.freq = freq
         self.prediction_length = prediction_length
         self.context_length = context_length or prediction_length
@@ -103,7 +103,6 @@ class SelfAttentionEstimator(GluonEstimator):
         self.use_feat_static_cat = use_feat_static_cat
         self.use_feat_static_real = use_feat_static_real
         self.train_sampler = train_sampler
-        self.batch_size = batch_size
 
     def create_transformation(self) -> Transformation:
         transforms = []

--- a/src/gluonts/model/san/_estimator.py
+++ b/src/gluonts/model/san/_estimator.py
@@ -77,6 +77,7 @@ class SelfAttentionEstimator(GluonEstimator):
         use_feat_static_real: bool = False,
         use_feat_static_cat: bool = True,
         train_sampler: InstanceSampler = ExpectedNumInstanceSampler(100),
+        batch_size: int = 32,
     ):
         super().__init__(trainer=trainer)
         self.freq = freq
@@ -102,6 +103,7 @@ class SelfAttentionEstimator(GluonEstimator):
         self.use_feat_static_cat = use_feat_static_cat
         self.use_feat_static_real = use_feat_static_real
         self.train_sampler = train_sampler
+        self.batch_size = batch_size
 
     def create_transformation(self) -> Transformation:
         transforms = []
@@ -273,7 +275,7 @@ class SelfAttentionEstimator(GluonEstimator):
         return RepresentableBlockPredictor(
             input_transform=transformation,
             prediction_net=prediction_network,
-            batch_size=self.trainer.batch_size,
+            batch_size=self.batch_size,
             freq=self.freq,
             prediction_length=self.prediction_length,
             ctx=self.trainer.ctx,

--- a/src/gluonts/model/seq2seq/_forking_estimator.py
+++ b/src/gluonts/model/seq2seq/_forking_estimator.py
@@ -129,6 +129,8 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
         Decides how much forking to do in the decoder. 1 reduces to seq2seq and enc_len reduces to MQ-C(R)NN.
     max_ts_len
         Returns the length of the longest time series in the dataset to be used in bounding context_length.
+    batch_size
+        The size of the batches to be used training and prediction.
     """
 
     @validated()

--- a/src/gluonts/model/seq2seq/_forking_estimator.py
+++ b/src/gluonts/model/seq2seq/_forking_estimator.py
@@ -156,6 +156,7 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
         dtype: DType = np.float32,
         num_forking: Optional[int] = None,
         max_ts_len: Optional[int] = None,
+        batch_size: int = 32,
     ) -> None:
         super().__init__(trainer=trainer)
 
@@ -175,6 +176,7 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
         assert embedding_dimension is None or all(
             e > 0 for e in embedding_dimension
         ), "Elements of `embedding_dimension` should be > 0"
+        assert batch_size > 0, "The value of `batch_size` should be > 0"
 
         self.encoder = encoder
         self.decoder = decoder
@@ -223,6 +225,7 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
         )
         self.scaling_decoder_dynamic_feature = scaling_decoder_dynamic_feature
         self.dtype = dtype
+        self.batch_size = batch_size
 
     def create_transformation(self) -> Transformation:
         chain = []
@@ -452,7 +455,7 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
         return RepresentableBlockPredictor(
             input_transform=transformation,
             prediction_net=prediction_network,
-            batch_size=self.trainer.batch_size,
+            batch_size=self.batch_size,
             freq=self.freq,
             prediction_length=self.prediction_length,
             ctx=self.trainer.ctx,

--- a/src/gluonts/model/seq2seq/_forking_estimator.py
+++ b/src/gluonts/model/seq2seq/_forking_estimator.py
@@ -158,7 +158,7 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
         max_ts_len: Optional[int] = None,
         batch_size: int = 32,
     ) -> None:
-        super().__init__(trainer=trainer)
+        super().__init__(trainer=trainer, batch_size=batch_size)
 
         assert (distr_output is None) != (quantile_output is None)
         assert (
@@ -176,7 +176,6 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
         assert embedding_dimension is None or all(
             e > 0 for e in embedding_dimension
         ), "Elements of `embedding_dimension` should be > 0"
-        assert batch_size > 0, "The value of `batch_size` should be > 0"
 
         self.encoder = encoder
         self.decoder = decoder
@@ -225,7 +224,6 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
         )
         self.scaling_decoder_dynamic_feature = scaling_decoder_dynamic_feature
         self.dtype = dtype
-        self.batch_size = batch_size
 
     def create_transformation(self) -> Transformation:
         chain = []

--- a/src/gluonts/model/seq2seq/_seq2seq_estimator.py
+++ b/src/gluonts/model/seq2seq/_seq2seq_estimator.py
@@ -74,9 +74,8 @@ class Seq2SeqEstimator(GluonEstimator):
         assert quantiles is None or all(
             0 <= d <= 1 for d in quantiles
         ), "Elements of `quantiles` should be >= 0 and <= 1"
-        assert batch_size > 0, "The value of `batch_size` should be > 0"
 
-        super().__init__(trainer=trainer)
+        super().__init__(trainer=trainer, batch_size=batch_size)
 
         self.context_length = (
             context_length if context_length is not None else prediction_length
@@ -95,7 +94,6 @@ class Seq2SeqEstimator(GluonEstimator):
             embedding_dims=[embedding_dimension for _ in cardinality],
         )
         self.num_parallel_samples = num_parallel_samples
-        self.batch_size = batch_size
 
     def create_transformation(self) -> transform.Transformation:
         return transform.Chain(

--- a/src/gluonts/model/seq2seq/_seq2seq_estimator.py
+++ b/src/gluonts/model/seq2seq/_seq2seq_estimator.py
@@ -63,6 +63,7 @@ class Seq2SeqEstimator(GluonEstimator):
         quantiles: Optional[List[float]] = None,
         trainer: Trainer = Trainer(),
         num_parallel_samples: int = 100,
+        batch_size: int = 32,
     ) -> None:
         assert (
             prediction_length > 0
@@ -73,6 +74,7 @@ class Seq2SeqEstimator(GluonEstimator):
         assert quantiles is None or all(
             0 <= d <= 1 for d in quantiles
         ), "Elements of `quantiles` should be >= 0 and <= 1"
+        assert batch_size > 0, "The value of `batch_size` should be > 0"
 
         super().__init__(trainer=trainer)
 
@@ -93,6 +95,7 @@ class Seq2SeqEstimator(GluonEstimator):
             embedding_dims=[embedding_dimension for _ in cardinality],
         )
         self.num_parallel_samples = num_parallel_samples
+        self.batch_size = batch_size
 
     def create_transformation(self) -> transform.Transformation:
         return transform.Chain(
@@ -175,7 +178,7 @@ class Seq2SeqEstimator(GluonEstimator):
         return RepresentableBlockPredictor(
             input_transform=transformation,
             prediction_net=prediction_network,
-            batch_size=self.trainer.batch_size,
+            batch_size=self.batch_size,
             freq=self.freq,
             prediction_length=self.prediction_length,
             ctx=self.trainer.ctx,

--- a/src/gluonts/model/simple_feedforward/_estimator.py
+++ b/src/gluonts/model/simple_feedforward/_estimator.py
@@ -116,6 +116,7 @@ class SimpleFeedForwardEstimator(GluonEstimator):
         mean_scaling: bool = True,
         num_parallel_samples: int = 100,
         train_sampler: InstanceSampler = ExpectedNumInstanceSampler(1.0),
+        batch_size: int = 32,
     ) -> None:
         """
         Defines an estimator. All parameters should be serializable.
@@ -134,6 +135,7 @@ class SimpleFeedForwardEstimator(GluonEstimator):
         assert (
             num_parallel_samples > 0
         ), "The value of `num_parallel_samples` should be > 0"
+        assert batch_size > 0, "The value of `batch_size` should be > 0"
 
         self.num_hidden_dimensions = (
             num_hidden_dimensions
@@ -156,6 +158,7 @@ class SimpleFeedForwardEstimator(GluonEstimator):
             else DummyValueImputation(self.distr_output.value_in_support)
         )
         self.train_sampler = train_sampler
+        self.batch_size = batch_size
 
     # here we do only a simple operation to convert the input data to a form
     # that can be digested by our model by only splitting the target in two, a
@@ -216,7 +219,7 @@ class SimpleFeedForwardEstimator(GluonEstimator):
             return RepresentableBlockPredictor(
                 input_transform=transformation,
                 prediction_net=prediction_network,
-                batch_size=self.trainer.batch_size,
+                batch_size=self.batch_size,
                 freq=self.freq,
                 prediction_length=self.prediction_length,
                 ctx=self.trainer.ctx,
@@ -236,7 +239,7 @@ class SimpleFeedForwardEstimator(GluonEstimator):
             return RepresentableBlockPredictor(
                 input_transform=transformation,
                 prediction_net=prediction_network,
-                batch_size=self.trainer.batch_size,
+                batch_size=self.batch_size,
                 forecast_generator=DistributionForecastGenerator(
                     self.distr_output
                 ),

--- a/src/gluonts/model/simple_feedforward/_estimator.py
+++ b/src/gluonts/model/simple_feedforward/_estimator.py
@@ -95,6 +95,8 @@ class SimpleFeedForwardEstimator(GluonEstimator):
         This is a model optimization that does not affect the accuracy (default: 100)
     train_sampler
         Controls the sampling of windows during training.
+    batch_size
+        The size of the batches to be used training and prediction.
     """
 
     # The validated() decorator makes sure that parameters are checked by

--- a/src/gluonts/model/simple_feedforward/_estimator.py
+++ b/src/gluonts/model/simple_feedforward/_estimator.py
@@ -121,7 +121,7 @@ class SimpleFeedForwardEstimator(GluonEstimator):
         """
         Defines an estimator. All parameters should be serializable.
         """
-        super().__init__(trainer=trainer)
+        super().__init__(trainer=trainer, batch_size=batch_size)
 
         assert (
             prediction_length > 0
@@ -135,7 +135,6 @@ class SimpleFeedForwardEstimator(GluonEstimator):
         assert (
             num_parallel_samples > 0
         ), "The value of `num_parallel_samples` should be > 0"
-        assert batch_size > 0, "The value of `batch_size` should be > 0"
 
         self.num_hidden_dimensions = (
             num_hidden_dimensions
@@ -158,7 +157,6 @@ class SimpleFeedForwardEstimator(GluonEstimator):
             else DummyValueImputation(self.distr_output.value_in_support)
         )
         self.train_sampler = train_sampler
-        self.batch_size = batch_size
 
     # here we do only a simple operation to convert the input data to a form
     # that can be digested by our model by only splitting the target in two, a

--- a/src/gluonts/model/tft/_estimator.py
+++ b/src/gluonts/model/tft/_estimator.py
@@ -82,7 +82,6 @@ class TemporalFusionTransformerEstimator(GluonEstimator):
             context_length is None or context_length > 0
         ), "The value of `context_length` should be > 0"
         assert dropout_rate >= 0, "The value of `dropout_rate` should be >= 0"
-        assert batch_size > 0, "The value of `batch_size` should be > 0"
 
         self.freq = freq
         self.prediction_length = prediction_length
@@ -103,7 +102,6 @@ class TemporalFusionTransformerEstimator(GluonEstimator):
         self.static_feature_dims = static_feature_dims
         self.dynamic_feature_dims = dynamic_feature_dims
         self.past_dynamic_features = past_dynamic_features
-        self.batch_size = batch_size
 
         self.past_dynamic_cardinalities = {}
         self.past_dynamic_feature_dims = {}

--- a/src/gluonts/model/tft/_estimator.py
+++ b/src/gluonts/model/tft/_estimator.py
@@ -70,6 +70,7 @@ class TemporalFusionTransformerEstimator(GluonEstimator):
         static_feature_dims: Dict[str, int] = {},
         dynamic_feature_dims: Dict[str, int] = {},
         past_dynamic_features: List[str] = [],
+        batch_size: int = 32,
     ) -> None:
         super(TemporalFusionTransformerEstimator, self).__init__(
             trainer=trainer
@@ -81,6 +82,7 @@ class TemporalFusionTransformerEstimator(GluonEstimator):
             context_length is None or context_length > 0
         ), "The value of `context_length` should be > 0"
         assert dropout_rate >= 0, "The value of `dropout_rate` should be >= 0"
+        assert batch_size > 0, "The value of `batch_size` should be > 0"
 
         self.freq = freq
         self.prediction_length = prediction_length
@@ -101,6 +103,7 @@ class TemporalFusionTransformerEstimator(GluonEstimator):
         self.static_feature_dims = static_feature_dims
         self.dynamic_feature_dims = dynamic_feature_dims
         self.past_dynamic_features = past_dynamic_features
+        self.batch_size = batch_size
 
         self.past_dynamic_cardinalities = {}
         self.past_dynamic_feature_dims = {}
@@ -362,7 +365,7 @@ class TemporalFusionTransformerEstimator(GluonEstimator):
         return RepresentableBlockPredictor(
             input_transform=transformation,
             prediction_net=prediction_network,
-            batch_size=self.trainer.batch_size,
+            batch_size=self.batch_size,
             freq=self.freq,
             prediction_length=self.prediction_length,
             ctx=self.trainer.ctx,

--- a/src/gluonts/model/tpp/deeptpp/_estimator.py
+++ b/src/gluonts/model/tpp/deeptpp/_estimator.py
@@ -105,7 +105,7 @@ class DeepTPPEstimator(GluonEstimator):
             not trainer.hybridize
         ), "DeepTPP currently only supports the non-hybridized training"
 
-        super().__init__(trainer=trainer)
+        super().__init__(trainer=trainer, batch_size=batch_size)
 
         assert (
             prediction_interval_length > 0
@@ -123,7 +123,6 @@ class DeepTPPEstimator(GluonEstimator):
         assert (
             num_training_instances > 0
         ), "The value of `num_training_instances` should be > 0"
-        assert batch_size > 0, "The value of `batch_size` should be > 0"
 
         self.num_hidden_dimensions = num_hidden_dimensions
         self.prediction_interval_length = prediction_interval_length
@@ -138,7 +137,6 @@ class DeepTPPEstimator(GluonEstimator):
         self.num_parallel_samples = num_parallel_samples
         self.num_training_instances = num_training_instances
         self.freq = freq
-        self.batch_size = batch_size
 
     def create_training_network(self) -> HybridBlock:
         return DeepTPPTrainingNetwork(

--- a/src/gluonts/model/tpp/deeptpp/_estimator.py
+++ b/src/gluonts/model/tpp/deeptpp/_estimator.py
@@ -99,6 +99,7 @@ class DeepTPPEstimator(GluonEstimator):
         num_parallel_samples: int = 100,
         num_training_instances: int = 100,
         freq: str = "H",
+        batch_size: int = 32,
     ) -> None:
         assert (
             not trainer.hybridize
@@ -122,6 +123,7 @@ class DeepTPPEstimator(GluonEstimator):
         assert (
             num_training_instances > 0
         ), "The value of `num_training_instances` should be > 0"
+        assert batch_size > 0, "The value of `batch_size` should be > 0"
 
         self.num_hidden_dimensions = num_hidden_dimensions
         self.prediction_interval_length = prediction_interval_length
@@ -136,6 +138,7 @@ class DeepTPPEstimator(GluonEstimator):
         self.num_parallel_samples = num_parallel_samples
         self.num_training_instances = num_training_instances
         self.freq = freq
+        self.batch_size = batch_size
 
     def create_training_network(self) -> HybridBlock:
         return DeepTPPTrainingNetwork(
@@ -184,7 +187,7 @@ class DeepTPPEstimator(GluonEstimator):
         return PointProcessGluonPredictor(
             input_names=["target", "valid_length"],
             prediction_net=prediction_network,
-            batch_size=self.trainer.batch_size,
+            batch_size=self.batch_size,
             prediction_interval_length=self.prediction_interval_length,
             freq=self.freq,
             ctx=self.trainer.ctx,

--- a/src/gluonts/model/tpp/deeptpp/_estimator.py
+++ b/src/gluonts/model/tpp/deeptpp/_estimator.py
@@ -84,6 +84,8 @@ class DeepTPPEstimator(GluonEstimator):
     freq
         Similar to the :code:`freq` of discrete-time models, specifies the time
         unit by which inter-arrival times are given.
+    batch_size
+        The size of the batches to be used training and prediction.
     """
 
     @validated()

--- a/src/gluonts/model/tpp/predictor.py
+++ b/src/gluonts/model/tpp/predictor.py
@@ -20,7 +20,7 @@ import numpy as np
 
 from gluonts.core.component import DType
 from gluonts.dataset.common import Dataset
-from gluonts.dataset.loader import DataBatch, InferenceDataLoader
+from gluonts.dataset.loader import DataBatch, DataLoader, InferenceDataLoader
 from gluonts.model.forecast import Forecast
 from gluonts.model.forecast_generator import ForecastGenerator
 from gluonts.model.predictor import OutputTransform
@@ -34,7 +34,7 @@ from .forecast import PointProcessSampleForecast
 class PointProcessForecastGenerator(ForecastGenerator):
     def __call__(
         self,
-        inference_data_loader: InferenceDataLoader,
+        inference_data_loader: DataLoader,
         prediction_net: mx.gluon.Block,
         input_names: List[str],
         freq: str,
@@ -105,9 +105,6 @@ class PointProcessGluonPredictor(GluonPredictor):
     The predictor also accounts for the fact that the prediction network
     outputs a 2-tuple of Tensors, for the samples themselves and their
     `valid_length`.
-
-    Finally, this class uses a VariableLengthInferenceDataLoader as opposed
-    to the default InferenceDataLoader.
 
     Parameters
     ----------

--- a/src/gluonts/model/transformer/_estimator.py
+++ b/src/gluonts/model/transformer/_estimator.py
@@ -114,6 +114,8 @@ class TransformerEstimator(GluonEstimator):
         This is a model optimization that does not affect the accuracy (default: 100)
     train_sampler
         Controls the sampling of windows during training.
+    batch_size
+        The size of the batches to be used training and prediction.
     """
 
     @validated()

--- a/src/gluonts/model/transformer/_estimator.py
+++ b/src/gluonts/model/transformer/_estimator.py
@@ -142,7 +142,7 @@ class TransformerEstimator(GluonEstimator):
         train_sampler: InstanceSampler = ExpectedNumInstanceSampler(1.0),
         batch_size: int = 32,
     ) -> None:
-        super().__init__(trainer=trainer)
+        super().__init__(trainer=trainer, batch_size=batch_size)
 
         assert (
             prediction_length > 0
@@ -163,7 +163,6 @@ class TransformerEstimator(GluonEstimator):
         assert (
             num_parallel_samples > 0
         ), "The value of `num_parallel_samples` should be > 0"
-        assert batch_size > 0, "The value of `batch_size` should be > 0"
 
         self.freq = freq
         self.prediction_length = prediction_length
@@ -189,7 +188,6 @@ class TransformerEstimator(GluonEstimator):
         )
         self.history_length = self.context_length + max(self.lags_seq)
         self.scaling = scaling
-        self.batch_size = batch_size
 
         self.config = {
             "model_dim": model_dim,

--- a/src/gluonts/model/transformer/_estimator.py
+++ b/src/gluonts/model/transformer/_estimator.py
@@ -140,6 +140,7 @@ class TransformerEstimator(GluonEstimator):
         use_feat_static_cat: bool = False,
         num_parallel_samples: int = 100,
         train_sampler: InstanceSampler = ExpectedNumInstanceSampler(1.0),
+        batch_size: int = 32,
     ) -> None:
         super().__init__(trainer=trainer)
 
@@ -162,6 +163,7 @@ class TransformerEstimator(GluonEstimator):
         assert (
             num_parallel_samples > 0
         ), "The value of `num_parallel_samples` should be > 0"
+        assert batch_size > 0, "The value of `batch_size` should be > 0"
 
         self.freq = freq
         self.prediction_length = prediction_length
@@ -187,6 +189,7 @@ class TransformerEstimator(GluonEstimator):
         )
         self.history_length = self.context_length + max(self.lags_seq)
         self.scaling = scaling
+        self.batch_size = batch_size
 
         self.config = {
             "model_dim": model_dim,
@@ -310,7 +313,7 @@ class TransformerEstimator(GluonEstimator):
         return RepresentableBlockPredictor(
             input_transform=transformation,
             prediction_net=prediction_network,
-            batch_size=self.trainer.batch_size,
+            batch_size=self.batch_size,
             freq=self.freq,
             prediction_length=self.prediction_length,
             ctx=self.trainer.ctx,

--- a/src/gluonts/model/wavenet/_estimator.py
+++ b/src/gluonts/model/wavenet/_estimator.py
@@ -133,6 +133,8 @@ class WaveNetEstimator(GluonEstimator):
         This is a model optimization that does not affect the accuracy (default: 200)
     train_sampler
         Controls the sampling of windows during training.
+    batch_size
+        The size of the batches to be used training and prediction.
     """
 
     @validated()

--- a/src/gluonts/model/wavenet/_estimator.py
+++ b/src/gluonts/model/wavenet/_estimator.py
@@ -160,6 +160,7 @@ class WaveNetEstimator(GluonEstimator):
         act_type: str = "elu",
         num_parallel_samples: int = 200,
         train_sampler: InstanceSampler = ExpectedNumInstanceSampler(1.0),
+        batch_size: int = 32,
     ) -> None:
         """
         Model with Wavenet architecture and quantized target.
@@ -210,6 +211,7 @@ class WaveNetEstimator(GluonEstimator):
         self.act_type = act_type
         self.num_parallel_samples = num_parallel_samples
         self.train_sampler = train_sampler
+        self.batch_size = batch_size
 
         seasonality = (
             get_seasonality(
@@ -287,7 +289,7 @@ class WaveNetEstimator(GluonEstimator):
         training_data_loader = TrainDataLoader(
             dataset=training_data,
             transform=transformation + SelectFields(input_names),
-            batch_size=self.trainer.batch_size,
+            batch_size=self.batch_size,
             stack_fn=partial(batchify, ctx=self.trainer.ctx, dtype=self.dtype),
             num_workers=num_workers,
             num_prefetch=num_prefetch,
@@ -300,7 +302,7 @@ class WaveNetEstimator(GluonEstimator):
             validation_data_loader = ValidationDataLoader(
                 dataset=validation_data,
                 transform=transformation,
-                batch_size=self.trainer.batch_size,
+                batch_size=self.batch_size,
                 stack_fn=partial(
                     batchify, ctx=self.trainer.ctx, dtype=self.dtype
                 ),
@@ -413,7 +415,7 @@ class WaveNetEstimator(GluonEstimator):
         return RepresentableBlockPredictor(
             input_transform=transformation,
             prediction_net=prediction_network,
-            batch_size=self.trainer.batch_size,
+            batch_size=self.batch_size,
             freq=self.freq,
             prediction_length=self.prediction_length,
             ctx=self.trainer.ctx,

--- a/src/gluonts/model/wavenet/_estimator.py
+++ b/src/gluonts/model/wavenet/_estimator.py
@@ -190,7 +190,7 @@ class WaveNetEstimator(GluonEstimator):
               'elu', 'relu', 'sigmoid', 'tanh', 'softrelu', 'softsign'
         """
 
-        super().__init__(trainer=trainer)
+        super().__init__(trainer=trainer, batch_size=batch_size)
 
         self.freq = freq
         self.prediction_length = prediction_length
@@ -211,7 +211,6 @@ class WaveNetEstimator(GluonEstimator):
         self.act_type = act_type
         self.num_parallel_samples = num_parallel_samples
         self.train_sampler = train_sampler
-        self.batch_size = batch_size
 
         seasonality = (
             get_seasonality(

--- a/src/gluonts/mx/model/estimator.py
+++ b/src/gluonts/mx/model/estimator.py
@@ -45,9 +45,17 @@ class GluonEstimator(Estimator):
 
     @validated()
     def __init__(
-        self, trainer: Trainer, lead_time: int = 0, dtype: DType = np.float32
+        self,
+        trainer: Trainer,
+        batch_size: int = 32,
+        lead_time: int = 0,
+        dtype: DType = np.float32,
     ) -> None:
         super().__init__(lead_time=lead_time)
+
+        assert batch_size > 0, "The value of `batch_size` should be > 0"
+
+        self.batch_size = batch_size
         self.trainer = trainer
         self.dtype = dtype
 

--- a/src/gluonts/mx/model/estimator.py
+++ b/src/gluonts/mx/model/estimator.py
@@ -46,6 +46,7 @@ class GluonEstimator(Estimator):
     @validated()
     def __init__(
         self,
+        *,
         trainer: Trainer,
         batch_size: int = 32,
         lead_time: int = 0,

--- a/src/gluonts/mx/model/estimator.py
+++ b/src/gluonts/mx/model/estimator.py
@@ -129,7 +129,7 @@ class GluonEstimator(Estimator):
         training_data_loader = TrainDataLoader(
             dataset=training_data,
             transform=transformation + SelectFields(input_names),
-            batch_size=self.trainer.batch_size,
+            batch_size=self.batch_size,
             stack_fn=partial(
                 batchify,
                 ctx=self.trainer.ctx,
@@ -147,7 +147,7 @@ class GluonEstimator(Estimator):
             validation_data_loader = ValidationDataLoader(
                 dataset=validation_data,
                 transform=transformation + SelectFields(input_names),
-                batch_size=self.trainer.batch_size,
+                batch_size=self.batch_size,
                 stack_fn=partial(
                     batchify,
                     ctx=self.trainer.ctx,

--- a/test/paper_examples/test_axiv_paper_examples.py
+++ b/test/paper_examples/test_axiv_paper_examples.py
@@ -11,6 +11,8 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+import pytest
+
 from gluonts.dataset.artificial import constant_dataset
 from gluonts.dataset.field_names import FieldName
 
@@ -49,6 +51,9 @@ def test_listing_1():
     )
 
 
+@pytest.mark.xfail(
+    reason="Changes in how batch_size is set broke this snippet."
+)
 def test_appendix_c():
     """
     Test GluonTS paper examples from arxiv paper:

--- a/test/paper_examples/test_axiv_paper_examples.py
+++ b/test/paper_examples/test_axiv_paper_examples.py
@@ -51,9 +51,6 @@ def test_listing_1():
     )
 
 
-@pytest.mark.xfail(
-    reason="Changes in how batch_size is set broke this snippet."
-)
 def test_appendix_c():
     """
     Test GluonTS paper examples from arxiv paper:

--- a/test/test_itertools.py
+++ b/test/test_itertools.py
@@ -22,10 +22,10 @@ import pytest
 from gluonts.dataset.artificial import constant_dataset
 from gluonts.itertools import (
     batcher,
-    cached,
-    cyclic,
-    iterable_slice,
-    pseudo_shuffled,
+    Cached,
+    Cyclic,
+    IterableSlice,
+    PseudoShuffled,
 )
 
 
@@ -33,7 +33,7 @@ from gluonts.itertools import (
     "data, n, expected", [([1, 2, 3], 7, [1, 2, 3, 1, 2, 3, 1]), ([], 4, [])]
 )
 def test_cyclic(data: Iterable, n: int, expected: List) -> None:
-    cyclic_data = cyclic(data)
+    cyclic_data = Cyclic(data)
     actual = list(itertools.islice(cyclic_data, n))
     assert actual == expected
 
@@ -47,7 +47,7 @@ def test_cyclic(data: Iterable, n: int, expected: List) -> None:
 )
 def test_pseudo_shuffled(data: Iterable) -> None:
     list_data = list(data)
-    shuffled_iter = pseudo_shuffled(iter(list_data), shuffle_buffer_length=5)
+    shuffled_iter = PseudoShuffled(iter(list_data), shuffle_buffer_length=5)
     shuffled_data = list(shuffled_iter)
     assert len(shuffled_data) == len(list_data)
     assert all(d in shuffled_data for d in list_data)
@@ -56,15 +56,15 @@ def test_pseudo_shuffled(data: Iterable) -> None:
 @pytest.mark.parametrize(
     "data, expected_elements_per_iteration",
     [
-        (cached(range(4)), (list(range(4)),) * 5),
+        (Cached(range(4)), (list(range(4)),) * 5),
         (batcher(range(10), 3), ([[0, 1, 2], [3, 4, 5], [6, 7, 8], [9]], [])),
-        (iterable_slice(range(10), 3), ([0, 1, 2],) * 5),
+        (IterableSlice(range(10), 3), ([0, 1, 2],) * 5),
         (
-            iterable_slice(iter(range(10)), 3),
+            IterableSlice(iter(range(10)), 3),
             ([0, 1, 2], [3, 4, 5], [6, 7, 8], [9], []),
         ),
         (
-            iterable_slice(iter(cyclic(range(5))), 3),
+            IterableSlice(iter(Cyclic(range(5))), 3),
             ([0, 1, 2], [3, 4, 0], [1, 2, 3], [4, 0, 1]),
         ),
     ],
@@ -79,9 +79,9 @@ def test_iterate_multiple_times(
 @pytest.mark.parametrize(
     "iterable, assert_content",
     [
-        (cached(range(5)), True),
-        (pseudo_shuffled(range(20), 5), False),
-        (iterable_slice(cyclic(range(5)), 9), True),
+        (Cached(range(5)), True),
+        (PseudoShuffled(range(20), 5), False),
+        (IterableSlice(Cyclic(range(5)), 9), True),
     ],
 )
 def test_pickle(iterable: Iterable, assert_content: bool):


### PR DESCRIPTION
*Description of changes:*
1. Simplify data loader into a single iterable `DataLoader` type, that does one thing. Legacy `TrainDataLoader`, `ValidationDataLoader`, `InferenceDataLoader` are kept as "alternative constructors" for backward compatibility, they just decorate `DataLoader`'s input/output sequence with very general purpose itertools, in order to get the desired behaviour.
2. Turn some itertools from generators into proper iterable types, so as to make them pickleable, which is needed for multiprocessing.
3. Re-introduce a (optional) `num_batches_per_epoch` argument to the `TrainDataLoader` (removed in #1202) to enable making the data loader of finite length. This allows using this otherwise-infinite-length iterator with other training loops (e.g. PyTorch Lightning) that don't do any slicing on their side, which is usually the case. It's about being general and not making any assumptions on who's going to use this component, that's all.
4. Deprecate the `batch_size` argument to the `Trainer` class. For what it's needed there, `batch_size` can be inferred from the loss shape, otherwise this attribute was simply used from the outside to configure the data loader. This allows using any sequence of batches as training data (as opposed to an object that has the `batch_size` attribute...).
5. Add the `batch_size` attribute and constructor argument to `GluonEstimator` types, and use this to configure data loaders. The default value for this is set to 32, as it was in the `Trainer` class.

Also adding/updating docstrings, documentation sections, and adding more test cases for itertools.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
