### PR TITLE
Add to_quantile_forecast method to Forecast classes

### DIFF
--- a/src/gluonts/model/forecast.py
+++ b/src/gluonts/model/forecast.py
@@ -455,14 +455,16 @@ class SampleForecast(Forecast):
             ]
         )
 
-    def to_quantile_forecast(self, quantiles: List[Union[float, str]]) -> "QuantileForecast":
+    def to_quantile_forecast(
+        self, quantiles: List[Union[float, str]]
+    ) -> "QuantileForecast":
         return QuantileForecast(
             forecast_arrays=np.array([self.quantile(q) for q in quantiles]),
             start_date=self.start_date,
             freq=self.freq,
             forecast_keys=quantiles,
             item_id=self.item_id,
-            info=self.info
+            info=self.info,
         )
 
 

--- a/src/gluonts/model/forecast.py
+++ b/src/gluonts/model/forecast.py
@@ -455,6 +455,16 @@ class SampleForecast(Forecast):
             ]
         )
 
+    def to_quantile_forecast(self, quantiles: List[Union[float, str]]) -> "QuantileForecast":
+        return QuantileForecast(
+            forecast_arrays=np.array([self.quantile(q) for q in quantiles]),
+            start_date=self.start_date,
+            freq=self.freq,
+            forecast_keys=quantiles,
+            item_id=self.item_id,
+            info=self.info
+        )
+
 
 class QuantileForecast(Forecast):
     """

--- a/src/gluonts/mx/model/forecast.py
+++ b/src/gluonts/mx/model/forecast.py
@@ -11,14 +11,14 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Union, List
 
 import mxnet as mx
 import numpy as np
 import pandas as pd
 
 from gluonts.core.component import validated
-from gluonts.model.forecast import Forecast, SampleForecast, Quantile
+from gluonts.model.forecast import Forecast, SampleForecast, Quantile, QuantileForecast
 from gluonts.mx.distribution import Distribution
 
 
@@ -104,4 +104,14 @@ class DistributionForecast(Forecast):
             freq=self.freq,
             item_id=self.item_id,
             info=self.info,
+        )
+
+    def to_quantile_forecast(self, quantiles: List[Union[float, str]]):
+        return QuantileForecast(
+            forecast_arrays=np.array([self.quantile(q) for q in quantiles]),
+            forecast_keys=quantiles,
+            start_date=self.start_date,
+            freq=self.freq,
+            item_id=self.item_id,
+            info=self.info
         )

--- a/src/gluonts/mx/model/forecast.py
+++ b/src/gluonts/mx/model/forecast.py
@@ -18,7 +18,12 @@ import numpy as np
 import pandas as pd
 
 from gluonts.core.component import validated
-from gluonts.model.forecast import Forecast, SampleForecast, Quantile, QuantileForecast
+from gluonts.model.forecast import (
+    Forecast,
+    SampleForecast,
+    Quantile,
+    QuantileForecast,
+)
 from gluonts.mx.distribution import Distribution
 
 
@@ -113,5 +118,5 @@ class DistributionForecast(Forecast):
             start_date=self.start_date,
             freq=self.freq,
             item_id=self.item_id,
-            info=self.info
+            info=self.info,
         )


### PR DESCRIPTION
…tion forecast to quantile forecast

*Issue #, if available:*

method that allows conversion from sample forecast to quantile forecast and distribution forecast to quantile forecast might be helpful in developing AutoGluon for GluonTS as quantile forecasts are easier to be shown as a data frame.

*Description of changes:*
Add two methods: 
SampleForecast.to_quantile_forecast
DistributionForecast.to_quantile_forecast

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
