### PR TITLE
Fix spelling error in ListDataset docstring

### DIFF
--- a/src/gluonts/dataset/common.py
+++ b/src/gluonts/dataset/common.py
@@ -218,7 +218,7 @@ class FileDataset(Dataset):
 
 class ListDataset(Dataset):
     """
-    Dataset backed directly by an list of dictionaries.
+    Dataset backed directly by a list of dictionaries.
 
     data_iter
         Iterable object yielding all items in the dataset.


### PR DESCRIPTION
*Issue #, if available:* No issue created

*Description of changes:* I found a very small spelling error in the `ListDataset`documentation and fixed it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
