### PR TITLE
Fix train-test split data leakage for m4_yearly and wiki-rolling_nips.

### DIFF
--- a/src/gluonts/dataset/repository/_m4.py
+++ b/src/gluonts/dataset/repository/_m4.py
@@ -58,15 +58,19 @@ def generate_m4_dataset(
     ]
 
     if m4_freq == "Yearly":
-        # some time series have more than 300 years which can not be represented in pandas,
-        # this is probably due to a misclassification of those time series as Yearly
-        # we simply use only the last 300 years for training
-        # note this does not affect test time as prediction length is less than 300 years
-        train_target_values = [ts[-300:] for ts in train_target_values]
-        test_target_values = [ts[-300:] for ts in test_target_values]
+        # some time series have more than 300 years which can not be
+        # represented in pandas, this is probably due to a misclassification
+        # of those time series as Yearly. We use only those time series with
+        # fewer than 300 items for this reason.
+        train_target_values = [
+            ts for ts in train_target_values if len(ts) <= 300
+        ]
+        test_target_values = [
+            ts for ts in test_target_values if len(ts) <= 300
+        ]
 
-    # the original dataset did not include time stamps, so we use a mock start date for each time series
-    # we use the earliest point available in pandas
+    # the original dataset did not include time stamps, so we use the earliest
+    # point available in pandas as the start date for each time series.
     mock_start_dataset = "1750-01-01 00:00:00"
 
     save_to_file(

--- a/test/dataset/test_train_test_data_leakage.py
+++ b/test/dataset/test_train_test_data_leakage.py
@@ -1,0 +1,52 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import pytest
+from gluonts.dataset.repository.datasets import dataset_names, get_dataset
+
+
+def check_train_test_split(dataset):
+    prediction_length = dataset.metadata.prediction_length
+
+    train_end = {}
+    for entry in dataset.train:
+        assert (
+            entry["item_id"] not in train_end
+        ), f"item {entry['item_id']} is duplicate"
+        train_end[entry["item_id"]] = (
+            entry["start"] + len(entry["target"]) * entry["start"].freq
+        )
+
+    test_end = {}
+    for entry in dataset.test:
+        test_end[entry["item_id"]] = (
+            entry["start"] + len(entry["target"]) * entry["start"].freq
+        )
+
+    for k in test_end:
+        if k not in train_end:
+            continue
+        expected_end = train_end[k] + prediction_length * train_end[k].freq
+        assert (
+            test_end[k] >= expected_end
+        ), f"test entry for item {k} ends at {test_end[k]} < {expected_end}"
+
+
+@pytest.mark.parametrize("name", dataset_names)
+def test_data_leakage(name):
+    try:
+        dataset = get_dataset(name)
+    except RuntimeError:
+        print(f"WARN dataset '{name}' could not be obtained")
+
+    check_train_test_split(dataset)


### PR DESCRIPTION
*Issue #, if available:*
#1418

*Description of changes:*
This pr fixes data leakage issues discussed in #1418.
Further tests for detecting data leakage is implemented and `item_id` values are added to the `m5` dataset.
The `item_id` values are added in order to test for data leakage within the `m5` dataset.

Worklog:

- [x] implement test.
- [x] fix data leakage in m4_yearly.
- [ ] fix data leakage in wiki-rolling_nips.
- [ ] add `item_id` to `m5` dataset.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
