### PR TITLE
Set default num_samples, shorten some import paths

### DIFF
--- a/docs/tutorials/forecasting/extended_tutorial.md
+++ b/docs/tutorials/forecasting/extended_tutorial.md
@@ -637,7 +637,7 @@ GluonTS comes with the `make_evaluation_predictions` function that automates the
 
 
 ```python
-from gluonts.evaluation.backtest import make_evaluation_predictions
+from gluonts.evaluation import make_evaluation_predictions
 ```
 
 

--- a/docs/tutorials/forecasting/howto_pytorch_lightning.md
+++ b/docs/tutorials/forecasting/howto_pytorch_lightning.md
@@ -301,12 +301,10 @@ from gluonts.evaluation import make_evaluation_predictions, Evaluator
 
 ```python
 forecast_it, ts_it = make_evaluation_predictions(
-    dataset=dataset.test,
-    predictor=predictor_pytorch,
-    num_samples=1000,
+    dataset=dataset.test, predictor=predictor_pytorch,
 )
 
-forecasts_pytorch = list(f.to_sample_forecast() for f in forecast_it)
+forecasts_pytorch = list(forecast_it)
 tss_pytorch = list(ts_it)
 ```
 

--- a/docs/tutorials/forecasting/howto_pytorch_lightning.md
+++ b/docs/tutorials/forecasting/howto_pytorch_lightning.md
@@ -295,8 +295,7 @@ For example, we can do backtesting on the test dataset: in what follows, `make_e
 
 
 ```python
-from gluonts.evaluation.backtest import make_evaluation_predictions
-from gluonts.evaluation import Evaluator
+from gluonts.evaluation import make_evaluation_predictions, Evaluator
 ```
 
 

--- a/docs/tutorials/forecasting/howto_pytorch_lightning.md
+++ b/docs/tutorials/forecasting/howto_pytorch_lightning.md
@@ -301,10 +301,10 @@ from gluonts.evaluation import make_evaluation_predictions, Evaluator
 
 ```python
 forecast_it, ts_it = make_evaluation_predictions(
-    dataset=dataset.test, predictor=predictor_pytorch,
+    dataset=dataset.test, predictor=predictor_pytorch
 )
 
-forecasts_pytorch = list(forecast_it)
+forecasts_pytorch = list(f.to_sample_forecast() for f in forecast_it)
 tss_pytorch = list(ts_it)
 ```
 

--- a/docs/tutorials/forecasting/quick_start_tutorial.md
+++ b/docs/tutorials/forecasting/quick_start_tutorial.md
@@ -169,7 +169,7 @@ GluonTS comes with the `make_evaluation_predictions` function that automates the
 
 
 ```python
-from gluonts.evaluation.backtest import make_evaluation_predictions
+from gluonts.evaluation import make_evaluation_predictions
 ```
 
 

--- a/evaluations/generate_evaluations.py
+++ b/evaluations/generate_evaluations.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import Dict
 
 from gluonts.dataset.repository.datasets import get_dataset, dataset_names
-from gluonts.evaluation.backtest import backtest_metrics
+from gluonts.evaluation import backtest_metrics
 from gluonts.model.seasonal_naive import SeasonalNaivePredictor
 
 metrics_persisted = ["mean_wQuantileLoss", "ND", "RMSE"]

--- a/examples/benchmark_m4.py
+++ b/examples/benchmark_m4.py
@@ -21,8 +21,7 @@ import pandas as pd
 
 from gluonts.dataset.repository.datasets import get_dataset
 from gluonts.distribution.piecewise_linear import PiecewiseLinearOutput
-from gluonts.evaluation import Evaluator
-from gluonts.evaluation.backtest import make_evaluation_predictions
+from gluonts.evaluation import make_evaluation_predictions, Evaluator
 from gluonts.model.deepar import DeepAREstimator
 from gluonts.model.seq2seq import MQCNNEstimator
 from gluonts.model.simple_feedforward import SimpleFeedForwardEstimator

--- a/examples/evaluate_model.py
+++ b/examples/evaluate_model.py
@@ -17,8 +17,7 @@ This example shows how to fit a model and evaluate its predictions.
 import pprint
 
 from gluonts.dataset.repository.datasets import get_dataset, dataset_recipes
-from gluonts.evaluation import Evaluator
-from gluonts.evaluation.backtest import make_evaluation_predictions
+from gluonts.evaluation import make_evaluation_predictions, Evaluator
 from gluonts.model.simple_feedforward import SimpleFeedForwardEstimator
 from gluonts.mx.trainer import Trainer
 

--- a/examples/persist_model.py
+++ b/examples/persist_model.py
@@ -18,8 +18,7 @@ import os
 import pprint
 
 from gluonts.dataset.repository.datasets import get_dataset
-from gluonts.evaluation import Evaluator
-from gluonts.evaluation.backtest import make_evaluation_predictions
+from gluonts.evaluation import make_evaluation_predictions, Evaluator
 from gluonts.model.simple_feedforward import SimpleFeedForwardEstimator
 from gluonts.support.util import get_download_path
 from gluonts.mx.trainer import Trainer

--- a/examples/run_rolling_forecast_backtest.py
+++ b/examples/run_rolling_forecast_backtest.py
@@ -17,8 +17,7 @@ import pandas as pd
 from gluonts.dataset.repository.datasets import get_dataset
 from gluonts.model.simple_feedforward import SimpleFeedForwardEstimator
 from gluonts.mx.trainer import Trainer
-from gluonts.evaluation import Evaluator
-from gluonts.evaluation.backtest import make_evaluation_predictions
+from gluonts.evaluation import make_evaluation_predictions, Evaluator
 from gluonts.dataset.rolling_dataset import (
     StepStrategy,
     generate_rolling_dataset,

--- a/examples/warm_start.py
+++ b/examples/warm_start.py
@@ -16,8 +16,7 @@ This example show how to intialize the network with parameters from a model that
 """
 
 from gluonts.dataset.repository.datasets import get_dataset, dataset_recipes
-from gluonts.evaluation import Evaluator
-from gluonts.evaluation.backtest import backtest_metrics
+from gluonts.evaluation import backtest_metrics, Evaluator
 from gluonts.model.simple_feedforward import SimpleFeedForwardEstimator
 from gluonts.mx.trainer import Trainer
 import pandas as pd

--- a/src/gluonts/evaluation/__init__.py
+++ b/src/gluonts/evaluation/__init__.py
@@ -12,8 +12,14 @@
 # permissions and limitations under the License.
 
 from ._base import Evaluator, MultivariateEvaluator
+from .backtest import make_evaluation_predictions, backtest_metrics
 
-__all__ = ["Evaluator", "MultivariateEvaluator"]
+__all__ = [
+    "Evaluator",
+    "MultivariateEvaluator",
+    "make_evaluation_predictions",
+    "backtest_metrics",
+]
 
 # fix Sphinx issues, see https://bit.ly/2K2eptM
 for item in __all__:

--- a/src/gluonts/evaluation/backtest.py
+++ b/src/gluonts/evaluation/backtest.py
@@ -34,13 +34,16 @@ from gluonts.transform import TransformedDataset
 
 
 def make_evaluation_predictions(
-    dataset: Dataset, predictor: Predictor, num_samples: int
+    dataset: Dataset,
+    predictor: Predictor,
+    num_samples: Optional[int] = 100,
 ) -> Tuple[Iterator[Forecast], Iterator[pd.Series]]:
     """
-    Return predictions on the last portion of predict_length time units of the
-    target. Such portion is cut before making predictions, such a function can
-    be used in evaluations where accuracy is evaluated on the last portion of
-    the target.
+    Returns predictions for the trailing prediction_length observations of the given
+    time series, using the given predictor.
+
+    The predictor will take as input the given time series without the trailing
+    prediction_length observations.
 
     Parameters
     ----------
@@ -54,6 +57,9 @@ def make_evaluation_predictions(
 
     Returns
     -------
+    Tuple[Iterator[Forecast], Iterator[pd.Series]]
+        A pair of iterators, the first one yielding the forecasts, and the second
+        one yielding the corresponding ground truth series.
     """
 
     prediction_length = predictor.prediction_length
@@ -118,9 +124,9 @@ def backtest_metrics(
     evaluator=Evaluator(
         quantiles=(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9)
     ),
-    num_samples: int = 100,
+    num_samples: Optional[int] = 100,
     logging_file: Optional[str] = None,
-):
+) -> Tuple[dict, pd.DataFrame]:
     """
     Parameters
     ----------
@@ -137,7 +143,7 @@ def backtest_metrics(
 
     Returns
     -------
-    tuple
+    Tuple[dict, pd.DataFrame]
         A tuple of aggregate metrics and per-time-series metrics obtained by
         training `forecaster` on `train_dataset` and evaluating the resulting
         `evaluator` provided on the `test_dataset`.

--- a/src/gluonts/evaluation/backtest.py
+++ b/src/gluonts/evaluation/backtest.py
@@ -36,7 +36,7 @@ from gluonts.transform import TransformedDataset
 def make_evaluation_predictions(
     dataset: Dataset,
     predictor: Predictor,
-    num_samples: Optional[int] = 100,
+    num_samples: int = 100,
 ) -> Tuple[Iterator[Forecast], Iterator[pd.Series]]:
     """
     Returns predictions for the trailing prediction_length observations of the given
@@ -53,7 +53,8 @@ def make_evaluation_predictions(
     predictor
         Model used to draw predictions.
     num_samples
-        Number of samples to draw on the model when evaluating.
+        Number of samples to draw on the model when evaluating. Only sampling-based
+        models will use this.
 
     Returns
     -------
@@ -124,7 +125,7 @@ def backtest_metrics(
     evaluator=Evaluator(
         quantiles=(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9)
     ),
-    num_samples: Optional[int] = 100,
+    num_samples: int = 100,
     logging_file: Optional[str] = None,
 ) -> Tuple[dict, pd.DataFrame]:
     """
@@ -137,7 +138,8 @@ def backtest_metrics(
     evaluator
         Evaluator to use.
     num_samples
-        Number of samples to use when generating sample-based forecasts.
+        Number of samples to use when generating sample-based forecasts. Only
+        sampling-based models will use this.
     logging_file
         If specified, information of the backtest is redirected to this file.
 

--- a/test/dataset/test_multiprocessing_loader.py
+++ b/test/dataset/test_multiprocessing_loader.py
@@ -36,8 +36,7 @@ from gluonts.dataset.loader import (
     TrainDataLoader,
     ValidationDataLoader,
 )
-from gluonts.evaluation import Evaluator
-from gluonts.evaluation.backtest import backtest_metrics
+from gluonts.evaluation import backtest_metrics, Evaluator
 from gluonts.model.deepar import DeepAREstimator
 from gluonts.mx.batchify import batchify, as_in_context
 from gluonts.mx.trainer import Trainer

--- a/test/model/conftest.py
+++ b/test/model/conftest.py
@@ -88,8 +88,7 @@ def from_hyperparameters(Estimator, hyperparameters, dsinfo):
 
 @pytest.fixture()
 def accuracy_test(dsinfo):
-    from gluonts.evaluation import Evaluator
-    from gluonts.evaluation.backtest import backtest_metrics
+    from gluonts.evaluation import backtest_metrics, Evaluator
 
     def test_accuracy(Estimator, hyperparameters, accuracy):
         estimator = from_hyperparameters(Estimator, hyperparameters, dsinfo)

--- a/test/model/deepvar/test_deepvar.py
+++ b/test/model/deepvar/test_deepvar.py
@@ -16,8 +16,7 @@ import pytest
 from gluonts.dataset.artificial import constant_dataset
 from gluonts.dataset.common import TrainDatasets
 from gluonts.dataset.multivariate_grouper import MultivariateGrouper
-from gluonts.evaluation import MultivariateEvaluator
-from gluonts.evaluation.backtest import backtest_metrics
+from gluonts.evaluation import backtest_metrics, MultivariateEvaluator
 from gluonts.model.deepvar import DeepVAREstimator
 from gluonts.mx.distribution import (
     LowrankMultivariateGaussianOutput,

--- a/test/model/gpvar/test_gpvar.py
+++ b/test/model/gpvar/test_gpvar.py
@@ -19,8 +19,7 @@ from flaky import flaky
 from gluonts.dataset.artificial import constant_dataset
 from gluonts.dataset.common import TrainDatasets
 from gluonts.dataset.multivariate_grouper import MultivariateGrouper
-from gluonts.evaluation import MultivariateEvaluator
-from gluonts.evaluation.backtest import backtest_metrics
+from gluonts.evaluation import backtest_metrics, MultivariateEvaluator
 from gluonts.model.gpvar import GPVAREstimator
 from gluonts.mx.distribution import LowrankMultivariateGaussian
 from gluonts.mx.distribution.lowrank_gp import GPArgProj, LowrankGPOutput

--- a/test/model/lstnet/test_lstnet.py
+++ b/test/model/lstnet/test_lstnet.py
@@ -19,8 +19,10 @@ import pytest
 from gluonts.dataset.artificial import constant_dataset
 from gluonts.dataset.common import TrainDatasets
 from gluonts.dataset.multivariate_grouper import MultivariateGrouper
-from gluonts.evaluation import MultivariateEvaluator
-from gluonts.evaluation.backtest import make_evaluation_predictions
+from gluonts.evaluation import (
+    make_evaluation_predictions,
+    MultivariateEvaluator,
+)
 from gluonts.model.lstnet import LSTNetEstimator
 from gluonts.mx.trainer import Trainer
 

--- a/test/model/naive_predictors/test_predictors.py
+++ b/test/model/naive_predictors/test_predictors.py
@@ -23,8 +23,7 @@ from pydantic import PositiveInt
 
 from gluonts.dataset.artificial import constant_dataset
 from gluonts.dataset.common import Dataset
-from gluonts.evaluation import Evaluator
-from gluonts.evaluation.backtest import backtest_metrics
+from gluonts.evaluation import backtest_metrics, Evaluator
 from gluonts.model.naive_2 import Naive2Predictor
 from gluonts.model.predictor import Predictor
 from gluonts.model.seasonal_naive import SeasonalNaivePredictor

--- a/test/model/test_backtest.py
+++ b/test/model/test_backtest.py
@@ -26,8 +26,7 @@ from gluonts.dataset.stat import (
     DatasetStatistics,
     calculate_dataset_statistics,
 )
-from gluonts.evaluation import Evaluator
-from gluonts.evaluation.backtest import BacktestInformation, backtest_metrics
+from gluonts.evaluation import BacktestInformation, backtest_metrics, Evaluator
 from gluonts.model.trivial.mean import MeanEstimator
 
 root = logging.getLogger()

--- a/test/model/test_backtest.py
+++ b/test/model/test_backtest.py
@@ -26,7 +26,8 @@ from gluonts.dataset.stat import (
     DatasetStatistics,
     calculate_dataset_statistics,
 )
-from gluonts.evaluation import BacktestInformation, backtest_metrics, Evaluator
+from gluonts.evaluation import backtest_metrics, Evaluator
+from gluonts.evaluation.backtest import BacktestInformation
 from gluonts.model.trivial.mean import MeanEstimator
 
 root = logging.getLogger()

--- a/test/model/test_predictor.py
+++ b/test/model/test_predictor.py
@@ -14,7 +14,7 @@
 import numpy as np
 
 from gluonts.dataset.common import ListDataset
-from gluonts.evaluation.backtest import backtest_metrics
+from gluonts.evaluation import backtest_metrics
 from gluonts.model.predictor import Localizer, ParallelizedPredictor
 from gluonts.model.trivial.identity import IdentityPredictor
 from gluonts.model.trivial.mean import MeanEstimator

--- a/test/paper_examples/test_axiv_paper_examples.py
+++ b/test/paper_examples/test_axiv_paper_examples.py
@@ -25,8 +25,7 @@ def test_listing_1():
     Listing 1
     """
     from gluonts.dataset.repository.datasets import get_dataset
-    from gluonts.evaluation import Evaluator
-    from gluonts.evaluation.backtest import backtest_metrics
+    from gluonts.evaluation import backtest_metrics, Evaluator
     from gluonts.model.deepar import DeepAREstimator
     from gluonts.mx.trainer import Trainer
 
@@ -163,8 +162,7 @@ def test_appendix_c():
                 future_length=self.prediction_length,
             )
 
-    from gluonts.evaluation import Evaluator
-    from gluonts.evaluation.backtest import backtest_metrics
+    from gluonts.evaluation import backtest_metrics, Evaluator
     from gluonts.mx.trainer import Trainer
 
     dataset_info, train_ds, test_ds = constant_dataset()

--- a/test/torch/model/test_simple_torch_model.py
+++ b/test/torch/model/test_simple_torch_model.py
@@ -21,8 +21,7 @@ from gluonts.dataset.artificial import default_synthetic
 from gluonts.dataset.field_names import FieldName
 from gluonts.dataset.loader import TrainDataLoader
 from gluonts.dataset.repository.datasets import get_dataset
-from gluonts.evaluation import Evaluator
-from gluonts.evaluation.backtest import make_evaluation_predictions
+from gluonts.evaluation import make_evaluation_predictions, Evaluator
 from gluonts.torch.batchify import batchify
 from gluonts.torch.model.forecast_generator import (
     DistributionForecastGenerator,

--- a/test/torch/model/test_simple_torch_model.py
+++ b/test/torch/model/test_simple_torch_model.py
@@ -202,9 +202,7 @@ def test_simple_model():
     predictor = net.get_predictor(transformation + prediction_splitter)
 
     forecast_it, ts_it = make_evaluation_predictions(
-        dataset=test_data,
-        predictor=predictor,
-        num_samples=100,
+        dataset=test_data, predictor=predictor
     )
 
     evaluator = Evaluator(quantiles=[0.5, 0.9], num_workers=None)


### PR DESCRIPTION
* Set a default `num_samples` in `make_evaluation_predictions`, which is annoying to set every time even when it is not needed.
* Fix docstrings
* Shorten import paths across the `gluonts.evaluation` package (backward compatible, old paths still available, but references to them are removed here)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
