### PR TITLE
Fix type error for using quantile_weights and add a proper Pytest 

### DIFF
--- a/src/gluonts/mx/block/quantile_output.py
+++ b/src/gluonts/mx/block/quantile_output.py
@@ -24,12 +24,12 @@ from gluonts.mx import Tensor
 class QuantileLoss(Loss):
     @validated()
     def __init__(
-        self,
-        quantiles: List[float],
-        quantile_weights: List[float] = None,
-        weight=None,
-        batch_axis=0,
-        **kwargs,
+            self,
+            quantiles: List[float],
+            quantile_weights: List[float] = None,
+            weight=None,
+            batch_axis=0,
+            **kwargs,
     ) -> None:
         """
         Represents the quantile loss used to fit decoders that learn quantiles.
@@ -53,14 +53,14 @@ class QuantileLoss(Loss):
         self.quantiles = quantiles
         self.num_quantiles = len(quantiles)
         self.quantile_weights = (
-            nd.ones(self.num_quantiles) / self.num_quantiles
+            [1.0/self.num_quantiles for i in range(self.num_quantiles)]
             if not quantile_weights
             else quantile_weights
         )
 
     # noinspection PyMethodOverriding
     def hybrid_forward(
-        self, F, y_true: Tensor, y_pred: Tensor, sample_weight=None
+            self, F, y_true: Tensor, y_pred: Tensor, sample_weight=None
     ):
         """
         Compute the weighted sum of quantile losses.
@@ -94,8 +94,8 @@ class QuantileLoss(Loss):
         for i, y_pred_q in enumerate(y_pred_all):
             q = self.quantiles[i]
             weighted_qt = (
-                self.compute_quantile_loss(F, y_true, y_pred_q, q)
-                * self.quantile_weights[i].asscalar()
+                    self.compute_quantile_loss(F, y_true, y_pred_q, q)
+                    * self.quantile_weights[i]
             )
             qt_loss.append(weighted_qt)
         stacked_qt_losses = F.stack(*qt_loss, axis=-1)
@@ -109,7 +109,7 @@ class QuantileLoss(Loss):
 
     @staticmethod
     def compute_quantile_loss(
-        F, y_true: Tensor, y_pred_p: Tensor, p: float
+            F, y_true: Tensor, y_pred_p: Tensor, p: float
     ) -> Tensor:
         """
         Compute the quantile loss of the given quantile
@@ -198,9 +198,9 @@ class QuantileOutput:
 
     @validated()
     def __init__(
-        self,
-        quantiles: List[float],
-        quantile_weights: Optional[List[float]] = None,
+            self,
+            quantiles: List[float],
+            quantile_weights: Optional[List[float]] = None,
     ) -> None:
         self.quantiles = quantiles
         self.quantile_weights = quantile_weights

--- a/src/gluonts/mx/block/quantile_output.py
+++ b/src/gluonts/mx/block/quantile_output.py
@@ -53,7 +53,7 @@ class QuantileLoss(Loss):
         self.quantiles = quantiles
         self.num_quantiles = len(quantiles)
         self.quantile_weights = (
-            [1.0/self.num_quantiles for i in range(self.num_quantiles)]
+            [1.0 / self.num_quantiles for i in range(self.num_quantiles)]
             if not quantile_weights
             else quantile_weights
         )

--- a/src/gluonts/mx/block/quantile_output.py
+++ b/src/gluonts/mx/block/quantile_output.py
@@ -109,7 +109,7 @@ class QuantileLoss(Loss):
 
     @staticmethod
     def compute_quantile_loss(
-            F, y_true: Tensor, y_pred_p: Tensor, p: float
+        F, y_true: Tensor, y_pred_p: Tensor, p: float
     ) -> Tensor:
         """
         Compute the quantile loss of the given quantile

--- a/src/gluonts/mx/block/quantile_output.py
+++ b/src/gluonts/mx/block/quantile_output.py
@@ -24,12 +24,12 @@ from gluonts.mx import Tensor
 class QuantileLoss(Loss):
     @validated()
     def __init__(
-            self,
-            quantiles: List[float],
-            quantile_weights: List[float] = None,
-            weight=None,
-            batch_axis=0,
-            **kwargs,
+        self,
+        quantiles: List[float],
+        quantile_weights: List[float] = None,
+        weight=None,
+        batch_axis=0,
+        **kwargs,
     ) -> None:
         """
         Represents the quantile loss used to fit decoders that learn quantiles.
@@ -60,7 +60,7 @@ class QuantileLoss(Loss):
 
     # noinspection PyMethodOverriding
     def hybrid_forward(
-            self, F, y_true: Tensor, y_pred: Tensor, sample_weight=None
+        self, F, y_true: Tensor, y_pred: Tensor, sample_weight=None
     ):
         """
         Compute the weighted sum of quantile losses.
@@ -94,8 +94,8 @@ class QuantileLoss(Loss):
         for i, y_pred_q in enumerate(y_pred_all):
             q = self.quantiles[i]
             weighted_qt = (
-                    self.compute_quantile_loss(F, y_true, y_pred_q, q)
-                    * self.quantile_weights[i]
+                self.compute_quantile_loss(F, y_true, y_pred_q, q)
+                * self.quantile_weights[i]
             )
             qt_loss.append(weighted_qt)
         stacked_qt_losses = F.stack(*qt_loss, axis=-1)
@@ -198,9 +198,9 @@ class QuantileOutput:
 
     @validated()
     def __init__(
-            self,
-            quantiles: List[float],
-            quantile_weights: Optional[List[float]] = None,
+        self,
+        quantiles: List[float],
+        quantile_weights: Optional[List[float]] = None,
     ) -> None:
         self.quantiles = quantiles
         self.quantile_weights = quantile_weights

--- a/src/gluonts/mx/distribution/lds.py
+++ b/src/gluonts/mx/distribution/lds.py
@@ -229,6 +229,13 @@ class LDS(Distribution):
         # TODO: Based on form of the prior decide to do either filtering
         #   or residual-sum-of-squares
         log_p, final_mean, final_cov = self.kalman_filter(x, observed)
+        if scale is not None:
+            F = self.F
+            # log_abs_det_jac: sum over all output dimensions.
+            ladj = -F.sum(F.log(F.abs(scale)), axis=-1, keepdims=True)
+
+            # Sum `ladj` over all time steps.
+            log_p = F.broadcast_add(log_p, ladj)
         return log_p, final_mean, final_cov
 
     def kalman_filter(

--- a/test/model/seq2seq/test_quantile_loss.py
+++ b/test/model/seq2seq/test_quantile_loss.py
@@ -15,7 +15,6 @@ from mxnet import nd
 
 from gluonts.mx.block.quantile_output import QuantileLoss
 
-
 def test_compute_quantile_loss() -> None:
     y_true = nd.ones(shape=(10, 10, 10))
     y_pred = nd.zeros(shape=(10, 10, 10, 2))
@@ -36,3 +35,21 @@ def test_compute_quantile_loss() -> None:
             - correct_qt_loss[idx]
             < 1e-5
         ), f"computing quantile loss at quantile {q} fails!"
+
+def test_compute_weighted_quantile_loss() -> None:
+    y_true = nd.ones(shape=(10, 10, 10))
+    y_pred = nd.zeros(shape=(10, 10, 10, 2))
+
+    quantiles = [0.5, 0.9]
+    quantile_weights = [0.5, 0.5]
+
+    loss = QuantileLoss(quantiles, quantile_weights)
+    # print(nd.mean(loss(y_true, y_pred)))
+    correct_weighted_qt_loss = 1.4
+    assert (
+        nd.mean(
+            loss(y_true, y_pred)
+        )
+        - correct_weighted_qt_loss
+        < 1e+2
+    ), f"computing weighted quantile loss fails!"

--- a/test/model/seq2seq/test_quantile_loss.py
+++ b/test/model/seq2seq/test_quantile_loss.py
@@ -48,18 +48,3 @@ def test_compute_quantile_loss(quantile_weights, correct_qt_loss) -> None:
             nd.mean(loss(y_true, y_pred)) - correct_qt_loss < 1e-5
         ), f"computing weighted quantile loss fails!"
 
-
-#
-# def test_compute_weighted_quantile_loss() -> None:
-#     y_true = nd.ones(shape=(10, 10, 10))
-#     y_pred = nd.zeros(shape=(10, 10, 10, 2))
-#
-#     quantiles = [0.5, 0.9]
-#     quantile_weights = [0.5, 0.5]
-#
-#     loss = QuantileLoss(quantiles, quantile_weights)
-#     # print(nd.mean(loss(y_true, y_pred)))
-#     correct_weighted_qt_loss = 1.4
-#     assert (
-#         nd.mean(loss(y_true, y_pred)) - correct_weighted_qt_loss < 1e2
-#     ), f"computing weighted quantile loss fails!"

--- a/test/model/seq2seq/test_quantile_loss.py
+++ b/test/model/seq2seq/test_quantile_loss.py
@@ -31,8 +31,8 @@ def test_compute_quantile_loss(quantile_weights, correct_qt_loss) -> None:
     quantiles = [0.5, 0.9]
 
     loss = QuantileLoss(quantiles, quantile_weights)
-    print(quantile_weights, correct_qt_loss)
-    if quantile_weights == None:
+    tol = 1e-5
+    if not quantile_weights:
         for idx, q in enumerate(quantiles):
             assert (
                 nd.mean(
@@ -41,9 +41,9 @@ def test_compute_quantile_loss(quantile_weights, correct_qt_loss) -> None:
                     )
                 )
                 - correct_qt_loss[idx]
-                < 1e-5
+                < tol
             ), f"computing quantile loss at quantile {q} fails!"
     else:
         assert (
-            nd.mean(loss(y_true, y_pred)) - correct_qt_loss < 1e-5
+            nd.mean(loss(y_true, y_pred)) - correct_qt_loss < tol
         ), f"computing weighted quantile loss fails!"

--- a/test/model/seq2seq/test_quantile_loss.py
+++ b/test/model/seq2seq/test_quantile_loss.py
@@ -47,4 +47,3 @@ def test_compute_quantile_loss(quantile_weights, correct_qt_loss) -> None:
         assert (
             nd.mean(loss(y_true, y_pred)) - correct_qt_loss < 1e-5
         ), f"computing weighted quantile loss fails!"
-

--- a/test/model/seq2seq/test_quantile_loss.py
+++ b/test/model/seq2seq/test_quantile_loss.py
@@ -37,6 +37,7 @@ def test_compute_quantile_loss() -> None:
             < 1e-5
         ), f"computing quantile loss at quantile {q} fails!"
 
+
 def test_compute_weighted_quantile_loss() -> None:
     y_true = nd.ones(shape=(10, 10, 10))
     y_pred = nd.zeros(shape=(10, 10, 10, 2))
@@ -48,9 +49,5 @@ def test_compute_weighted_quantile_loss() -> None:
     # print(nd.mean(loss(y_true, y_pred)))
     correct_weighted_qt_loss = 1.4
     assert (
-        nd.mean(
-            loss(y_true, y_pred)
-        )
-        - correct_weighted_qt_loss
-        < 1e+2
+        nd.mean(loss(y_true, y_pred)) - correct_weighted_qt_loss < 1e2
     ), f"computing weighted quantile loss fails!"

--- a/test/model/seq2seq/test_quantile_loss.py
+++ b/test/model/seq2seq/test_quantile_loss.py
@@ -15,6 +15,7 @@ from mxnet import nd
 
 from gluonts.mx.block.quantile_output import QuantileLoss
 
+
 def test_compute_quantile_loss() -> None:
     y_true = nd.ones(shape=(10, 10, 10))
     y_pred = nd.zeros(shape=(10, 10, 10, 2))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Quantile loss class has an argument 'quantile_weights' which is set to be 'None' as a default. This argument is going to be used when computing approximate CRPS loss.

1. I found the bug when this argument is passed. The type must be 'List', but it is operated under nd.array.asscalar(), giving error as follows 

`E           AttributeError: 'float' object has no attribute 'asscalar'`
`Python-gluonts/src/gluonts/mx/block/quantile_output.py:101: AttributeError`


2.  Fixed the type/AttributeError and added a proper pytest example under 'test_quantile_loss.py' file. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
