### PR TITLE
adjustments to variable length functionality in batchify

### DIFF
--- a/src/gluonts/mx/batchify.py
+++ b/src/gluonts/mx/batchify.py
@@ -22,41 +22,30 @@ from gluonts.dataset.common import DataBatch
 from gluonts.support.util import pad_to_size
 
 
-# TODO: should the following contempate mxnet arrays or just numpy arrays?
 def _is_stackable(arrays: List, axis: int = 0) -> bool:
     """
     Check if elements are scalars, have too few dimensions, or their
     target axes have equal length; i.e. they are directly `stack` able.
     """
-    if isinstance(arrays[0], (mx.nd.NDArray, np.ndarray)):
+    if isinstance(arrays[0], np.ndarray):
         s = set(arr.shape[axis] for arr in arrays)
         return len(s) <= 1 and arrays[0].shape[axis] != 0
     return True
 
 
-# TODO: should the following contempate mxnet arrays or just numpy arrays?
 def _pad_arrays(
-    data: List[Union[np.ndarray, mx.nd.NDArray]], axis: int = 0
-) -> List[Union[np.ndarray, mx.nd.NDArray]]:
-    assert isinstance(data[0], (np.ndarray, mx.nd.NDArray))
-    is_mx = isinstance(data[0], mx.nd.NDArray)
+    data: List[np.ndarray],
+    axis: int = 0,
+    is_right_pad: bool = True,
+) -> List[np.ndarray]:
+    assert isinstance(data[0], np.ndarray)
 
     # MxNet causes a segfault when persisting 0-length arrays. As such,
     # we add a dummy pad of length 1 to 0-length dims.
     max_len = max(1, functools.reduce(max, (x.shape[axis] for x in data)))
-    padded_data = []
-
-    for x in data:
-        # MxNet lacks the functionality to pad n-D arrays consistently.
-        # We fall back to numpy if x is an mx.nd.NDArray.
-        if is_mx:
-            x = x.asnumpy()
-
-        x = pad_to_size(x, max_len, axis)
-
-        padded_data.append(x if not is_mx else mx.nd.array(x))
-
-    return padded_data
+    return [
+        pad_to_size(x, max_len, axis, is_right_pad=is_right_pad) for x in data
+    ]
 
 
 def stack(
@@ -64,9 +53,10 @@ def stack(
     ctx: Optional[mx.context.Context] = None,
     dtype: Optional[DType] = np.float32,
     variable_length: bool = False,
+    is_right_pad: bool = True,
 ):
     if variable_length and not _is_stackable(data):
-        data = _pad_arrays(data, axis=0)
+        data = _pad_arrays(data, axis=0, is_right_pad=is_right_pad)
     if isinstance(data[0], mx.nd.NDArray):
         # TODO: think about using shared context NDArrays
         #  https://github.com/awslabs/gluon-ts/blob/42bee73409f801e7bca73245ca21cd877891437c/src/gluonts/dataset/parallelized_loader.py#L157
@@ -83,6 +73,7 @@ def batchify(
     ctx: Optional[mx.context.Context] = None,
     dtype: Optional[DType] = np.float32,
     variable_length: bool = False,
+    is_right_pad: bool = True,
 ) -> DataBatch:
     return {
         key: stack(
@@ -90,6 +81,7 @@ def batchify(
             ctx=ctx,
             dtype=dtype,
             variable_length=variable_length,
+            is_right_pad=is_right_pad,
         )
         for key in data[0].keys()
     }

--- a/test/dataset/test_variable_length.py
+++ b/test/dataset/test_variable_length.py
@@ -197,9 +197,7 @@ def test_inference_loader_short_intervals(loader_factory, pp_dataset):
 
 @pytest.mark.parametrize("is_right_pad", [True, False])
 def test_variable_length_stack(pp_dataset, is_right_pad):
-    arrays = [
-        d["target"].T for d in list(iter(pp_dataset()))
-    ]
+    arrays = [d["target"].T for d in list(iter(pp_dataset()))]
 
     stacked = stack(
         arrays,
@@ -214,10 +212,7 @@ def test_variable_length_stack(pp_dataset, is_right_pad):
 
 @pytest.mark.parametrize("is_right_pad", [True, False])
 def test_variable_length_stack_zerosize(pp_dataset, is_right_pad):
-    arrays = [
-        np.zeros(shape=(0, 2))
-        for _ in range(5)
-    ]
+    arrays = [np.zeros(shape=(0, 2)) for _ in range(5)]
 
     stacked = stack(
         arrays,
@@ -233,9 +228,7 @@ def test_variable_length_stack_zerosize(pp_dataset, is_right_pad):
 @pytest.mark.parametrize("axis", [0, 1])
 @pytest.mark.parametrize("is_right_pad", [True, False])
 def test_pad_arrays_axis(axis: int, is_right_pad: bool):
-    arrays = [
-        d["target"] for d in list(iter(get_dataset()))
-    ]
+    arrays = [d["target"] for d in list(iter(get_dataset()))]
     if axis == 0:
         arrays = [x.T for x in arrays]
 
@@ -246,9 +239,7 @@ def test_pad_arrays_axis(axis: int, is_right_pad: bool):
 
 
 def test_pad_arrays_pad_left():
-    arrays = [
-        d["target"] for d in list(iter(get_dataset()))
-    ]
+    arrays = [d["target"] for d in list(iter(get_dataset()))]
     padded_arrays = _pad_arrays(arrays, 1, is_right_pad=False)
 
     for padded_array in padded_arrays[1:]:

--- a/test/dataset/test_variable_length.py
+++ b/test/dataset/test_variable_length.py
@@ -195,20 +195,16 @@ def test_inference_loader_short_intervals(loader_factory, pp_dataset):
     assert d["past_target"].shape[1] == 1
 
 
-@pytest.mark.parametrize(
-    "array_type, multi_processing",
-    itertools.product(["np", "mx"], [True, False]),
-)
-def test_variable_length_stack(pp_dataset, array_type, multi_processing):
+@pytest.mark.parametrize("is_right_pad", [True, False])
+def test_variable_length_stack(pp_dataset, is_right_pad):
     arrays = [
-        d["target"].T if array_type == "np" else mx.nd.array(d["target"].T)
-        for d in list(iter(pp_dataset()))
+        d["target"].T for d in list(iter(pp_dataset()))
     ]
 
-    assert isinstance(multi_processing, bool)
     stacked = stack(
         arrays,
         variable_length=True,
+        is_right_pad=is_right_pad,
     )
 
     assert stacked.shape[0] == 3
@@ -216,24 +212,17 @@ def test_variable_length_stack(pp_dataset, array_type, multi_processing):
     assert stacked.shape[2] == 2
 
 
-@pytest.mark.parametrize(
-    "array_type, multi_processing",
-    itertools.product(["np", "mx"], [True, False]),
-)
-def test_variable_length_stack_zerosize(
-    pp_dataset, array_type, multi_processing
-):
+@pytest.mark.parametrize("is_right_pad", [True, False])
+def test_variable_length_stack_zerosize(pp_dataset, is_right_pad):
     arrays = [
         np.zeros(shape=(0, 2))
-        if array_type == "np"
-        else mx.nd.array(np.zeros(shape=(0, 2)))
         for _ in range(5)
     ]
 
-    assert isinstance(multi_processing, bool)
     stacked = stack(
         arrays,
         variable_length=True,
+        is_right_pad=is_right_pad,
     )
 
     assert stacked.shape[0] == 5
@@ -241,19 +230,26 @@ def test_variable_length_stack_zerosize(
     assert stacked.shape[2] == 2
 
 
-@pytest.mark.parametrize(
-    "array_type, multi_processing, axis",
-    itertools.product(["np", "mx"], [True, False], [0, 1]),
-)
-def test_pad_arrays_axis(array_type, multi_processing, axis: int):
+@pytest.mark.parametrize("axis", [0, 1])
+@pytest.mark.parametrize("is_right_pad", [True, False])
+def test_pad_arrays_axis(axis: int, is_right_pad: bool):
     arrays = [
-        d["target"] if array_type == "np" else mx.nd.array(d["target"])
-        for d in list(iter(get_dataset()))
+        d["target"] for d in list(iter(get_dataset()))
     ]
     if axis == 0:
         arrays = [x.T for x in arrays]
 
-    padded_arrays = _pad_arrays(arrays, axis)
+    padded_arrays = _pad_arrays(arrays, axis, is_right_pad=is_right_pad)
 
     assert all(a.shape[axis] == 8 for a in padded_arrays)
     assert all(a.shape[1 - axis] == 2 for a in padded_arrays)
+
+
+def test_pad_arrays_pad_left():
+    arrays = [
+        d["target"] for d in list(iter(get_dataset()))
+    ]
+    padded_arrays = _pad_arrays(arrays, 1, is_right_pad=False)
+
+    for padded_array in padded_arrays[1:]:
+        assert np.allclose(padded_array[:, 0], 0)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

batchify functions for handling variable length arrays handled mxnet arrays, which were marked as todos. this PR removes this, restricting the accepted array types to numpy arrays. moreover, it exposes the `is_right_pad` option, already available in `pad_to_size`, also in `batchify` and `stack`. This allows users to specify whether the arrays should be padded on the right (as is the mxnet convention, in functions like `SequenceMask`) or left.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
