### PR TITLE
TFT transform fix casting to floats

### DIFF
--- a/src/gluonts/model/tft/_transform.py
+++ b/src/gluonts/model/tft/_transform.py
@@ -115,7 +115,7 @@ class TFTInstanceSplitter(InstanceSplitter):
                             d[field].shape[:-1] + (pad_length,),
                             dtype=d[field].dtype,
                         )
-                        * self.dummy_value
+                        * d[field].dtype(self.dummy_value)
                     )
                     past_piece = np.concatenate(
                         [pad_block, d[field][..., :i]], axis=-1

--- a/src/gluonts/model/tft/_transform.py
+++ b/src/gluonts/model/tft/_transform.py
@@ -110,13 +110,11 @@ class TFTInstanceSplitter(InstanceSplitter):
                 if i >= self.past_length:
                     past_piece = d[field][..., i - self.past_length : i]
                 else:
-                    pad_block = (
-                        np.ones(
-                            d[field].shape[:-1] + (pad_length,),
-                            dtype=d[field].dtype,
-                        )
-                        * self.dummy_value
-                    ).astype(d[field].dtype)
+                    pad_block = np.full(
+                        shape=d[field].shape[:-1] + (pad_length,),
+                        fill_value=self.dummy_value,
+                        dtype=d[field].dtype,
+                    )
                     past_piece = np.concatenate(
                         [pad_block, d[field][..., :i]], axis=-1
                     )

--- a/src/gluonts/model/tft/_transform.py
+++ b/src/gluonts/model/tft/_transform.py
@@ -115,8 +115,8 @@ class TFTInstanceSplitter(InstanceSplitter):
                             d[field].shape[:-1] + (pad_length,),
                             dtype=d[field].dtype,
                         )
-                        * d[field].dtype(self.dummy_value)
-                    )
+                        * self.dummy_value
+                    ).astype(d[field].dtype)
                     past_piece = np.concatenate(
                         [pad_block, d[field][..., :i]], axis=-1
                     )


### PR DESCRIPTION
`pad_block` is always float causing long tensors to be cast to floats as well.

*Description of changes:*

set the `pad_block`'s type to the `d[field].dtype`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
