### PR TITLE
Fix dockerfiles

### DIFF
--- a/examples/dockerfiles/Dockerfile.gpu
+++ b/examples/dockerfiles/Dockerfile.gpu
@@ -16,5 +16,6 @@ ADD . /gluonts
 
 RUN pip3.7 install mxnet-cu92>=1.6.0
 RUN pip3.7 install /gluonts[shell]
+ENV MXNET_USE_FUSION=0
 
 ENTRYPOINT ["python3.7", "-m", "gluonts.shell"]

--- a/examples/dockerfiles/Dockerfile.r
+++ b/examples/dockerfiles/Dockerfile.r
@@ -2,7 +2,7 @@ FROM rpy2/rpy2:2.9.x
 
 ADD . /gluonts
 
-RUN pip install -r /gluonts/requirements/requirements-mxnet.txt
+RUN pip install mxnet>=1.6.0
 RUN pip install /gluonts[shell]
 
 RUN R -e 'install.packages(c("forecast", "nnfor"), repos="https://cloud.r-project.org")'

--- a/src/gluonts/shell/train.py
+++ b/src/gluonts/shell/train.py
@@ -13,6 +13,7 @@
 
 import json
 import logging
+import multiprocessing
 from typing import Any, Optional, Type, Union
 
 import gluonts
@@ -90,6 +91,8 @@ def run_train(
         if "num_workers" in hyperparameters.keys()
         else None
     )
+    if num_workers:
+        multiprocessing.set_start_method("spawn", force=True)
     shuffle_buffer_length = (
         int(hyperparameters["shuffle_buffer_length"])
         if "shuffle_buffer_length" in hyperparameters.keys()

--- a/src/gluonts/shell/train.py
+++ b/src/gluonts/shell/train.py
@@ -32,6 +32,7 @@ from gluonts.transform import FilterTransformation, TransformedDataset
 
 from .env import TrainEnv
 
+multiprocessing.set_start_method("spawn", force=True)
 logger = logging.getLogger(__name__)
 
 
@@ -91,8 +92,6 @@ def run_train(
         if "num_workers" in hyperparameters.keys()
         else None
     )
-    if num_workers:
-        multiprocessing.set_start_method("spawn", force=True)
     shuffle_buffer_length = (
         int(hyperparameters["shuffle_buffer_length"])
         if "shuffle_buffer_length" in hyperparameters.keys()

--- a/src/gluonts/testutil/shell.py
+++ b/src/gluonts/testutil/shell.py
@@ -13,18 +13,16 @@
 
 import json
 import multiprocessing
-from multiprocessing.context import ForkContext
 import socket
 import tempfile
 import time
+import typing
 from contextlib import closing, contextmanager
-from multiprocessing import Process, get_context
+from multiprocessing.context import ForkContext
 from pathlib import Path
 from typing import Any, ContextManager, Dict, Iterable, List, Optional, Type
-import typing
 
 import requests
-
 from gluonts.dataset.common import DataEntry, serialize_data_entry
 from gluonts.dataset.repository.datasets import materialize_dataset
 from gluonts.model.predictor import Predictor


### PR DESCRIPTION
*Description of changes:*
Some of the [dockerfiles](examples/dockerfiles) cannot be built/does not execute properly, this PR fixes this. 

These are the problems which this PR addresses:

1. The GPU image crashes on SageMaker due to MXNET_USE_FUSION being enabled. 
2. The GPU image crashes when passing `num_workers` as a hyperparameter. 
3. The mxnet version in the requirements file is unavailable when building the [R image](examples/dockerfiles/Dockerfile.R) so the R image fails to build.

*Problem 1* 

This occurs when the gpu image is run. 
For example running the SimpleFeedForwardEstimator on the electricity dataset with these hyperparameters:
```
epochs	1
forecaster_name	gluonts.model.simple_feedforward.SimpleFeedForwardEstimator
freq	D
prediction_length	7
```

Results in this error (removed redundant parts)

```
AlgorithmError: Traceback (most recent call last): 
File "src/operator/fusion/fused_op.cu", line 647 MXNetError: 
Check failed: compileResult == NVRTC_SUCCESS (5 vs. 0) : NVRTC Compilation failed. 
Please set environment variable MXNET_USE_FUSION to 0.
. . .
```
Following the advice in the logs and setting `MXNET_USE_FUSION=0` fixes the issue.

**Problem 2** (requires problem 1 to be fixed beforehand)
Executing an algorithm with num_workers set to a value causes a CUDA initializtion error. 
A fix for a similar issue was proposed by @lostella for #1054 applying this fix when `num_workers` has been passed fixes problem 2. [link](https://github.com/awslabs/gluon-ts/issues/1054#issuecomment-706161305)


**problem 3**
The latest available mxnet version which can be installed in the R image is mxnet 1.6.0 but the current [mxnet requirement](requirements/requirements-mxnet.txt) is 1.7.0 which breaks the build. Changing the installation requirement to `>=1.6.0` fixes the issue.


I tested the changes on the SimpleFeedForwardEstimator as well as the DeepFactorEstimator on a `ml.g4dn.2xlarge` instance on SageMaker. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
