### PR TITLE
set is_pad_field's type to the data type in spilters

### DIFF
--- a/src/gluonts/transform/split.py
+++ b/src/gluonts/transform/split.py
@@ -225,7 +225,7 @@ class InstanceSplitter(FlatMapTransformation):
                     ..., i + lt : i + lt + pl
                 ]
                 del d[ts_field]
-            pad_indicator = np.zeros(self.past_length)
+            pad_indicator = np.zeros(self.past_length, dtype=dtype=d[ts_field].dtype)
             if pad_length > 0:
                 pad_indicator[:pad_length] = 1
 
@@ -374,7 +374,7 @@ class CanonicalInstanceSplitter(FlatMapTransformation):
             )
 
             # set is_pad field
-            is_pad = np.zeros(self.instance_length)
+            is_pad = np.zeros(self.instance_length, dtype=d[ts_field].dtype)
             if pad_length > 0:
                 is_pad[:pad_length] = 1
             d[self.is_pad_field] = is_pad

--- a/src/gluonts/transform/split.py
+++ b/src/gluonts/transform/split.py
@@ -225,7 +225,7 @@ class InstanceSplitter(FlatMapTransformation):
                     ..., i + lt : i + lt + pl
                 ]
                 del d[ts_field]
-            pad_indicator = np.zeros(self.past_length, dtype=dtype=d[ts_field].dtype)
+            pad_indicator = np.zeros(self.past_length, dtype=target.dtype)
             if pad_length > 0:
                 pad_indicator[:pad_length] = 1
 
@@ -374,7 +374,7 @@ class CanonicalInstanceSplitter(FlatMapTransformation):
             )
 
             # set is_pad field
-            is_pad = np.zeros(self.instance_length, dtype=d[ts_field].dtype)
+            is_pad = np.zeros(self.instance_length, dtype=ts_target.dtype)
             if pad_length > 0:
                 is_pad[:pad_length] = 1
             d[self.is_pad_field] = is_pad


### PR DESCRIPTION
Else it ends up being `float64` and needs to be cast down when checking with `past_observed_values` etc.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
