### PR TITLE
Added lightgbm support for QRX/Rotbaum

### DIFF
--- a/src/gluonts/model/rotbaum/_lgb_wrapper.py
+++ b/src/gluonts/model/rotbaum/_lgb_wrapper.py
@@ -8,6 +8,7 @@ class lgb_wrapper:
     A wrapped of lightgbm that can be fed into the model parameters in QRX
     and TreePredictor.
     """
+
     def __init__(self, **lgb_params):
         self.model = LGBMRegressor(**lgb_params)
 

--- a/src/gluonts/model/rotbaum/_lgb_wrapper.py
+++ b/src/gluonts/model/rotbaum/_lgb_wrapper.py
@@ -1,0 +1,18 @@
+import pandas as pd
+
+from lightgbm import LGBMRegressor
+
+
+class lgb_wrapper:
+    """
+    A wrapped of lightgbm that can be fed into the model parameters in QRX
+    and TreePredictor.
+    """
+    def __init__(self, **lgb_params):
+        self.model = LGBMRegressor(**lgb_params)
+
+    def fit(self, train_data, train_target):
+        self.model.fit(pd.DataFrame(train_data), train_target)
+
+    def predict(self, data):
+        return self.model.predict(pd.DataFrame(data))

--- a/src/gluonts/model/rotbaum/_model.py
+++ b/src/gluonts/model/rotbaum/_model.py
@@ -13,6 +13,7 @@
 
 from typing import Dict, List, Optional
 
+import copy
 import numpy as np
 import pandas as pd
 import xgboost
@@ -99,7 +100,7 @@ class QRX:
             true values associated with each prediction.
         """
         if model:
-            self.model = model
+            self.model = copy.deepcopy(model)
         else:
             self.model = self._create_xgboost_model(xgboost_params)
         self.clump_size = clump_size


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* I added lightgbm support for QRX/Rotbaum. You will instantiate an lgb_wrapper instance, and then feed it into the model parameter in QRX/Rotbaum.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
