### PR TITLE
Fix get_lags_for_frequency for minute data in DeepVAR

### DIFF
--- a/src/gluonts/model/deepvar/_estimator.py
+++ b/src/gluonts/model/deepvar/_estimator.py
@@ -125,7 +125,7 @@ def get_lags_for_frequency(
         lags = [[1, 2]]
     elif granularity == "H":
         lags = [[1, 24, 168]]
-    elif granularity in ("min", "T") :
+    elif granularity in ("min", "T"):
         lags = [[1, 4, 12, 24, 48]]
     else:
         lags = [[1]]


### PR DESCRIPTION
the granularity can be "T" for minute data

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup