### PR TITLE
Added lightgbm support for QRX/Rotbaum

### DIFF
--- a/src/gluonts/model/rotbaum/_lgb_wrapper.py
+++ b/src/gluonts/model/rotbaum/_lgb_wrapper.py
@@ -8,6 +8,7 @@ class lgb_wrapper:
     A wrapped of lightgbm that can be fed into the model parameters in QRX
     and TreePredictor.
     """
+
     def __init__(self, **lgb_params):
         self.model = LGBMRegressor(**lgb_params)
 

--- a/src/gluonts/model/rotbaum/_lgb_wrapper.py
+++ b/src/gluonts/model/rotbaum/_lgb_wrapper.py
@@ -17,11 +17,13 @@ from lightgbm import LGBMRegressor
 
 from gluonts.core.component import validated
 
+
 class lgb_wrapper:
     """
     A wrapped of lightgbm that can be fed into the model parameters in QRX
     and TreePredictor.
     """
+
     @validated()
     def __init__(self, **lgb_params):
         self.model = LGBMRegressor(**lgb_params)

--- a/src/gluonts/model/rotbaum/_lgb_wrapper.py
+++ b/src/gluonts/model/rotbaum/_lgb_wrapper.py
@@ -15,13 +15,14 @@ import pandas as pd
 
 from lightgbm import LGBMRegressor
 
+from gluonts.core.component import validated
 
 class lgb_wrapper:
     """
     A wrapped of lightgbm that can be fed into the model parameters in QRX
     and TreePredictor.
     """
-
+    @validated()
     def __init__(self, **lgb_params):
         self.model = LGBMRegressor(**lgb_params)
 

--- a/src/gluonts/model/rotbaum/_lgb_wrapper.py
+++ b/src/gluonts/model/rotbaum/_lgb_wrapper.py
@@ -1,0 +1,18 @@
+import pandas as pd
+
+from lightgbm import LGBMRegressor
+
+
+class lgb_wrapper:
+    """
+    A wrapped of lightgbm that can be fed into the model parameters in QRX
+    and TreePredictor.
+    """
+    def __init__(self, **lgb_params):
+        self.model = LGBMRegressor(**lgb_params)
+
+    def fit(self, train_data, train_target):
+        self.model.fit(pd.DataFrame(train_data), train_target)
+
+    def predict(self, data):
+        return self.model.predict(pd.DataFrame(data))

--- a/src/gluonts/model/rotbaum/_lgb_wrapper.py
+++ b/src/gluonts/model/rotbaum/_lgb_wrapper.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
 import pandas as pd
 
 from lightgbm import LGBMRegressor

--- a/src/gluonts/model/rotbaum/_model.py
+++ b/src/gluonts/model/rotbaum/_model.py
@@ -13,6 +13,7 @@
 
 from typing import Dict, List, Optional
 
+import copy
 import numpy as np
 import pandas as pd
 import xgboost
@@ -99,7 +100,7 @@ class QRX:
             true values associated with each prediction.
         """
         if model:
-            self.model = model
+            self.model = copy.deepcopy(model)
         else:
             self.model = self._create_xgboost_model(xgboost_params)
         self.clump_size = clump_size

--- a/src/gluonts/model/rotbaum/_predictor.py
+++ b/src/gluonts/model/rotbaum/_predictor.py
@@ -213,6 +213,7 @@ class TreePredictor(RepresentablePredictor):
                 executor.submit(
                     model.fit, feature_data, np.array(target_data)[:, n_step]
                 )
+        return self
 
     def predict(
         self, dataset: Dataset, num_samples: Optional[int] = None


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Added lightgbm support for QRX/Rotbaum. Instantiate a an lgb_wrapper object, and then feed into the model parameter in QRX/Rotbaum.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
