### PR TITLE
made QRX faster by not computing quantiles for all bins

### DIFF
--- a/src/gluonts/model/rotbaum/_model.py
+++ b/src/gluonts/model/rotbaum/_model.py
@@ -197,7 +197,9 @@ class QRX:
         gc.collect()
 
     @staticmethod
-    def clump(dic: Dict, min_num: int, sorted_keys: Optional[List]) -> Dict:
+    def clump(
+        dic: Dict, min_num: int, sorted_keys: Optional[List] = None
+    ) -> Dict:
         """
         Returns a new dictionary whose keys are the same as dic's keys.
         Runs over dic's keys, from smallest to largest, and every time that

--- a/src/gluonts/model/rotbaum/_model.py
+++ b/src/gluonts/model/rotbaum/_model.py
@@ -302,37 +302,6 @@ class QRX:
             else:
                 return sorted_list[halfway_indx + 1]
 
-    @staticmethod
-    def _get_quantiles_from_dic_with_list_values(
-        dic: Dict, quantile: float
-    ) -> Dict:
-        """
-        Given a dictionary of float to lists, returns a
-        dictionary that takes num to np.percentile(dic[num], 100 * quantile).
-
-        The function is meant to be efficient under the assumption that
-        dic's values have list objects that repeat many times over.
-
-        Parameters
-        ----------
-        dic: dict
-            float to list objects, with potentially many repetitions
-        quantile: float
-
-        Returns
-        -------
-        dict
-            float to float
-        """
-        df = pd.DataFrame(dic.items(), columns=["keys", "values"])
-        df["id"] = df["values"].apply(id)
-        df_by_id = df.groupby("id")["values"].first().reset_index()
-        df_by_id["quantiles"] = df_by_id["values"].apply(
-            lambda l: np.percentile(l, quantile * 100)
-        )
-        df_by_id = df_by_id[["id", "quantiles"]].merge(df, on="id")
-        return dict(zip(df_by_id["keys"], df_by_id["quantiles"]))
-
     def _get_and_cache_quantile_computation(
         self, feature_vector_in_train: List, quantile: float
     ):

--- a/src/gluonts/model/rotbaum/_model.py
+++ b/src/gluonts/model/rotbaum/_model.py
@@ -17,6 +17,8 @@ import copy
 import numpy as np
 import pandas as pd
 import xgboost
+import gc
+from collections import defaultdict
 
 from gluonts.core.component import validated
 
@@ -104,12 +106,11 @@ class QRX:
         else:
             self.model = self._create_xgboost_model(xgboost_params)
         self.clump_size = clump_size
-        self.df = None
-        self.processed_df = None
-        self.cell_values = None
-        self.cell_values_dict = None
+        self.sorted_train_preds = None
         self.x_train_is_dataframe = None
-        self.quantile_dicts = {}
+        self.id_to_bins = None
+        self.preds_to_id = None
+        self.quantile_dicts = defaultdict(dict)
 
     @staticmethod
     def _create_xgboost_model(model_params: Optional[dict] = None):
@@ -141,11 +142,13 @@ class QRX:
     ):
         """
         Fits self.model and partitions R^n into cells. More accurately,
-        it creates a dictionary taking predictions on train to lists of
-        associated true values, and puts it in self.cell_values.
+        it creates two dictionaries: self.preds_to_ids whose keys are the
+        predictions of the training dataset and whose values are the ids of
+        their associated bins, and self.ids_to_bins whose keys are the ids
+        of the bins and whose values are associated lists of true values.
         """
         self.x_train_is_dataframe = x_train_is_dataframe
-        self.quantile_dicts = {}
+        self.quantile_dicts = defaultdict(dict)
         if not x_train_is_dataframe:
             x_train, y_train = np.array(x_train), np.array(y_train)  # xgboost
         # doens't like lists
@@ -169,19 +172,32 @@ class QRX:
             y_train = y_train[idx]
         self.model.fit(x_train, y_train, **kwargs)
         y_train_pred = self.model.predict(x_train)
-        self.df = pd.DataFrame(
+        df = pd.DataFrame(
             {
                 "y_true": y_train,
                 "y_pred": y_train_pred,
             }
         ).reset_index(drop=True)
-        self.cell_values_dict = self.preprocess_df(
-            self.df, clump_size=self.clump_size
+        self.sorted_train_preds = sorted(df["y_pred"].unique())
+        cell_values_dict = self.preprocess_df(df, clump_size=self.clump_size)
+        del df
+        gc.collect()
+        cell_values_dict_df = pd.DataFrame(
+            cell_values_dict.items(), columns=["keys", "values"]
         )
-        self.cell_values = sorted(self.cell_values_dict.keys())
+        cell_values_dict_df["id"] = cell_values_dict_df["values"].apply(id)
+        self.id_to_bins = (
+            cell_values_dict_df.groupby("id")["values"].first().to_dict()
+        )
+        self.preds_to_id = (
+            cell_values_dict_df.groupby("keys")["id"].first().to_dict()
+        )
+        del cell_values_dict_df
+        del cell_values_dict
+        gc.collect()
 
     @staticmethod
-    def clump(dic: Dict, min_num: int) -> Dict:
+    def clump(dic: Dict, min_num: int, sorted_keys: Optional[List]) -> Dict:
         """
         Returns a new dictionary whose keys are the same as dic's keys.
         Runs over dic's keys, from smallest to largest, and every time that
@@ -210,6 +226,8 @@ class QRX:
             float to list
         min_num: int
             minimal number of clump size.
+        sorted_keys: list
+            sorted(dic.keys()) or None
 
         Returns
         -------
@@ -217,7 +235,8 @@ class QRX:
             float to list; with the values often having the same list object
             appear multiple times
         """
-        sorted_keys = sorted(dic)
+        if sorted_keys is None:
+            sorted_keys = sorted(dic)
         new_dic = {}
         iter_length = 0
         iter_list = []
@@ -234,8 +253,7 @@ class QRX:
                 # list object.
         return new_dic
 
-    @classmethod
-    def preprocess_df(cls, df: pd.DataFrame, clump_size: int = 100) -> Dict:
+    def preprocess_df(self, df: pd.DataFrame, clump_size: int = 100) -> Dict:
         """
         Associates true values to each prediction that appears in train. For
         the nature of this association, see details in .clump.
@@ -257,7 +275,7 @@ class QRX:
             of each being at least clump_size.
         """
         dic = dict(df.groupby("y_pred")["y_true"].apply(list))
-        dic = cls.clump(dic, clump_size)
+        dic = self.clump(dic, clump_size, self.sorted_train_preds)
         return dic
 
     @classmethod
@@ -313,7 +331,35 @@ class QRX:
         df_by_id = df_by_id[["id", "quantiles"]].merge(df, on="id")
         return dict(zip(df_by_id["keys"], df_by_id["quantiles"]))
 
-    def predict(self, x_test, quantile: float) -> List:
+    def _get_and_cache_quantile_computation(
+        self, feature_vector_in_train: List, quantile: float
+    ):
+        """
+        Updates self.quantile_dicts[quantile][feature_vector_in_train] to be the quantile of the associated true value bin.
+
+        Parameters
+        ----------
+        feature_vector_in_train: list
+             Feature vector that appears in the training data.
+        quantile: float
+
+        Returns
+        -------
+        float
+            The quantile of the associated true value bin.
+        """
+        if feature_vector_in_train not in self.quantile_dicts[quantile]:
+            self.quantile_dicts[quantile][
+                feature_vector_in_train
+            ] = np.percentile(
+                self.id_to_bins[self.preds_to_id[feature_vector_in_train]],
+                quantile * 100,
+            )
+        return self.quantile_dicts[quantile][feature_vector_in_train]
+
+    def predict(
+        self, x_test: Union[pd.DataFrame, List], quantile: float
+    ) -> List:
         """
         Quantile prediction.
 
@@ -328,18 +374,13 @@ class QRX:
         list
             list of floats
         """
-        if quantile in self.quantile_dicts:
-            quantile_dic = self.quantile_dicts[quantile]
-        else:
-            quantile_dic = self._get_quantiles_from_dic_with_list_values(
-                self.cell_values_dict, quantile
-            )
-            self.quantile_dicts[quantile] = quantile_dic
-        # Remember dic per quantile and use if already done
         if self.x_train_is_dataframe:
             preds = self.model.predict(x_test)
             predicted_values = [
-                quantile_dic[self.get_closest_pt(self.cell_values, pred)]
+                self._get_and_cache_quantile_computation(
+                    self.get_closest_pt(self.sorted_train_preds, pred),
+                    quantile,
+                )
                 for pred in preds
             ]
         else:
@@ -348,8 +389,14 @@ class QRX:
                 pred = self.model.predict(np.array([pt]))[
                     0
                 ]  # xgboost doesn't like lists
-                closest_pred = self.get_closest_pt(self.cell_values, pred)
-                predicted_values.append(quantile_dic[closest_pred])
+                closest_pred = self.get_closest_pt(
+                    self.sorted_train_preds, pred
+                )
+                predicted_values.append(
+                    self._get_and_cache_quantile_computation(
+                        closest_pred, quantile
+                    )
+                )
         return predicted_values
 
     def estimate_dist(self, x_test: List[List[float]]) -> List:
@@ -368,6 +415,8 @@ class QRX:
         predicted_samples = []
         for pt in x_test:
             pred = self.model.predict(np.array([pt]))[0]
-            closest_pred = self.get_closest_pt(self.cell_values, pred)
-            predicted_samples.append(self.cell_values_dict[closest_pred])
+            closest_pred = self.get_closest_pt(self.sorted_train_preds, pred)
+            predicted_samples.append(
+                self.id_to_bins[self.preds_to_id[closest_pred]]
+            )
         return predicted_samples


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Made QRX faster by not computing quantiles for all bins ahead of time, but rather in an ad hoc fashion and caching the results.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
