### PR TITLE
Add transform objects for dealing with sparse time series.

### DIFF
--- a/src/gluonts/transform/convert.py
+++ b/src/gluonts/transform/convert.py
@@ -759,3 +759,67 @@ def cdf_to_gaussian_forward_transform(
             tensor_to_numpy(input_batch["intercepts"]),
         )
     return outputs
+
+
+class SparseToDense(FlatMapTransformation):
+    """
+    Convert a sparse univariate time series to the `interval-size` format,
+    i.e., a two dimensional time series where the first dimension corresponds
+    to the time since last positive value (1-indexed), and the second dimension
+    corresponds to the size of the demand. This format is used often in the
+    intermittent demand literature, where predictions are performed on this
+    "dense" time series, e.g., as in Croston's method.
+
+    As an example, the time series `[0, 0, 1, 0, 3, 2, 0, 4]` is converted into
+    the 2-dimensional time series `[[3, 2, 1, 2], [1, 3, 2, 4]]`, with a
+    shape (2, M) where M denotes the number of non-zero items in the time series.
+
+    Parameters
+    ----------
+    target_field
+        The target field to be converted, containing a univariate and sparse
+        time series
+    drop_empty
+        If True, all-zero time series will be dropped.
+    discard_first
+        If True, the first element in the converted dense series will be dropped,
+        replacing the target with a (2, M-1) tet instead. This can be used
+        when the first 'inter-demand' time is not well-defined. e.g., when the true
+        starting index of the time-series is not known.
+    """
+
+    @validated()
+    def __init__(
+        self,
+        target_field: str,
+        drop_empty: bool = False,
+        discard_first: bool = False,
+    ) -> None:
+
+        self.target_field = target_field
+        self.drop_empty = drop_empty
+        self.discard_first = discard_first
+
+    def _process_sparse_time_sample(self, a: List) -> Tuple[List, List]:
+        a = np.array(a)
+        nz = np.nonzero(a)[0]
+
+        if len(nz) == 0:
+            return [], []
+
+        times = np.diff(np.r_[-1, np.nonzero(a)[0]]).astype(np.float).tolist()
+        sizes = a[np.nonzero(a)].tolist()
+
+        return (times[1:], sizes[1:]) if self.discard_first else (times, sizes)
+
+    def flatmap_transform(
+        self, data: DataEntry, is_train: bool
+    ) -> Iterator[DataEntry]:
+        target = data[self.target_field]
+
+        times, sizes = self._process_sparse_time_sample(target)
+
+        if len(times) > 0 or not self.drop_empty:
+            new_data = data.copy()
+            new_data[self.target_field] = [times, sizes]
+            yield new_data

--- a/src/gluonts/transform/feature.py
+++ b/src/gluonts/transform/feature.py
@@ -555,3 +555,39 @@ class AddAggregateLags(MapTransformation):
         )
 
         return data
+
+
+class AddTrailingZeros(SimpleTransformation):
+    """
+    Add the number of 'trailing' zeros in each univariate time series as a feature, to be
+    used when dealing with sparse (intermittent) time series. For
+    example, for a time series `[0, 0, 2, 3, 0]`, the number of trailing
+    zeros will be 1.
+
+    Parameters
+    ----------
+    new_field
+        Name of the new field to be created, which will contain the number of trailing
+        zeros.
+    target_field
+        Field with target values (array) of time series
+    """
+
+    def __init__(
+        self,
+        new_field: str = "trailing_zeros",
+        target_field: str = "target",
+    ) -> None:
+        self.target_field = target_field
+        self.new_field = new_field
+
+    def map_transform(self, data: DataEntry, is_train: bool) -> DataEntry:
+        return self.transform(data)
+
+    def transform(self, data: DataEntry) -> DataEntry:
+        target = data[self.target_field]
+        if len(target) == 0:
+            return data
+        nz = np.nonzero(target[::-1])[0]
+        data[self.new_field] = min(nz) if len(nz) > 0 else len(target)
+        return data

--- a/src/gluonts/transform/feature.py
+++ b/src/gluonts/transform/feature.py
@@ -557,7 +557,7 @@ class AddAggregateLags(MapTransformation):
         return data
 
 
-class AddTrailingZeros(SimpleTransformation):
+class CountTrailingZeros(SimpleTransformation):
     """
     Add the number of 'trailing' zeros in each univariate time series as a feature, to be
     used when dealing with sparse (intermittent) time series. For
@@ -581,13 +581,9 @@ class AddTrailingZeros(SimpleTransformation):
         self.target_field = target_field
         self.new_field = new_field
 
-    def map_transform(self, data: DataEntry, is_train: bool) -> DataEntry:
-        return self.transform(data)
-
     def transform(self, data: DataEntry) -> DataEntry:
         target = data[self.target_field]
         if len(target) == 0:
             return data
-        nz = np.nonzero(target[::-1])[0]
-        data[self.new_field] = min(nz) if len(nz) > 0 else len(target)
+        data[self.new_field] = len(target) - len(np.trim_zeros(target, "b"))
         return data

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -36,6 +36,8 @@ from gluonts.transform import (
     MissingValueImputation,
     RollingMeanValueImputation,
 )
+from gluonts.transform.convert import SparseToDense
+from gluonts.transform.feature import AddTrailingZeros
 
 FREQ = "1D"
 
@@ -1091,3 +1093,105 @@ def assert_padded_array(
         f"Sampled and reference arrays do not match. '"
         f"Got {sampled_no_padding} but should be {reference_no_padding}."
     )
+
+
+@pytest.mark.parametrize(
+    "target, expected",
+    [
+        ([0, 0, 1, 1, 2, 0, 0], 2),
+        ([0, 0, 1, 1, 2, 0, 0, 0, 0], 4),
+        ([0, 0, 1, 1, 2], 0),
+        ([0, 0], 2),
+        ([], 0),
+    ],
+)
+@pytest.mark.parametrize("convert_to_np", [True, False])
+@pytest.mark.parametrize("is_train", [True, False])
+def test_add_trailing_zeros(target, expected, convert_to_np, is_train):
+    if convert_to_np:
+        target = np.array(target)
+
+    data_set = ListDataset(
+        [{"target": target, "start": "2010-01-01"}], freq="1m"
+    )
+    transform = AddTrailingZeros(new_field="time_remaining")
+
+    transformed = next(transform(data_set, is_train=is_train))
+
+    if len(target) == 0:
+        assert "time_remaining" not in transformed
+        return
+
+    assert "time_remaining" in transformed
+    assert transformed["time_remaining"] == expected
+
+
+@pytest.mark.parametrize(
+    "transform, target, expected",
+    [
+        (
+            SparseToDense(target_field="target"),
+            [0, 0, 1, 0, 3, 2, 0, 4],
+            [[3, 2, 1, 2], [1, 3, 2, 4]],
+        ),
+        (
+            SparseToDense(target_field="target", discard_first=True),
+            [0, 0, 1, 0, 3, 2, 0, 4],
+            [[2, 1, 2], [3, 2, 4]],
+        ),
+        (
+            SparseToDense(target_field="target", discard_first=True),
+            [0, 0, 0, 0, 0, 0],
+            [[], []],
+        ),
+        (
+            SparseToDense(target_field="target", discard_first=False),
+            [0, 0, 0, 0, 0, 0],
+            [[], []],
+        ),
+        (
+            SparseToDense(target_field="target", discard_first=True),
+            [0, 0, 1, 0],
+            [[], []],
+        ),
+        (
+            SparseToDense(
+                target_field="target", discard_first=True, drop_empty=True
+            ),
+            [0, 0, 0, 0, 0, 0],
+            [[], []],
+        ),
+        (
+            SparseToDense(
+                target_field="target", discard_first=False, drop_empty=True
+            ),
+            [0, 0, 0, 0, 0, 0],
+            [[], []],
+        ),
+        (
+            SparseToDense(
+                target_field="target", discard_first=True, drop_empty=True
+            ),
+            [0, 0, 1, 0],
+            [[], []],
+        ),
+    ],
+)
+@pytest.mark.parametrize("convert_to_np", [True, False])
+@pytest.mark.parametrize("is_train", [True, False])
+def test_sparse_to_dense(transform, target, expected, convert_to_np, is_train):
+    if convert_to_np:
+        target = np.array(target)
+
+    data_set = ListDataset(
+        [{"target": target, "start": "2010-01-01"}], freq="1m"
+    )
+
+    if transform.drop_empty:
+        try:
+            next(transform(data_set, is_train=is_train))
+        except StopIteration:
+            return
+
+    transformed = next(transform(data_set, is_train=is_train))
+    assert np.allclose(transformed["target"], expected)

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -36,8 +36,8 @@ from gluonts.transform import (
     MissingValueImputation,
     RollingMeanValueImputation,
 )
-from gluonts.transform.convert import SparseToDense
-from gluonts.transform.feature import AddTrailingZeros
+from gluonts.transform.convert import ToIntervalSizeFormat
+from gluonts.transform.feature import CountTrailingZeros
 
 FREQ = "1D"
 
@@ -1107,14 +1107,14 @@ def assert_padded_array(
 )
 @pytest.mark.parametrize("convert_to_np", [True, False])
 @pytest.mark.parametrize("is_train", [True, False])
-def test_add_trailing_zeros(target, expected, convert_to_np, is_train):
+def test_count_trailing_zeros(target, expected, convert_to_np, is_train):
     if convert_to_np:
         target = np.array(target)
 
     data_set = ListDataset(
         [{"target": target, "start": "2010-01-01"}], freq="1m"
     )
-    transform = AddTrailingZeros(new_field="time_remaining")
+    transform = CountTrailingZeros(new_field="time_remaining")
 
     transformed = next(transform(data_set, is_train=is_train))
 
@@ -1130,46 +1130,46 @@ def test_add_trailing_zeros(target, expected, convert_to_np, is_train):
     "transform, target, expected",
     [
         (
-            SparseToDense(target_field="target"),
+            ToIntervalSizeFormat(target_field="target"),
             [0, 0, 1, 0, 3, 2, 0, 4],
             [[3, 2, 1, 2], [1, 3, 2, 4]],
         ),
         (
-            SparseToDense(target_field="target", discard_first=True),
+            ToIntervalSizeFormat(target_field="target", discard_first=True),
             [0, 0, 1, 0, 3, 2, 0, 4],
             [[2, 1, 2], [3, 2, 4]],
         ),
         (
-            SparseToDense(target_field="target", discard_first=True),
+            ToIntervalSizeFormat(target_field="target", discard_first=True),
             [0, 0, 0, 0, 0, 0],
             [[], []],
         ),
         (
-            SparseToDense(target_field="target", discard_first=False),
+            ToIntervalSizeFormat(target_field="target", discard_first=False),
             [0, 0, 0, 0, 0, 0],
             [[], []],
         ),
         (
-            SparseToDense(target_field="target", discard_first=True),
+            ToIntervalSizeFormat(target_field="target", discard_first=True),
             [0, 0, 1, 0],
             [[], []],
         ),
         (
-            SparseToDense(
+            ToIntervalSizeFormat(
                 target_field="target", discard_first=True, drop_empty=True
             ),
             [0, 0, 0, 0, 0, 0],
             [[], []],
         ),
         (
-            SparseToDense(
+            ToIntervalSizeFormat(
                 target_field="target", discard_first=False, drop_empty=True
             ),
             [0, 0, 0, 0, 0, 0],
             [[], []],
         ),
         (
-            SparseToDense(
+            ToIntervalSizeFormat(
                 target_field="target", discard_first=True, drop_empty=True
             ),
             [0, 0, 1, 0],
@@ -1179,7 +1179,9 @@ def test_add_trailing_zeros(target, expected, convert_to_np, is_train):
 )
 @pytest.mark.parametrize("convert_to_np", [True, False])
 @pytest.mark.parametrize("is_train", [True, False])
-def test_sparse_to_dense(transform, target, expected, convert_to_np, is_train):
+def test_to_interval_size_format(
+    transform, target, expected, convert_to_np, is_train
+):
     if convert_to_np:
         target = np.array(target)
 


### PR DESCRIPTION
*Issue #, if available:*

Related to creating dedicated neural intermittent demand models in GluonTS.

*Description of changes:*

This PR adds two simple transformation objects that are meant to specifically deal with intermittent time series. Namely, `AddTrailingZeros` simply adds the number of zero valued time steps that are trailing in each of the target time series, allowing models to explicitly condition on the number of steps since the last 'demand' point when making a prediction. `SparseToDense` transformation takes a univariate time series and converts it to a size-interval format as often used in intermittent demand forecasting (e.g., in Croston's method).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
