### PR TITLE
Fix time features ranges, split unnormalized features

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 holidays>=0.9
 matplotlib~=3.0
 numpy~=1.16
-pandas>=1.0
+pandas~=1.1
 pydantic~=1.1,<1.7
 tqdm~=4.23
 toolz~=0.10

--- a/src/gluonts/model/deepstate/issm.py
+++ b/src/gluonts/model/deepstate/issm.py
@@ -20,12 +20,12 @@ from gluonts.mx import Tensor
 from gluonts.mx.distribution.distribution import getF
 from gluonts.mx.util import _broadcast_param
 from gluonts.time_feature import (
-    DayOfWeek,
-    HourOfDay,
-    MinuteOfHour,
-    MonthOfYear,
     TimeFeature,
-    WeekOfYear,
+    DayOfWeekIndex,
+    HourOfDayIndex,
+    MinuteOfHourIndex,
+    MonthOfYearIndex,
+    WeekOfYearIndex,
 )
 
 
@@ -310,19 +310,19 @@ class CompositeISSM(ISSM):
     def seasonal_features(cls, freq: str) -> List[TimeFeature]:
         offset = to_offset(freq)
         if offset.name == "M":
-            return [MonthOfYear(normalized=False)]
+            return [MonthOfYearIndex()]
         elif offset.name == "W-SUN":
-            return [WeekOfYear(normalized=False)]
+            return [WeekOfYearIndex()]
         elif offset.name == "D":
-            return [DayOfWeek(normalized=False)]
+            return [DayOfWeekIndex()]
         elif offset.name == "B":  # TODO: check this case
-            return [DayOfWeek(normalized=False)]
+            return [DayOfWeekIndex()]
         elif offset.name == "H":
-            return [HourOfDay(normalized=False), DayOfWeek(normalized=False)]
+            return [HourOfDayIndex(), DayOfWeekIndex()]
         elif offset.name == "T":
             return [
-                MinuteOfHour(normalized=False),
-                HourOfDay(normalized=False),
+                MinuteOfHourIndex(),
+                HourOfDayIndex(),
             ]
         else:
             RuntimeError(f"Unsupported frequency {offset.name}")

--- a/src/gluonts/time_feature/__init__.py
+++ b/src/gluonts/time_feature/__init__.py
@@ -12,14 +12,21 @@
 # permissions and limitations under the License.
 
 from ._base import (
+    TimeFeature,
     DayOfMonth,
     DayOfWeek,
     DayOfYear,
     HourOfDay,
     MinuteOfHour,
     MonthOfYear,
-    TimeFeature,
     WeekOfYear,
+    DayOfMonthIndex,
+    DayOfWeekIndex,
+    DayOfYearIndex,
+    HourOfDayIndex,
+    MinuteOfHourIndex,
+    MonthOfYearIndex,
+    WeekOfYearIndex,
     time_features_from_frequency_str,
 )
 from .holiday import SPECIAL_DATE_FEATURES, SpecialDateFeatureSet
@@ -35,6 +42,14 @@ __all__ = [
     "MonthOfYear",
     "TimeFeature",
     "WeekOfYear",
+    "DayOfMonthIndex",
+    "DayOfWeekIndex",
+    "DayOfYearIndex",
+    "HourOfDayIndex",
+    "MinuteOfHourIndex",
+    "MonthOfYearIndex",
+    "TimeFeatureIndex",
+    "WeekOfYearIndex",
     "SPECIAL_DATE_FEATURES",
     "SpecialDateFeatureSet",
     "get_lags_for_frequency",

--- a/src/gluonts/time_feature/__init__.py
+++ b/src/gluonts/time_feature/__init__.py
@@ -34,13 +34,13 @@ from .lag import get_lags_for_frequency
 from .seasonality import get_seasonality
 
 __all__ = [
+    "TimeFeature",
     "DayOfMonth",
     "DayOfWeek",
     "DayOfYear",
     "HourOfDay",
     "MinuteOfHour",
     "MonthOfYear",
-    "TimeFeature",
     "WeekOfYear",
     "DayOfMonthIndex",
     "DayOfWeekIndex",
@@ -48,7 +48,6 @@ __all__ = [
     "HourOfDayIndex",
     "MinuteOfHourIndex",
     "MonthOfYearIndex",
-    "TimeFeatureIndex",
     "WeekOfYearIndex",
     "SPECIAL_DATE_FEATURES",
     "SpecialDateFeatureSet",

--- a/src/gluonts/time_feature/_base.py
+++ b/src/gluonts/time_feature/_base.py
@@ -27,8 +27,8 @@ class TimeFeature:
     """
 
     @validated()
-    def __init__(self, normalized: bool = True):
-        self.normalized = normalized
+    def __init__(self):
+        pass
 
     def __call__(self, index: pd.DatetimeIndex) -> np.ndarray:
         pass
@@ -38,87 +38,101 @@ class TimeFeature:
 
 
 class MinuteOfHour(TimeFeature):
-    """
-    Minute of hour encoded as value between [-0.5, 0.5]
-    """
+    """Minute of hour encoded as value between [-0.5, 0.5]"""
 
     def __call__(self, index: pd.DatetimeIndex) -> np.ndarray:
-        if self.normalized:
-            return index.minute / 59.0 - 0.5
-        else:
-            return index.minute.map(float)
+        return index.minute / 59.0 - 0.5
+
+
+class MinuteOfHourIndex(TimeFeature):
+    """Minute of hour encoded as zero-based index, between 0 and 59"""
+
+    def __call__(self, index: pd.DatetimeIndex) -> np.ndarray:
+        return index.minute.map(float)
 
 
 class HourOfDay(TimeFeature):
-    """
-    Hour of day encoded as value between [-0.5, 0.5]
-    """
+    """Hour of day encoded as value between [-0.5, 0.5]"""
 
     def __call__(self, index: pd.DatetimeIndex) -> np.ndarray:
-        if self.normalized:
-            return index.hour / 23.0 - 0.5
-        else:
-            return index.hour.map(float)
+        return index.hour / 23.0 - 0.5
+
+
+class HourOfDayIndex(TimeFeature):
+    """Hour of day encoded as zero-based index, between 0 and 23"""
+
+    def __call__(self, index: pd.DatetimeIndex) -> np.ndarray:
+        return index.hour.map(float)
 
 
 class DayOfWeek(TimeFeature):
-    """
-    Hour of day encoded as value between [-0.5, 0.5]
-    """
+    """Hour of day encoded as value between [-0.5, 0.5]"""
 
     def __call__(self, index: pd.DatetimeIndex) -> np.ndarray:
-        if self.normalized:
-            return index.dayofweek / 6.0 - 0.5
-        else:
-            return index.dayofweek.map(float)
+        return index.dayofweek / 6.0 - 0.5
+
+
+class DayOfWeekIndex(TimeFeature):
+    """Hour of day encoded as zero-based index, between 0 and 6"""
+
+    def __call__(self, index: pd.DatetimeIndex) -> np.ndarray:
+        return index.dayofweek.map(float)
 
 
 class DayOfMonth(TimeFeature):
-    """
-    Day of month encoded as value between [-0.5, 0.5]
-    """
+    """Day of month encoded as value between [-0.5, 0.5]"""
 
     def __call__(self, index: pd.DatetimeIndex) -> np.ndarray:
-        if self.normalized:
-            return (index.day - 1) / 30.0 - 0.5
-        else:
-            return (index.day - 1).map(float)
+        return (index.day - 1) / 30.0 - 0.5
+
+
+class DayOfMonthIndex(TimeFeature):
+    """Day of month encoded as zero-based index, between 0 and 11"""
+
+    def __call__(self, index: pd.DatetimeIndex) -> np.ndarray:
+        return (index.day - 1).map(float)
 
 
 class DayOfYear(TimeFeature):
-    """
-    Day of year encoded as value between [-0.5, 0.5]
-    """
+    """Day of year encoded as value between [-0.5, 0.5]"""
 
     def __call__(self, index: pd.DatetimeIndex) -> np.ndarray:
-        if self.normalized:
-            return (index.dayofyear - 1) / 365.0 - 0.5
-        else:
-            return (index.dayofyear - 1).map(float)
+        return (index.dayofyear - 1) / 365.0 - 0.5
+
+
+class DayOfYearIndex(TimeFeature):
+    """Day of year encoded as zero-based index, between 0 and 365"""
+
+    def __call__(self, index: pd.DatetimeIndex) -> np.ndarray:
+        return (index.dayofyear - 1).map(float)
 
 
 class MonthOfYear(TimeFeature):
-    """
-    Month of year encoded as value between [-0.5, 0.5]
-    """
+    """Month of year encoded as value between [-0.5, 0.5]"""
 
     def __call__(self, index: pd.DatetimeIndex) -> np.ndarray:
-        if self.normalized:
-            return (index.month - 1) / 11.0 - 0.5
-        else:
-            return (index.month - 1).map(float)
+        return (index.month - 1) / 11.0 - 0.5
+
+
+class MonthOfYearIndex(TimeFeature):
+    """Month of year encoded as zero-based index, between 0 and 11"""
+
+    def __call__(self, index: pd.DatetimeIndex) -> np.ndarray:
+        return (index.month - 1).map(float)
 
 
 class WeekOfYear(TimeFeature):
-    """
-    Week of year encoded as value between [-0.5, 0.5]
-    """
+    """Week of year encoded as value between [-0.5, 0.5]"""
 
     def __call__(self, index: pd.DatetimeIndex) -> np.ndarray:
-        if self.normalized:
-            return (index.isocalendar().week - 1) / 52.0 - 0.5
-        else:
-            return (index.isocalendar().week - 1).map(float)
+        return (index.isocalendar().week - 1) / 52.0 - 0.5
+
+
+class WeekOfYearIndex(TimeFeature):
+    """Week of year encoded as zero-based index, between 0 and 52"""
+
+    def __call__(self, index: pd.DatetimeIndex) -> np.ndarray:
+        return (index.isocalendar().week - 1).map(float)
 
 
 def time_features_from_frequency_str(freq_str: str) -> List[TimeFeature]:

--- a/src/gluonts/time_feature/_base.py
+++ b/src/gluonts/time_feature/_base.py
@@ -116,9 +116,9 @@ class WeekOfYear(TimeFeature):
 
     def __call__(self, index: pd.DatetimeIndex) -> np.ndarray:
         if self.normalized:
-            return (index.weekofyear - 1) / 52.0 - 0.5
+            return (index.isocalendar().week - 1) / 52.0 - 0.5
         else:
-            return (index.weekofyear - 1).map(float)
+            return (index.isocalendar().week - 1).map(float)
 
 
 def time_features_from_frequency_str(freq_str: str) -> List[TimeFeature]:

--- a/src/gluonts/time_feature/_base.py
+++ b/src/gluonts/time_feature/_base.py
@@ -80,9 +80,9 @@ class DayOfMonth(TimeFeature):
 
     def __call__(self, index: pd.DatetimeIndex) -> np.ndarray:
         if self.normalized:
-            return index.day / 30.0 - 0.5
+            return (index.day - 1) / 30.0 - 0.5
         else:
-            return index.day.map(float)
+            return (index.day - 1).map(float)
 
 
 class DayOfYear(TimeFeature):
@@ -92,9 +92,9 @@ class DayOfYear(TimeFeature):
 
     def __call__(self, index: pd.DatetimeIndex) -> np.ndarray:
         if self.normalized:
-            return index.dayofyear / 364.0 - 0.5
+            return (index.dayofyear - 1) / 365.0 - 0.5
         else:
-            return index.dayofyear.map(float)
+            return (index.dayofyear - 1).map(float)
 
 
 class MonthOfYear(TimeFeature):
@@ -104,9 +104,9 @@ class MonthOfYear(TimeFeature):
 
     def __call__(self, index: pd.DatetimeIndex) -> np.ndarray:
         if self.normalized:
-            return index.month / 11.0 - 0.5
+            return (index.month - 1) / 11.0 - 0.5
         else:
-            return index.month.map(float)
+            return (index.month - 1).map(float)
 
 
 class WeekOfYear(TimeFeature):
@@ -116,9 +116,9 @@ class WeekOfYear(TimeFeature):
 
     def __call__(self, index: pd.DatetimeIndex) -> np.ndarray:
         if self.normalized:
-            return index.weekofyear / 51.0 - 0.5
+            return (index.weekofyear - 1) / 52.0 - 0.5
         else:
-            return index.weekofyear.map(float)
+            return (index.weekofyear - 1).map(float)
 
 
 def time_features_from_frequency_str(freq_str: str) -> List[TimeFeature]:

--- a/test/time_feature/test_features.py
+++ b/test/time_feature/test_features.py
@@ -1,0 +1,95 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from gluonts.time_feature import (
+    TimeFeature,
+    MinuteOfHour,
+    HourOfDay,
+    DayOfWeek,
+    DayOfMonth,
+    DayOfYear,
+    WeekOfYear,
+    MonthOfYear,
+)
+
+
+@pytest.mark.parametrize(
+    "feature, index",
+    [
+        (
+            MinuteOfHour(),
+            pd.date_range(
+                "01-01-2015 00:00:00", periods=60 * 2 * 24, freq="1min"
+            ),
+        ),
+        (
+            HourOfDay(),
+            pd.date_range("01-01-2015 00:00:00", periods=14 * 24, freq="1h"),
+        ),
+        (DayOfWeek(), pd.date_range("01-01-2015", periods=365 * 5, freq="D")),
+        (DayOfMonth(), pd.date_range("01-01-2015", periods=365 * 5, freq="D")),
+        (DayOfYear(), pd.date_range("01-01-2015", periods=365 * 5, freq="D")),
+        (WeekOfYear(), pd.date_range("01-01-2015", periods=53 * 5, freq="W")),
+        (MonthOfYear(), pd.date_range("01-01-2015", periods=12 * 5, freq="M")),
+    ],
+)
+def test_feature_normalized_bounds(
+    feature: TimeFeature, index: pd.DatetimeIndex
+):
+    values = feature(index)
+    for v in values:
+        assert -0.5 <= v <= 0.5
+
+
+@pytest.mark.parametrize(
+    "feature, index, cardinality",
+    [
+        (
+            MinuteOfHour(normalized=False),
+            pd.date_range(
+                "01-01-2015 00:00:00", periods=60 * 2 * 24, freq="1min"
+            ),
+            60,
+        ),
+        (
+            HourOfDay(normalized=False),
+            pd.date_range("01-01-2015 00:00:00", periods=14 * 24, freq="1h"),
+            24,
+        ),
+        (
+            DayOfWeek(normalized=False),
+            pd.date_range("01-01-2015", periods=365 * 5, freq="D"),
+            7,
+        ),
+        (
+            DayOfMonth(normalized=False),
+            pd.date_range("01-01-2015", periods=365 * 5, freq="D"),
+            31,
+        ),
+        (
+            DayOfYear(normalized=False),
+            pd.date_range("01-01-2015", periods=365 * 5, freq="D"),
+            366,
+        ),
+        (
+            WeekOfYear(normalized=False),
+            pd.date_range("01-01-2015", periods=53 * 5, freq="W"),
+            53,
+        ),
+        (
+            MonthOfYear(normalized=False),
+            pd.date_range("01-01-2015", periods=12 * 5, freq="M"),
+            12,
+        ),
+    ],
+)
+def test_feature_unnormalized_bounds(
+    feature: TimeFeature, index: pd.DatetimeIndex, cardinality: int
+):
+    values = feature(index)
+    counts = [0] * cardinality
+    for v in values:
+        assert 0 <= int(v) < cardinality
+        counts[int(v)] += 1
+    assert all(c > 0 for c in counts)

--- a/test/time_feature/test_features.py
+++ b/test/time_feature/test_features.py
@@ -24,6 +24,13 @@ from gluonts.time_feature import (
     DayOfYear,
     WeekOfYear,
     MonthOfYear,
+    MinuteOfHourIndex,
+    HourOfDayIndex,
+    DayOfWeekIndex,
+    DayOfMonthIndex,
+    DayOfYearIndex,
+    WeekOfYearIndex,
+    MonthOfYearIndex,
 )
 
 
@@ -59,39 +66,39 @@ def test_feature_normalized_bounds(
     "feature, index, cardinality",
     [
         (
-            MinuteOfHour(normalized=False),
+            MinuteOfHourIndex(),
             pd.date_range(
                 "01-01-2015 00:00:00", periods=60 * 2 * 24, freq="1min"
             ),
             60,
         ),
         (
-            HourOfDay(normalized=False),
+            HourOfDayIndex(),
             pd.date_range("01-01-2015 00:00:00", periods=14 * 24, freq="1h"),
             24,
         ),
         (
-            DayOfWeek(normalized=False),
+            DayOfWeekIndex(),
             pd.date_range("01-01-2015", periods=365 * 5, freq="D"),
             7,
         ),
         (
-            DayOfMonth(normalized=False),
+            DayOfMonthIndex(),
             pd.date_range("01-01-2015", periods=365 * 5, freq="D"),
             31,
         ),
         (
-            DayOfYear(normalized=False),
+            DayOfYearIndex(),
             pd.date_range("01-01-2015", periods=365 * 5, freq="D"),
             366,
         ),
         (
-            WeekOfYear(normalized=False),
+            WeekOfYearIndex(),
             pd.date_range("01-01-2015", periods=53 * 5, freq="W"),
             53,
         ),
         (
-            MonthOfYear(normalized=False),
+            MonthOfYearIndex(),
             pd.date_range("01-01-2015", periods=12 * 5, freq="M"),
             12,
         ),

--- a/test/time_feature/test_features.py
+++ b/test/time_feature/test_features.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
 import numpy as np
 import pandas as pd
 import pytest


### PR DESCRIPTION
*Description of changes:* This PR adds a test for the expected ranges of time features, and fixes the features so that they fall within them. At the same time it splits the `normalized=False` case in separate classes.

A pandas deprecation (`DatetimeIndex.weekofyear`) has been updated as per the docs (https://pandas.pydata.org/docs/reference/api/pandas.DatetimeIndex.weekofyear.html#pandas.DatetimeIndex.weekofyear) and the requirement has been bumped accordingly.

*Background:* Some time features are out of the `[-0.5, 0.5]` range (or `[0, cardinality)` when not normalized) because some of them are 1-based in pandas. Some of them were also slightly off because of edge cases (e.g. leap years).

This is a problem mainly for state space models that use unnormalized features to construct ISSM coefficients, but in any case it doesn't reflect the docstring correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
