### PR TITLE
Added lead_time argument to PyTorchPredictor

### DIFF
--- a/src/gluonts/torch/model/predictor.py
+++ b/src/gluonts/torch/model/predictor.py
@@ -50,8 +50,9 @@ class PyTorchPredictor(Predictor):
         input_transform: Transformation,
         forecast_generator: ForecastGenerator = SampleForecastGenerator(),
         output_transform: Optional[OutputTransform] = None,
+        lead_time: int = 0,
     ) -> None:
-        super().__init__(prediction_length, freq)
+        super().__init__(prediction_length, freq=freq, lead_time=lead_time)
         self.input_names = input_names
         self.prediction_net = prediction_net
         self.batch_size = batch_size


### PR DESCRIPTION
I cannot set the lead_time to PyTorchPredictor constructor for my LSTNet model.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
