### PR TITLE
Added **kwargs to QRX and lgb_wrapper fit functions

### DIFF
--- a/src/gluonts/model/rotbaum/_lgb_wrapper.py
+++ b/src/gluonts/model/rotbaum/_lgb_wrapper.py
@@ -28,8 +28,8 @@ class lgb_wrapper:
     def __init__(self, **lgb_params):
         self.model = LGBMRegressor(**lgb_params)
 
-    def fit(self, train_data, train_target):
-        self.model.fit(pd.DataFrame(train_data), train_target)
+    def fit(self, train_data, train_target, **kwargs):
+        self.model.fit(pd.DataFrame(train_data), train_target, **kwargs)
 
     def predict(self, data):
         return self.model.predict(pd.DataFrame(data))

--- a/src/gluonts/model/rotbaum/_model.py
+++ b/src/gluonts/model/rotbaum/_model.py
@@ -124,7 +124,7 @@ class QRX:
             }
         return xgboost.sklearn.XGBModel(**model_params)
 
-    def fit(self, x_train, y_train, **kwargs):
+    def fit(self, x_train, y_train, max_sample_size=None, seed=1, **kwargs):
         """
         Fits self.model and partitions R^n into cells. More accurately,
         it creates a dictionary taking predictions on train to lists of
@@ -137,11 +137,24 @@ class QRX:
         y_train: list
         eval_set: list of tuples of train (list of lists) and labels
             Optional. Main use case is if using lightgbm.
+        max_sample_size: int
+            If not None, choose without replacement
+            min(max_sample_size, len(x_train)) many datapoints to train on.
+        seed: int
+            seed for sampling purposes
         """
         self.quantile_dicts = {}
         x_train, y_train = np.array(x_train), np.array(y_train)  # xgboost
         # doens't like lists
-        self.model.fit(np.array(x_train), np.array(y_train), **kwargs)
+        if max_sample_size:
+            assert max_sample_size > 0
+            sample_size = min(max_sample_size, len(x_train))
+            np.random.seed(seed)
+            idx = np.random.choice(np.arange(len(x_train)), sample_size,
+                                   replace=False)
+            x_train = x_train[idx]
+            y_train = y_train[idx]
+        self.model.fit(x_train, y_train, **kwargs)
         y_train_pred = self.model.predict(x_train)
         self.df = pd.DataFrame(
             {"x": list(x_train), "y_true": y_train, "y_pred": y_train_pred}

--- a/src/gluonts/model/rotbaum/_model.py
+++ b/src/gluonts/model/rotbaum/_model.py
@@ -124,7 +124,7 @@ class QRX:
             }
         return xgboost.sklearn.XGBModel(**model_params)
 
-    def fit(self, x_train, y_train):
+    def fit(self, x_train, y_train, **kwargs):
         """
         Fits self.model and partitions R^n into cells. More accurately,
         it creates a dictionary taking predictions on train to lists of
@@ -135,11 +135,13 @@ class QRX:
         x_train: list
             list of lists
         y_train: list
+        eval_set: list of tuples of train (list of lists) and labels
+            Optional. Main use case is if using lightgbm.
         """
         self.quantile_dicts = {}
         x_train, y_train = np.array(x_train), np.array(y_train)  # xgboost
         # doens't like lists
-        self.model.fit(np.array(x_train), np.array(y_train))
+        self.model.fit(np.array(x_train), np.array(y_train), **kwargs)
         y_train_pred = self.model.predict(x_train)
         self.df = pd.DataFrame(
             {"x": list(x_train), "y_true": y_train, "y_pred": y_train_pred}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Added **kwargs to QRX and lgb_wrapper fit functions. This would be helpful for example if want eval_set for lightgbm use with QRX.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
