### PR TITLE
Add discussions link to issue templates form

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and Discussions
+    url: https://github.com/awslabs/gluon-ts/discussions
+    about: Use GitHub Discussions to ask and answer questions, exchange ideas, and share learning.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This puts a link to the Discussion section in the Issue submission form, so that (hopefully) questions and discussions are directed there

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
