### PR TITLE
fix compatibility for pandas < 1.1 in `time_feature/_base.py`

### DIFF
--- a/src/gluonts/time_feature/_base.py
+++ b/src/gluonts/time_feature/_base.py
@@ -125,22 +125,30 @@ class WeekOfYear(TimeFeature):
     """Week of year encoded as value between [-0.5, 0.5]"""
 
     def __call__(self, index: pd.DatetimeIndex) -> np.ndarray:
+        # TODO:
+        # * pandas >= 1.1 does not support `.week`
+        # * pandas == 1.0 does not support `.isocalendar()`
+        # as soon as we drop support for `pandas == 1.0`, we should remove this
         try:
-            return (index.isocalendar().week - 1) / 52.0 - 0.5
+            week = index.isocalendar().week
         except AttributeError:
-            # compatibility for pandas < 1.1
-            return (index.week - 1) / 52.0 - 0.5
+            week = index.week
+        return (week - 1) / 52.0 - 0.5
 
 
 class WeekOfYearIndex(TimeFeature):
     """Week of year encoded as zero-based index, between 0 and 52"""
 
     def __call__(self, index: pd.DatetimeIndex) -> np.ndarray:
+        # TODO:
+        # * pandas >= 1.1 does not support `.week`
+        # * pandas == 1.0 does not support `.isocalendar()`
+        # as soon as we drop support for `pandas == 1.0`, we should remove this
         try:
-            return (index.isocalendar().week - 1).map(float)
+            week = index.isocalendar().week
         except AttributeError:
-            # compatibility for pandas < 1.1
-            return (index.week - 1).map(float)
+            week = index.week
+        return (week - 1).map(float)
 
 
 def norm_freq_str(freq_str: str) -> str:

--- a/src/gluonts/time_feature/_base.py
+++ b/src/gluonts/time_feature/_base.py
@@ -125,14 +125,14 @@ class WeekOfYear(TimeFeature):
     """Week of year encoded as value between [-0.5, 0.5]"""
 
     def __call__(self, index: pd.DatetimeIndex) -> np.ndarray:
-        return (index.isocalendar().week - 1) / 52.0 - 0.5
+        return (index.week - 1) / 52.0 - 0.5
 
 
 class WeekOfYearIndex(TimeFeature):
     """Week of year encoded as zero-based index, between 0 and 52"""
 
     def __call__(self, index: pd.DatetimeIndex) -> np.ndarray:
-        return (index.isocalendar().week - 1).map(float)
+        return (index.week - 1).map(float)
 
 
 def norm_freq_str(freq_str: str) -> str:

--- a/src/gluonts/time_feature/_base.py
+++ b/src/gluonts/time_feature/_base.py
@@ -125,14 +125,22 @@ class WeekOfYear(TimeFeature):
     """Week of year encoded as value between [-0.5, 0.5]"""
 
     def __call__(self, index: pd.DatetimeIndex) -> np.ndarray:
-        return (index.week - 1) / 52.0 - 0.5
+        try:
+            return (index.isocalendar().week - 1) / 52.0 - 0.5
+        except AttributeError:
+            # compatibility for pandas < 1.1
+            return (index.week - 1) / 52.0 - 0.5
 
 
 class WeekOfYearIndex(TimeFeature):
     """Week of year encoded as zero-based index, between 0 and 52"""
 
     def __call__(self, index: pd.DatetimeIndex) -> np.ndarray:
-        return (index.week - 1).map(float)
+        try:
+            return (index.isocalendar().week - 1).map(float)
+        except AttributeError:
+            # compatibility for pandas < 1.1
+            return (index.week - 1).map(float)
 
 
 def norm_freq_str(freq_str: str) -> str:


### PR DESCRIPTION
*Issue #, if available:*
```
     def __call__(self, index: pd.DatetimeIndex) -> np.ndarray:
 >       return (index.isocalendar().week - 1).map(float)
 E       AttributeError: 'DatetimeIndex' object has no attribute 'isocalendar'
```
According to https://github.com/awslabs/gluon-ts/issues/1335 we support pandas >= 1.0, but when using pandas < 1.1 we get the displayed error for `class WeekOfYearIndex` and `class WeekOfYear`.

*Description of changes:*
Added try block around `isocalendar()` function call and replaced it for the given error with the respective implementation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
