### PR TITLE
Fixed pytorch's predict to numpy helper

### DIFF
--- a/src/gluonts/torch/model/predictor.py
+++ b/src/gluonts/torch/model/predictor.py
@@ -34,7 +34,7 @@ from gluonts.transform import Transformation
 
 @predict_to_numpy.register(nn.Module)
 def _(prediction_net: nn.Module, inputs: torch.Tensor) -> np.ndarray:
-    return prediction_net(*inputs).data.numpy()
+    return prediction_net(*inputs).cpu().numpy()
 
 
 class PyTorchPredictor(Predictor):


### PR DESCRIPTION
currently this does not work when the tensors are on the gpu
