### PR TITLE
Restrict numpy to <1.20

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 holidays>=0.9
 matplotlib~=3.0
-numpy~=1.16
+numpy~=1.16,<1.20
 pandas~=1.1
 pydantic~=1.1,<1.7
 tqdm~=4.23


### PR DESCRIPTION
*Description of changes:* the recent release of numpy 1.20 broke some of our serde logic. This limits compatibility to <1.20, while we figure out how to fix it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
