### PR TITLE
Lock the version for mxtheme to 0.3.15

### DIFF
--- a/requirements/requirements-docs.txt
+++ b/requirements/requirements-docs.txt
@@ -10,4 +10,4 @@ sphinx-autobuild~=0.7
 sphinx-autorun
 sphinx-gallery
 tornado==5.1.1
-mxtheme==0.3.*
+mxtheme==0.3.15


### PR DESCRIPTION
*Description of changes:* The latest mxtheme==0.3.16 gave issues in docs builds: https://github.com/awslabs/gluon-ts/pull/1450/checks?check_run_id=2543302170

We will unlock or bump this version at some other stage.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
