### PR TITLE
Add strategies for aggregating metrics to Evaluator class.

### DIFF
--- a/src/gluonts/evaluation/_base.py
+++ b/src/gluonts/evaluation/_base.py
@@ -126,7 +126,7 @@ class Evaluator:
         custom_eval_fn: Optional[Dict] = None,
         num_workers: Optional[int] = multiprocessing.cpu_count(),
         chunk_size: int = 32,
-        aggregation_strategy: Optional[str] = "default",
+        aggregation_strategy: Optional[str] = "inf_only",
         ignore_invalid_values: bool = True,
     ) -> None:
         self.quantiles = tuple(map(Quantile.parse, quantiles))
@@ -394,7 +394,9 @@ class Evaluator:
         ), "Some of the requested item metrics are missing."
 
         agg_kwargs = {}
-        if self.aggregation_strategy == "all":
+        if self.aggregation_strategy == "inf_only":
+            pass
+        elif self.aggregation_strategy == "all":
             agg_kwargs = {"skipna": False}
         elif self.aggregation_strategy == "valid":
             metric_per_ts = metric_per_ts.apply(np.ma.masked_invalid)

--- a/src/gluonts/evaluation/_base.py
+++ b/src/gluonts/evaluation/_base.py
@@ -101,18 +101,16 @@ class Evaluator:
         Ignore `NaN` and `inf` values in the timeseries when calculating metrics.
     aggregation_strategy:
         Selects how invalid values in per-timeseries metrics should be filtered
-        when calculating the aggregate metric.
-        "all"
-            Both `nan` and `inf` possible in aggregate metrics, no filtering
-            will be applied.
-        "valid"
-            Filters all `nan` or `inf` values in the per-timeseries metrics.
-            No `nan` or `inf` possible in the aggregate metric unless all
-            per-timeseries metrics are `inf` or `nan`.
-        "inf_only"
-            Filter out all `nan` values but keep any `inf` values.
-            `nan` only possible if all timeseries for a metric resulted in `nan`.
-            `inf` values are possible in the aggregate metric.
+        when calculating the aggregate metric. Available options are:
+        `"all" | "valid" | "inf_only"`.
+        Setting it to "all" makes Both `nan` and `inf` possible in aggregate
+        metrics, no filtering will be applied.
+        Setting it to "valid" filters all `nan` or `inf` values from the
+        per-timeseries metrics. Thus no `nan` or `inf` are possible in the
+        aggregate metric unless all per-timeseries metrics are `inf` or `nan`.
+        Setting it to "inf_only" filters out all `nan` but keeps `inf`.
+        Thus `nan` is only possible in the aggregate metric if all timeseries
+        for a metric resulted in `nan`.
     """
 
     default_quantiles = 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This pr adds logic which allows users to choose how per-timeseries metrics should be aggregated when calling `Evaluator.get_aggregate_metrics`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
