### PR TITLE
Allow Pytorch predictor to be loaded on different devices

### DIFF
--- a/src/gluonts/torch/model/predictor.py
+++ b/src/gluonts/torch/model/predictor.py
@@ -137,7 +137,7 @@ class PyTorchPredictor(Predictor):
         with (path / f"prediction_net.json").open("r") as fp:
             prediction_net = load_json(fp.read())
         prediction_net.load_state_dict(
-            torch.load(path / "prediction_net_state")
+            torch.load(path / "prediction_net_state", map_location=device)
         )
 
         parameters["device"] = device


### PR DESCRIPTION
This allows the Pytorch model to be used on sagemaker after training on a GPU for example. Again apologies for these tiny PRs. cc @edrinb-zalando 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
