### PR TITLE
Fix s3fs ImportError for fsspec 0.9.0

### DIFF
--- a/requirements/requirements-extras-sagemaker-sdk.txt
+++ b/requirements/requirements-extras-sagemaker-sdk.txt
@@ -1,2 +1,4 @@
 sagemaker~=2.0
-s3fs~=0.4
+s3fs~=0.6; python_version >= "3.7.0"
+s3fs~=0.5; python_version < "3.7.0"
+fsspec~=0.8,<0.9; python_version < "3.7.0"


### PR DESCRIPTION
*Issue #, if available:*
[Tests](https://github.com/awslabs/gluon-ts/pull/1261/checks?check_run_id=2277104757) fail for Python3.6, because there is an ImportError inside fsspec since the latest update to 0.9.0 (see https://github.com/intake/filesystem_spec/issues/597 or https://github.com/dask/s3fs/issues/457).
```
___ ERROR collecting test/nursery/sagemaker_sdk/test_entry_point_scripts.py ____
ImportError while importing test module '/home/runner/work/gluon-ts/gluon-ts/test/nursery/sagemaker_sdk/test_entry_point_scripts.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
test/nursery/sagemaker_sdk/test_entry_point_scripts.py:23: in <module>
    from gluonts.nursery.sagemaker_sdk.defaults import NUM_SAMPLES, QUANTILES
src/gluonts/nursery/sagemaker_sdk/__init__.py:15: in <module>
    from .estimator import GluonTSFramework
src/gluonts/nursery/sagemaker_sdk/estimator.py:24: in <module>
    import s3fs
/opt/hostedtoolcache/Python/3.6.13/x64/lib/python3.6/site-packages/s3fs/__init__.py:1: in <module>
    from .core import S3FileSystem, S3File
/opt/hostedtoolcache/Python/3.6.13/x64/lib/python3.6/site-packages/s3fs/core.py:12: in <module>
    from fsspec.asyn import AsyncFileSystem, sync, sync_wrapper, maybe_sync
E   ImportError: cannot import name 'maybe_sync'

```
*Description of changes:*
Due to s3fs 0.6 only supporting Python ≥ 3.7, the requirements are changed to:
```
s3fs~=0.5
fsspec~=0.8,<0.9
```
when Python 3.6 is used. Otherwise `s3fs~=0.6` is used, which does not cause an error for Python ≥ 3.7.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
