### PR TITLE
DeepState: Compute log-density exactly when scaling transformation is…

### DIFF
--- a/src/gluonts/mx/distribution/lds.py
+++ b/src/gluonts/mx/distribution/lds.py
@@ -229,6 +229,12 @@ class LDS(Distribution):
         # TODO: Based on form of the prior decide to do either filtering
         #   or residual-sum-of-squares
         log_p, final_mean, final_cov = self.kalman_filter(x, observed)
+        if scale is not None:
+            # log_abs_det_jac: sum over all the output dimensions.
+            ladj = self.F.sum(self.F.log(scale), axis=-1, keepdims=True)
+
+            # subtract `ladj` for every time step.
+            log_p = self.F.broadcast_sub(log_p, ladj)
         return log_p, final_mean, final_cov
 
     def kalman_filter(

--- a/src/gluonts/mx/distribution/lds.py
+++ b/src/gluonts/mx/distribution/lds.py
@@ -230,11 +230,12 @@ class LDS(Distribution):
         #   or residual-sum-of-squares
         log_p, final_mean, final_cov = self.kalman_filter(x, observed)
         if scale is not None:
-            # log_abs_det_jac: sum over all the output dimensions.
-            ladj = self.F.sum(self.F.log(scale), axis=-1, keepdims=True)
+            F = self.F
+            # log_abs_det_jac: sum over all output dimensions.
+            ladj = -F.sum(F.log(F.abs(scale)), axis=-1, keepdims=True)
 
-            # subtract `ladj` for every time step.
-            log_p = self.F.broadcast_sub(log_p, ladj)
+            # Sum `ladj` over all time steps.
+            log_p = F.broadcast_add(log_p, ladj)
         return log_p, final_mean, final_cov
 
     def kalman_filter(


### PR DESCRIPTION
… used.

*Issue #, if available:*

*Description of changes:*
Log-density for deep state model is off by a constant factor when scaling is used. Other models don't have such problems. Fixing it so that log-density on test data can be used as an evaluation metric.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
