### PR TITLE
Pytorch's AffineTransform doesn't take None as inputs

### DIFF
--- a/src/gluonts/torch/modules/distribution_output.py
+++ b/src/gluonts/torch/modules/distribution_output.py
@@ -133,7 +133,13 @@ class DistributionOutput(Output):
         else:
             distr = self.distr_cls(*distr_args)
             return TransformedDistribution(
-                distr, [AffineTransform(loc=loc, scale=scale)]
+                distr,
+                [
+                    AffineTransform(
+                        loc=0.0 if loc is None else loc,
+                        scale=1.0 if scale is None else scale,
+                    )
+                ],
             )
 
     @property


### PR DESCRIPTION
My mistake... `AffineTransform` doesn't take `None` for `loc` or `scale`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
