### PR TITLE
Fix missing import in `gluonts.mx.model.GluonEstimator`

### DIFF
--- a/src/gluonts/mx/model/estimator.py
+++ b/src/gluonts/mx/model/estimator.py
@@ -18,6 +18,7 @@ import numpy as np
 from mxnet.gluon import HybridBlock
 from pydantic import ValidationError
 
+from gluonts.core import fqname_for
 from gluonts.core.component import (
     DType,
     from_hyperparameters,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
