### PR TITLE
Add unit tests for metrics.

### DIFF
--- a/test/evaluation/test_evaluator.py
+++ b/test/evaluation/test_evaluator.py
@@ -17,43 +17,8 @@ import pytest
 
 from gluonts.evaluation import Evaluator, MultivariateEvaluator
 from gluonts.model.forecast import QuantileForecast, SampleForecast
-from gluonts.evaluation.metrics import mape, smape
 
 QUANTILES = [str(q / 10.0) for q in range(1, 10)]
-
-
-@pytest.mark.parametrize(
-    "target, forecast, expected_metric_values",
-    [
-        (
-            np.array([1.0, 2.0, 3.0, 0.0, 0.0]),
-            np.array([2.0, 3.0, 4.0, 1.0, 0.0]),
-            {
-                mape: (1 / 1 + 1 / 2 + 1 / 3) / 3,
-                smape: 2
-                * (1 / (1 + 2) + 1 / (2 + 3) + 1 / (3 + 4) + 1 / 1)
-                / 4,
-            },
-        ),
-        (
-            np.array([0.0, 0.0, 0.0, 0.0, 0.0]),
-            np.array([0.1, 0.01, 0.001, 0.0001, 0.00001]),
-            {mape: np.nan, smape: 2.0},
-        ),
-        (
-            np.array([0.0, 0.0, 0.0, 0.0, 0.0]),
-            np.array([0.0, 0.0, 0.0, 0.0, 0.0]),
-            {mape: np.nan, smape: np.nan},
-        ),
-    ],
-)
-def test_metric_values(
-    target: np.ndarray, forecast: np.ndarray, expected_metric_values: dict
-):
-    for metric, expected_value in expected_metric_values.items():
-        assert np.isclose(
-            metric(target, forecast), expected_value, equal_nan=True
-        )
 
 
 def data_iterator(ts):

--- a/test/evaluation/test_metrics.py
+++ b/test/evaluation/test_metrics.py
@@ -1,4 +1,16 @@
-from typing import Optional
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
 from pydantic.decorator import Callable
 from gluonts.evaluation.metrics import (
     abs_target_mean,

--- a/test/evaluation/test_metrics.py
+++ b/test/evaluation/test_metrics.py
@@ -15,6 +15,7 @@ from pydantic.decorator import Callable
 from gluonts.evaluation.metrics import (
     abs_target_mean,
     abs_target_sum,
+    calculate_seasonal_error,
     mase,
     mape,
     msis,
@@ -252,6 +253,28 @@ def test_msis(
             seasonal_error=seasonal_error,
             alpha=alpha,
             exclude_zero_denominator=False,  # TODO remove when refactoring msis
+        ),
+        expected,
+    )
+
+
+@pytest.mark.parametrize(
+    "past_data, seasonality, expected",
+    [
+        (LINEAR, 1, 0.1),
+        (LINEAR, 2, 0.2),
+        (LINEAR, 3, 0.3),
+        (LINEAR, 4, 0.4),
+        (LINEAR, len(LINEAR), 0.1),
+        (CONSTANT, 2, 0.0),
+        (ZEROES, 1, 0.0),
+        (EXPONENTIAL, 3, 0.054945),
+    ],
+)
+def test_seasonal_error(past_data, seasonality, expected):
+    np.testing.assert_almost_equal(
+        calculate_seasonal_error(
+            past_data=past_data, forecast=None, seasonality=seasonality
         ),
         expected,
     )

--- a/test/evaluation/test_metrics.py
+++ b/test/evaluation/test_metrics.py
@@ -1,0 +1,180 @@
+from typing import Optional
+from pydantic.decorator import Callable
+from gluonts.evaluation.metrics import (
+    abs_target_mean,
+    abs_target_sum,
+    mase,
+    mape,
+    quantile_loss,
+    smape,
+    mse,
+    abs_error,
+    coverage,
+)
+import numpy as np
+import pytest
+
+
+ZEROES = np.array([0.0] * 5)
+LINEAR = np.array([0.0, 0.1, 0.2, 0.3, 0.4])
+EXPONENTIAL = np.array([0.1, 0.01, 0.001, 0.0001, 0.00001])
+CONSTANT = np.array([0.4] * 5)
+
+
+# TODO remove `"exclude_zero_denominator": True` when metrics are refactored
+@pytest.mark.parametrize(
+    "target, forecast, metrics",
+    [
+        (
+            ZEROES,
+            ZEROES,
+            [
+                (
+                    mase,
+                    np.nan,
+                    {"seasonal_error": 0.0, "exclude_zero_denominator": False},
+                ),
+                (
+                    mase,
+                    0.0,
+                    {"seasonal_error": 1.0, "exclude_zero_denominator": False},
+                ),
+                (mse, 0.0, {}),
+                (abs_error, 0.0, {}),
+                (quantile_loss, 0.0, {"q": 0.5}),
+                (coverage, 0.0, {}),
+                (mape, np.nan, {"exclude_zero_denominator": False}),
+                (smape, np.nan, {"exclude_zero_denominator": False}),
+            ],
+        ),
+        (
+            LINEAR,
+            ZEROES,
+            [
+                (
+                    mase,
+                    0.2 / 10e-10,
+                    {
+                        "seasonal_error": 10e-10,
+                        "exclude_zero_denominator": False,
+                    },
+                ),
+                (
+                    mase,
+                    np.inf,
+                    {"seasonal_error": 0.0, "exclude_zero_denominator": False},
+                ),
+                (mse, 0.06, {}),
+                (abs_error, 1.0, {}),
+                (quantile_loss, 0.2, {"q": 0.1}),
+                (quantile_loss, 1.0, {"q": 0.5}),
+                (quantile_loss, 1.8, {"q": 0.9}),
+                (coverage, 0.0, {}),
+                (mape, np.nan, {"exclude_zero_denominator": False}),
+                (smape, np.nan, {"exclude_zero_denominator": False}),
+            ],
+        ),
+        (
+            LINEAR,
+            CONSTANT,
+            [
+                (
+                    mase,
+                    0.2,
+                    {"exclude_zero_denominator": False, "seasonal_error": 1},
+                ),
+                (mse, 0.06, {}),
+                (abs_error, 1.0, {}),
+                (quantile_loss, 1.8, {"q": 0.1}),
+                (quantile_loss, 1.0, {"q": 0.5}),
+                (quantile_loss, 0.2, {"q": 0.9}),
+                (coverage, 0.8, {}),
+                (mape, np.inf, {"exclude_zero_denominator": False}),
+                (
+                    smape,
+                    0.8304761904761906,
+                    {"exclude_zero_denominator": False},
+                ),
+            ],
+        ),
+        (
+            ZEROES,
+            EXPONENTIAL,
+            [
+                (
+                    mase,
+                    0.022222,
+                    {"exclude_zero_denominator": False, "seasonal_error": 1},
+                ),
+                (mse, 0.00202020202, {}),
+                (abs_error, 0.11111, {}),
+                (quantile_loss, 0.199998, {"q": 0.1}),
+                (quantile_loss, 0.11111, {"q": 0.5}),
+                (quantile_loss, 0.0222219, {"q": 0.9}),
+                (coverage, 1.0, {}),
+                (mape, np.nan, {}),
+                (mape, np.inf, {"exclude_zero_denominator": False}),
+                (smape, 2.0, {}),
+                (smape, 2.0, {"exclude_zero_denominator": False}),
+            ],
+        ),
+        (
+            np.array([1.0, 2.0, 3.0, 0.0, 0.0]),
+            np.array([2.0, 3.0, 4.0, 1.0, 0.0]),
+            [
+                (
+                    mase,
+                    0.8,
+                    {"exclude_zero_denominator": False, "seasonal_error": 1},
+                ),
+                (mse, 0.8, {}),
+                (abs_error, 4.0, {}),
+                (quantile_loss, 7.2, {"q": 0.1}),
+                (quantile_loss, 4.0, {"q": 0.5}),
+                (quantile_loss, 0.7999999, {"q": 0.9}),
+                (coverage, 0.8, {}),
+                (mape, 0.6111111, {}),
+                (mape, np.nan, {"exclude_zero_denominator": False}),
+                (smape, 0.8380952, {}),
+                (smape, np.nan, {"exclude_zero_denominator": False}),
+            ],
+        ),
+        (
+            CONSTANT,
+            EXPONENTIAL,
+            [
+                (
+                    mase,
+                    0.377778,
+                    {"exclude_zero_denominator": False, "seasonal_error": 1},
+                ),
+                (mse, 0.14424260202, {}),
+                (abs_error, 1.88889, {}),
+                (quantile_loss, 0.377778, {"q": 0.1}),
+                (quantile_loss, 1.88889, {"q": 0.5}),
+                (quantile_loss, 3.400002, {"q": 0.9}),
+                (coverage, 0.0, {}),
+                (mape, 0.944445, {"exclude_zero_denominator": False}),
+                (smape, 1.8182728, {"exclude_zero_denominator": False}),
+            ],
+        ),
+    ],
+)
+def test_metrics(target, forecast, metrics):
+    for metric, expected, kwargs in metrics:
+        np.testing.assert_almost_equal(
+            metric(target, forecast, **kwargs), expected
+        )
+
+
+@pytest.mark.parametrize(
+    "target, metric, expected",
+    [
+        (ZEROES, abs_target_sum, 0.0),
+        (LINEAR, abs_target_sum, 1.0),
+        (ZEROES, abs_target_mean, 0.0),
+        (LINEAR, abs_target_mean, 0.2),
+    ],
+)
+def test_target_metrics(target, metric, expected):
+    np.testing.assert_almost_equal(metric(target), expected)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds unit tests to the metrics used when backtesting.

Worklog:

- [x] abs_target_sum
- [x] abs_target_mean
- [x] mase
- [x] mape
- [x] quantile_loss
- [x] smape
- [x] mse
- [x] abs_error
- [x] coverage
- [x] msis
- [x] owa
- [x] seasonal_error

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
