### PR TITLE
fix bug about attention mask

### DIFF
--- a/src/gluonts/model/tft/_layers.py
+++ b/src/gluonts/model/tft/_layers.py
@@ -287,12 +287,12 @@ class SelfAttention(HybridBlock):
         )
         unidir_mask = F.broadcast_lesser_equal(k_idx, q_idx)
         unidir_mask = F.broadcast_like(unidir_mask, score)
-        score = F.where(unidir_mask, score, F.ones_like(score) * 1e-9)
+        score = F.where(unidir_mask, score, F.ones_like(score) * -1e9)
         if key_mask is not None:
             key_mask = key_mask.expand_dims(axis=1)  # head
             key_mask = key_mask.expand_dims(axis=2)  # query
             key_mask = F.broadcast_like(key_mask, score)
-            score = F.where(key_mask, score, F.ones_like(score) * 1e-9)
+            score = F.where(key_mask, score, F.ones_like(score) * -1e9)
         return score
 
     def _compute_attn_score(


### PR DESCRIPTION
score attention mask should be -inf, so that after softmax, score in masked will be zero.

*Issue #, if available:*

*Description of changes:*
Mask with 1e-9 make no sense, it should be -1e9


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
