### PR TITLE
Make Normalizing Flow a HybridBlock instead of a Block

### DIFF
--- a/src/gluonts/mx/block/sndense.py
+++ b/src/gluonts/mx/block/sndense.py
@@ -19,7 +19,6 @@ import mxnet as mx
 from mxnet import nd
 from mxnet import autograd
 from mxnet import init
-from mxnet.gluon import Block
 
 # First-party imports
 from gluonts.core.component import validated
@@ -31,7 +30,7 @@ from gluonts.mx.activation import get_activation
 EPSILON = 1e-12
 
 
-class SNDense(Block):
+class SNDense(mx.gluon.HybridBlock):
     """
     Dense layer with spectral normalization applied to
     weights, as in [BJC19]_.
@@ -72,11 +71,11 @@ class SNDense(Block):
             )
 
             if use_bias:
-                self.bias = self.params.get(
+                self._bias = self.params.get(
                     "bias", shape=(units,), init=bias_initializer, dtype=dtype
                 )
             else:
-                self.bias = None
+                self._bias = None
 
             if activation is not None:
                 self._act = get_activation(activation, prefix=activation + "_")
@@ -90,7 +89,7 @@ class SNDense(Block):
         )
 
     # noinspection PyMethodOverriding
-    def forward(self, x: Tensor) -> Tensor:
+    def hybrid_forward(self, F, x, _weight, _u, _bias=None):
         """
 
         Parameters
@@ -106,9 +105,9 @@ class SNDense(Block):
         """
         act = nd.FullyConnected(
             data=x,
-            weight=self.weight,
-            bias=self.bias.data(),
-            no_bias=self.bias is None,
+            weight=self._spectral_norm(_weight, _u),
+            bias=_bias,
+            no_bias=_bias is None,
             num_hidden=self._units,
             flatten=self._flatten,
             name="fwd",

--- a/src/gluonts/mx/block/snmlp.py
+++ b/src/gluonts/mx/block/snmlp.py
@@ -17,7 +17,6 @@ import warnings
 
 # Third-party imports
 import mxnet as mx
-from mxnet.gluon import Block
 from mxnet.ndarray import linalg_gemm2 as gemm2
 
 # First-party imports
@@ -28,7 +27,9 @@ from gluonts.mx.activation import get_activation, get_activation_deriv
 from gluonts.mx.block.sndense import SNDense
 
 
-def jacobian_sn_mlp_block_bf(layers: List[Tuple[Block, Tensor]]) -> Tensor:
+def jacobian_sn_mlp_block_bf(
+    layers: List[Tuple[mx.gluon.HybridBlock, Tensor]]
+) -> Tensor:
     """
     Brute force computation of the jacobian of a SNMlpBlock
     jac is of shape (Batch dim1, ..., Output dim, Input dim)
@@ -68,7 +69,7 @@ def jacobian_sn_mlp_block_bf(layers: List[Tuple[Block, Tensor]]) -> Tensor:
     return jac
 
 
-class SNMLPBlock(Block):
+class SNMLPBlock(mx.gluon.HybridBlock):
     @validated()
     def __init__(
         self,
@@ -139,7 +140,7 @@ class SNMLPBlock(Block):
         ]
 
     # noinspection PyMethodOverriding
-    def forward(self, x: Tensor) -> Tensor:
+    def hybrid_forward(self, F, x: Tensor) -> Tensor:
         """
 
         Parameters

--- a/src/gluonts/mx/distribution/bijection.py
+++ b/src/gluonts/mx/distribution/bijection.py
@@ -14,7 +14,7 @@
 from typing import Optional, Union, List
 
 import numpy as np
-from mxnet.gluon.nn import Block
+from mxnet.gluon.nn import HybridBlock
 
 from gluonts.core.component import validated
 from gluonts.mx import Tensor
@@ -230,11 +230,11 @@ class ComposedBijection(Bijection):
         return ComposedBijection(self._bijections + bijections)
 
 
-class BijectionBlock(Block, Bijection):
+class BijectionHybridBlock(HybridBlock, Bijection):
     """Allows a Bijection to have parameters"""
 
 
-class ComposedBijectionBlock(BijectionBlock, ComposedBijection):
+class ComposedBijectionHybridBlock(BijectionHybridBlock, ComposedBijection):
     """
     Allows a ComposedBijection object to have parameters
     """
@@ -246,7 +246,7 @@ class ComposedBijectionBlock(BijectionBlock, ComposedBijection):
         *args,
         **kwargs,
     ) -> None:
-        Block.__init__(self, *args, **kwargs)
+        HybridBlock.__init__(self, *args, **kwargs)
         ComposedBijection.__init__(self, bij_blocks)
 
     def __iadd__(self, bij_blocks: List[Bijection]):

--- a/src/gluonts/mx/distribution/iresnet.py
+++ b/src/gluonts/mx/distribution/iresnet.py
@@ -21,8 +21,8 @@ from gluonts.mx.util import _broadcast_param
 from gluonts.mx.block.snmlp import SNMLPBlock
 from gluonts.mx.distribution.distribution import getF
 from gluonts.mx.distribution.bijection import (
-    BijectionBlock,
-    ComposedBijectionBlock,
+    BijectionHybridBlock,
+    ComposedBijectionHybridBlock,
 )
 
 
@@ -45,7 +45,7 @@ def log_abs_det(A: Tensor) -> Tensor:
     return F.diag(L, axis1=-2, axis2=-1).abs().log().sum(-1)
 
 
-class InvertibleResnetBlock(BijectionBlock):
+class InvertibleResnetHybridBlock(BijectionHybridBlock):
     """
     Based on [BJC19]_,
     apart from f and f_inv that are swapped.
@@ -185,7 +185,7 @@ class InvertibleResnetBlock(BijectionBlock):
         return ladj
 
 
-def iresnet(num_blocks: int, **block_kwargs) -> ComposedBijectionBlock:
+def iresnet(num_blocks: int, **block_kwargs) -> ComposedBijectionHybridBlock:
     """
 
     Parameters
@@ -199,6 +199,9 @@ def iresnet(num_blocks: int, **block_kwargs) -> ComposedBijectionBlock:
     -------
 
     """
-    return ComposedBijectionBlock(
-        [InvertibleResnetBlock(**block_kwargs) for _ in range(num_blocks)]
+    return ComposedBijectionHybridBlock(
+        [
+            InvertibleResnetHybridBlock(**block_kwargs)
+            for _ in range(num_blocks)
+        ]
     )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Normalizing flow is derived from `mx.gluon.Block` which makes it hard to use it in existing gluonts networks that are derived from `mx.gluon.HybridBlock`. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
