### PR TITLE
Fixed MASE in N-BEATS: removed redundant factor

### DIFF
--- a/src/gluonts/model/n_beats/_network.py
+++ b/src/gluonts/model/n_beats/_network.py
@@ -619,11 +619,8 @@ class NBEATSNetwork(mx.gluon.HybridBlock):
 
         According to paper: https://arxiv.org/abs/1905.10437.
         """
-        factor = 1 / (
-            self.context_length + self.prediction_length - periodicity
-        )
         whole_target = F.concat(past_target, future_target, dim=1)
-        seasonal_error = factor * F.mean(
+        seasonal_error = F.mean(
             F.abs(
                 F.slice_axis(whole_target, axis=1, begin=periodicity, end=None)
                 - F.slice_axis(whole_target, axis=1, begin=0, end=-periodicity)


### PR DESCRIPTION
*Description of changes:*
Since to compute `seasonal_error` we are taking the mean, `factor` is not needed. See also the [N-BEATS authors implementation](https://github.com/ElementAI/N-BEATS/blob/04f56c4ca4c144071b94089f7195b1dd606072b0/common/torch/losses.py#L61).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
