### PR TITLE
Input masking and scaling in NBEATS (following authors' implementation)

### DIFF
--- a/src/gluonts/model/n_beats/_estimator.py
+++ b/src/gluonts/model/n_beats/_estimator.py
@@ -27,6 +27,7 @@ from gluonts.transform import (
     InstanceSplitter,
     Transformation,
     InstanceSampler,
+    AddObservedValuesIndicator,
 )
 
 from ._network import (
@@ -105,6 +106,8 @@ class NBEATSEstimator(GluonEstimator):
         Controls the sampling of windows during training.
     batch_size
         The size of the batches to be used training and prediction.
+    scale
+        if True scales the input observations by the mean
     kwargs
         Arguments passed to 'GluonEstimator'.
     """
@@ -130,6 +133,7 @@ class NBEATSEstimator(GluonEstimator):
         loss_function: Optional[str] = "MAPE",
         train_sampler: InstanceSampler = ExpectedNumInstanceSampler(1.0),
         batch_size: int = 32,
+        scale: Optional[bool] = True,
         **kwargs,
     ) -> None:
         """
@@ -151,6 +155,7 @@ class NBEATSEstimator(GluonEstimator):
         ), f"The loss function has to be one of the following: {VALID_LOSS_FUNCTIONS}."
 
         self.freq = freq
+        self.scale = scale
         self.prediction_length = prediction_length
         self.context_length = (
             context_length
@@ -244,6 +249,11 @@ class NBEATSEstimator(GluonEstimator):
     def create_transformation(self) -> Transformation:
         return Chain(
             [
+                AddObservedValuesIndicator(
+                    target_field=FieldName.TARGET,
+                    output_field=FieldName.OBSERVED_VALUES,
+                    dtype=self.dtype,
+                ),
                 InstanceSplitter(
                     target_field=FieldName.TARGET,
                     is_pad_field=FieldName.IS_PAD,
@@ -252,7 +262,7 @@ class NBEATSEstimator(GluonEstimator):
                     train_sampler=self.train_sampler,
                     past_length=self.context_length,
                     future_length=self.prediction_length,
-                    time_series_fields=[],
+                    time_series_fields=[FieldName.OBSERVED_VALUES],
                 )
             ]
         )
@@ -273,6 +283,7 @@ class NBEATSEstimator(GluonEstimator):
             stack_types=self.stack_types,
             loss_function=self.loss_function,
             freq=self.freq,
+            scale=self.scale
         )
 
     # we now define how the prediction happens given that we are provided a
@@ -291,6 +302,7 @@ class NBEATSEstimator(GluonEstimator):
             sharing=self.sharing,
             stack_types=self.stack_types,
             params=trained_network.collect_params(),
+            scale=self.scale
         )
 
         return RepresentableBlockPredictor(

--- a/src/gluonts/model/n_beats/_estimator.py
+++ b/src/gluonts/model/n_beats/_estimator.py
@@ -133,7 +133,7 @@ class NBEATSEstimator(GluonEstimator):
         loss_function: Optional[str] = "MAPE",
         train_sampler: InstanceSampler = ExpectedNumInstanceSampler(1.0),
         batch_size: int = 32,
-        scale: Optional[bool] = True,
+        scale: Optional[bool] = False,
         **kwargs,
     ) -> None:
         """

--- a/src/gluonts/model/n_beats/_estimator.py
+++ b/src/gluonts/model/n_beats/_estimator.py
@@ -133,7 +133,7 @@ class NBEATSEstimator(GluonEstimator):
         loss_function: Optional[str] = "MAPE",
         train_sampler: InstanceSampler = ExpectedNumInstanceSampler(1.0),
         batch_size: int = 32,
-        scale: Optional[bool] = False,
+        scale: bool = False,
         **kwargs,
     ) -> None:
         """

--- a/src/gluonts/model/n_beats/_estimator.py
+++ b/src/gluonts/model/n_beats/_estimator.py
@@ -263,7 +263,7 @@ class NBEATSEstimator(GluonEstimator):
                     past_length=self.context_length,
                     future_length=self.prediction_length,
                     time_series_fields=[FieldName.OBSERVED_VALUES],
-                )
+                ),
             ]
         )
 
@@ -283,7 +283,7 @@ class NBEATSEstimator(GluonEstimator):
             stack_types=self.stack_types,
             loss_function=self.loss_function,
             freq=self.freq,
-            scale=self.scale
+            scale=self.scale,
         )
 
     # we now define how the prediction happens given that we are provided a
@@ -302,7 +302,7 @@ class NBEATSEstimator(GluonEstimator):
             sharing=self.sharing,
             stack_types=self.stack_types,
             params=trained_network.collect_params(),
-            scale=self.scale
+            scale=self.scale,
         )
 
         return RepresentableBlockPredictor(

--- a/src/gluonts/model/n_beats/_network.py
+++ b/src/gluonts/model/n_beats/_network.py
@@ -517,7 +517,13 @@ class NBEATSNetwork(mx.gluon.HybridBlock):
                     )
 
     # noinspection PyMethodOverriding,PyPep8Naming
-    def hybrid_forward(self, F, past_target: Tensor, past_observed_values: Tensor, future_observed_values: Tensor):
+    def hybrid_forward(
+        self,
+        F,
+        past_target: Tensor,
+        past_observed_values: Tensor,
+        future_observed_values: Tensor,
+    ):
 
         past_target, scale = self.scaler(past_target, past_observed_values)
 
@@ -536,11 +542,11 @@ class NBEATSNetwork(mx.gluon.HybridBlock):
 
         forecast = F.broadcast_mul(forecast, scale)
 
-        return forecast if future_observed_values is None else forecast * future_observed_values
-
-
-
-
+        return (
+            forecast
+            if future_observed_values is None
+            else forecast * future_observed_values
+        )
 
     def smape_loss(self, F, forecast: Tensor, future_target: Tensor) -> Tensor:
         r"""
@@ -639,8 +645,12 @@ class NBEATSTrainingNetwork(NBEATSNetwork):
 
     # noinspection PyMethodOverriding,PyPep8Naming
     def hybrid_forward(
-            self, F, past_target: Tensor, future_target: Tensor,
-            past_observed_values: Tensor, future_observed_values: Tensor
+        self,
+        F,
+        past_target: Tensor,
+        future_target: Tensor,
+        past_observed_values: Tensor,
+        future_observed_values: Tensor,
     ) -> Tensor:
         """
 
@@ -666,9 +676,10 @@ class NBEATSTrainingNetwork(NBEATSNetwork):
             Loss tensor. Shape: (batch_size, ).
         """
         forecast = super().hybrid_forward(
-            F, past_target=past_target,
+            F,
+            past_target=past_target,
             past_observed_values=past_observed_values,
-            future_observed_values=future_observed_values
+            future_observed_values=future_observed_values,
         )
 
         if self.loss_function == "sMAPE":
@@ -694,8 +705,12 @@ class NBEATSPredictionNetwork(NBEATSNetwork):
 
     # noinspection PyMethodOverriding,PyPep8Naming
     def hybrid_forward(
-            self, F, past_target: Tensor, future_target: Tensor = None,
-            past_observed_values: Tensor = None, future_observed_values: Tensor = None,
+        self,
+        F,
+        past_target: Tensor,
+        future_target: Tensor = None,
+        past_observed_values: Tensor = None,
+        future_observed_values: Tensor = None,
     ) -> Tensor:
         """
 
@@ -719,9 +734,10 @@ class NBEATSPredictionNetwork(NBEATSNetwork):
             Prediction sample. Shape: (batch_size, 1, prediction_length).
         """
         forecasts = super().hybrid_forward(
-            F, past_target=past_target,
+            F,
+            past_target=past_target,
             past_observed_values=past_observed_values,
-            future_observed_values=None
+            future_observed_values=None,
         )
 
         # dimension collapsed previously because we only have one sample each:

--- a/src/gluonts/model/n_beats/_network.py
+++ b/src/gluonts/model/n_beats/_network.py
@@ -522,7 +522,8 @@ class NBEATSNetwork(mx.gluon.HybridBlock):
         F,
         past_target: Tensor,
         past_observed_values: Tensor,
-        future_observed_values: Tensor,
+        future_target: Optional[Tensor],
+        future_observed_values: Optional[Tensor],
     ):
 
         past_target, scale = self.scaler(past_target, past_observed_values)
@@ -679,6 +680,7 @@ class NBEATSTrainingNetwork(NBEATSNetwork):
             F,
             past_target=past_target,
             past_observed_values=past_observed_values,
+            future_target=None,
             future_observed_values=future_observed_values,
         )
 
@@ -737,6 +739,7 @@ class NBEATSPredictionNetwork(NBEATSNetwork):
             F,
             past_target=past_target,
             past_observed_values=past_observed_values,
+            future_target=None,
             future_observed_values=None,
         )
 

--- a/src/gluonts/model/n_beats/_network.py
+++ b/src/gluonts/model/n_beats/_network.py
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from typing import List
+from typing import List, Optional
 
 import mxnet as mx
 import numpy as np
@@ -648,8 +648,8 @@ class NBEATSTrainingNetwork(NBEATSNetwork):
         self,
         F,
         past_target: Tensor,
-        future_target: Tensor,
         past_observed_values: Tensor,
+        future_target: Tensor,
         future_observed_values: Tensor,
     ) -> Tensor:
         """
@@ -708,9 +708,9 @@ class NBEATSPredictionNetwork(NBEATSNetwork):
         self,
         F,
         past_target: Tensor,
-        future_target: Tensor = None,
-        past_observed_values: Tensor = None,
-        future_observed_values: Tensor = None,
+        past_observed_values: Tensor,
+        future_target: Optional[Tensor] = None,
+        future_observed_values: Optional[Tensor] = None,
     ) -> Tensor:
         """
 


### PR DESCRIPTION
*Issue:*
NBEATS implementation differs from [the one of the authors](https://github.com/ElementAI/N-BEATS/blob/master/models/nbeats.py). In particular it lacks proper [masking of the input](https://github.com/ElementAI/N-BEATS/blob/master/models/nbeats.py#L72), which is also described in the [paper](https://arxiv.org/pdf/1905.10437.pdf) at the end of page 26.


*Description of changes:*
Added proper input masking and optional (default to False) input scaling. Input scaling is used in the [meta-learning version of NBEATS](https://arxiv.org/pdf/2002.02887.pdf) to account for time series of different magnitudes. Here, scaling is implemented similarly to DeeAR (using MeanScaler) while in the paper the input/output of the model is scaled/descaled by the maximum value in the input.

Strangely, the authors' implementation also seems to [include part of the input as one of the additive components of the final forecasts](https://github.com/ElementAI/N-BEATS/blob/master/models/nbeats.py#L69). This pull request does not include this change since it is not described in the [original NBEATS paper](https://arxiv.org/pdf/1905.10437.pdf).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
