### PR TITLE
Use broadcast_logical_or in inflated_beta

### DIFF
--- a/src/gluonts/model/deepstate/issm.py
+++ b/src/gluonts/model/deepstate/issm.py
@@ -106,19 +106,19 @@ class ISSM:
         pass
 
     def latent_dim(self) -> int:
-        raise NotImplemented()
+        raise NotImplementedError
 
     def output_dim(self) -> int:
-        raise NotImplemented()
+        raise NotImplementedError
 
     def emission_coeff(self, seasonal_indicators: Tensor):
-        raise NotImplemented()
+        raise NotImplementedError
 
     def transition_coeff(self, seasonal_indicators: Tensor):
-        raise NotImplemented()
+        raise NotImplementedError
 
     def innovation_coeff(self, seasonal_indicators: Tensor):
-        raise NotImplemented()
+        raise NotImplementedError
 
     def get_issm_coeff(
         self, seasonal_indicators: Tensor

--- a/src/gluonts/mx/distribution/inflated_beta.py
+++ b/src/gluonts/mx/distribution/inflated_beta.py
@@ -75,7 +75,9 @@ class ZeroAndOneInflatedBeta(MixtureDistribution):
         F = self.F
 
         # mask zeros for the Beta distribution input to prevent NaN gradients
-        inputs = F.where(F.logical_or(x == 0, x == 1), x.zeros_like() + 0.5, x)
+        inputs = F.where(
+            F.broadcast_logical_or(x == 0, x == 1), x.zeros_like() + 0.5, x
+        )
 
         # compute log density, case by case
         return F.where(

--- a/test/distribution/test_inflated_beta.py
+++ b/test/distribution/test_inflated_beta.py
@@ -1,0 +1,52 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import pandas as pd
+import pytest
+
+from gluonts.dataset import common
+from gluonts.model import deepar
+from gluonts.mx.distribution.inflated_beta import ZeroAndOneInflatedBetaOutput
+from gluonts.mx.trainer import Trainer
+
+
+@pytest.mark.parametrize("hybridize", [False, True])
+def test_symbol_and_array(hybridize: bool):
+    # Tests for cases like the one presented in issue 1211, in which the Inflated
+    # Beta outputs used a method only available to arrays and not to symbols.
+    # We simply go through a short training to ensure no exceptions are raised.
+    data = [
+        {
+            "target": [0, 0.0460043, 0.263906, 0.4103112, 1],
+            "start": pd.to_datetime("1999-01-04"),
+        },
+        {
+            "target": [1, 0.65815564, 0.44982578, 0.58875054, 0],
+            "start": pd.to_datetime("1999-01-04"),
+        },
+    ]
+    dataset = common.ListDataset(data, freq="W-MON", one_dim_target=True)
+
+    trainer = Trainer(epochs=1, num_batches_per_epoch=2, hybridize=hybridize)
+
+    estimator = deepar.DeepAREstimator(
+        freq="W",
+        prediction_length=2,
+        trainer=trainer,
+        distr_output=ZeroAndOneInflatedBetaOutput(),
+        context_length=2,
+        batch_size=1,
+        scaling=False,
+    )
+
+    estimator.train(dataset)


### PR DESCRIPTION


*Issue #, if available:* addresses [#1211](https://github.com/awslabs/gluon-ts/issues/1211)

*Description of changes:* The various inflated beta distribution classes used `F.logical_or` to mask ones and zeros (for which the loss function is undefined), but there is no `logical_or` method for `mxnet.symbol`.

We now use `F.broadcast_logical_or` which exists as a method of both `mxnet.ndarray` and `mxnet.symbol`, either of which can be imported as `F`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
