### PR TITLE
Deep renewal processes for intermittent demand forecasting

### DIFF
--- a/src/gluonts/model/renewal/__init__.py
+++ b/src/gluonts/model/renewal/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from ._estimator import DeepRenewalProcessEstimator
+
+__all__ = ["DeepRenewalProcessEstimator"]
+
+# fix Sphinx issues, see https://bit.ly/2K2eptM
+for item in __all__:
+    if hasattr(item, "__module__"):
+        setattr(item, "__module__", __name__)

--- a/src/gluonts/model/renewal/_estimator.py
+++ b/src/gluonts/model/renewal/_estimator.py
@@ -1,0 +1,286 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+from functools import partial
+from typing import Optional, Callable
+
+from gluonts.core.component import validated
+from gluonts.model.renewal._predictor import DeepRenewalProcessPredictor
+from mxnet.gluon import HybridBlock
+
+from gluonts.itertools import Cyclic
+from gluonts.model.predictor import Predictor
+from gluonts.model.renewal._transform import AddAxisLength
+from gluonts.mx.trainer import Trainer
+from gluonts.mx.util import copy_parameters
+from gluonts.transform.convert import ToIntervalSizeFormat, SwapAxes
+from gluonts.transform.feature import CountTrailingZeros
+from gluonts.dataset.common import Dataset
+from gluonts.dataset.field_names import FieldName
+from gluonts.dataset.loader import DataLoader
+from gluonts.mx.model.estimator import GluonEstimator
+from gluonts.transform import (
+    InstanceSplitter,
+    ExpectedNumInstanceSampler,
+    Chain,
+    AsNumpyArray,
+    ValidationSplitSampler,
+    TestSplitSampler,
+    RenameFields,
+    Transformation,
+    InstanceSampler,
+    SelectFields,
+    TransformedDataset,
+    AddObservedValuesIndicator,
+)
+from gluonts.mx.batchify import batchify, as_in_context
+from gluonts.model.renewal._network import (
+    DeepRenewalTrainingNetwork,
+    DeepRenewalPredictionNetwork,
+)
+from gluonts.mx.distribution import NegativeBinomialOutput, DistributionOutput
+
+
+class DeepRenewalProcessEstimator(GluonEstimator):
+    """
+    Implements a deep renewal process estimator designed to forecast intermittent time series
+    sampled in discrete time, as described in [TWJ19]_.
+
+    In short, instead of viewing sparse time series as a univariate stochastic process, this
+    estimator transforms a sparse time series [0, 0, 0, 3, 0, 0, 7] to an interval-size format,
+    [(4, 3), (3, 7)] where each ordered pair marks the time since the last positive time step
+    (interval) and the value of the positive time step (size). Then, probabilistic prediction
+    is performed on this transformed time series, as is customary in the intermittent demand
+    literature, e.g., Croston's method.
+
+    This construction is a self-modulated marked renewal process in discrete time as one assumes
+    the (conditional) distribution of intervals are identical.
+
+    Parameters
+    ----------
+    freq
+        Frequency of the data to train on and predict
+    prediction_length
+        Length of the prediction horizon
+    context_length
+        The number of time steps the model will condition on
+    num_cells
+        Number of hidden units used in the RNN cell (LSTM) and dense layer for
+        projection to distribution arguments
+    num_layers
+        Number of layers in the LSTM
+    dropout_rate
+        Dropout regularization parameter (default: 0.1)
+    trainer
+        Trainer object to be used (default: Trainer())
+    interval_distr_output
+        Distribution output object for the intervals. Must be a distribution with
+        support on positive integers, where the first argument corresponds to the
+        (conditional) mean.
+    size_distr_output
+        Distribution output object for the demand sizes. Must be a distribution with
+        support on positive integers, where the first argument corresponds to the
+        (conditional) mean.
+    train_sampler
+        Controls the sampling of windows during training.
+    validation_sampler
+        Controls the sampling of windows during validation.
+    batch_size
+        The size of the batches to be used training and prediction.
+    num_parallel_samples
+        Number of evaluation samples per time series to increase parallelism during inference.
+        This is a model optimization that does not affect the accuracy (default: 100)
+    """
+
+    @validated()
+    def __init__(
+        self,
+        freq: str,
+        prediction_length: int,
+        context_length: int,
+        num_cells: int,
+        num_layers: int,
+        dropout_rate: float = 0.1,
+        interval_distr_output: DistributionOutput = NegativeBinomialOutput(),
+        size_distr_output: DistributionOutput = NegativeBinomialOutput(),
+        train_sampler: Optional[InstanceSampler] = None,
+        validation_sampler: Optional[InstanceSampler] = None,
+        trainer: Trainer = Trainer(hybridize=False),
+        batch_size: int = 32,
+        num_parallel_samples: int = 100,
+        **kwargs,
+    ):
+        super().__init__(trainer=trainer, batch_size=batch_size, **kwargs)
+
+        assert (
+            prediction_length > 0
+        ), "The value of `prediction_length` should be > 0"
+        assert (
+            context_length is None or context_length > 0
+        ), "The value of `context_length` should be > 0"
+        assert dropout_rate >= 0, "The value of `dropout_rate` should be >= 0"
+
+        self.freq = freq
+        self.context_length = context_length
+        self.prediction_length = prediction_length
+        self.num_cells = num_cells
+        self.num_layers = num_layers
+        self.dropout_rate = dropout_rate
+        self.interval_distr_output = interval_distr_output
+        self.size_distr_output = size_distr_output
+        self.num_parallel_samples = num_parallel_samples
+
+        self.train_sampler = (
+            train_sampler
+            if train_sampler is not None
+            else ExpectedNumInstanceSampler(
+                num_instances=5, min_future=prediction_length
+            )
+        )
+        self.validation_sampler = (
+            validation_sampler
+            if validation_sampler is not None
+            else ValidationSplitSampler(min_future=prediction_length)
+        )
+
+    def create_transformation(self) -> Transformation:
+        return AddObservedValuesIndicator(
+            target_field=FieldName.TARGET,
+            output_field=FieldName.OBSERVED_VALUES,
+        )
+
+    def _create_instance_splitter(self, mode: str):
+        assert mode in ["training", "validation", "test"]
+
+        instance_sampler = {
+            "training": self.train_sampler,
+            "validation": self.validation_sampler,
+            "test": TestSplitSampler(),
+        }[mode]
+
+        return InstanceSplitter(
+            target_field=FieldName.TARGET,
+            is_pad_field=FieldName.IS_PAD,
+            start_field=FieldName.START,
+            forecast_start_field=FieldName.FORECAST_START,
+            instance_sampler=instance_sampler,
+            past_length=self.context_length,
+            future_length=self.prediction_length,
+        )
+
+    @staticmethod
+    def _create_post_split_transform():
+        return Chain(
+            [
+                CountTrailingZeros(
+                    new_field="time_remaining",
+                    target_field="past_target",
+                    as_array=True,
+                ),
+                ToIntervalSizeFormat(
+                    target_field="past_target", discard_first=True
+                ),
+                RenameFields({"future_target": "sparse_future"}),
+                AsNumpyArray(field="past_target", expected_ndim=2),
+                SwapAxes(input_fields=["past_target"], axes=(0, 1)),
+                AddAxisLength(target_field="past_target", axis=0),
+            ]
+        )
+
+    def _stack_fn(self) -> Callable:
+        return partial(
+            batchify,
+            ctx=self.trainer.ctx,
+            dtype=self.dtype,
+            variable_length=True,
+            is_right_pad=False,
+        )
+
+    def create_training_data_loader(
+        self,
+        data: Dataset,
+        **kwargs,
+    ) -> DataLoader:
+        train_transform = (
+            self._create_instance_splitter("training")
+            + self._create_post_split_transform()
+            + SelectFields(["past_target", "valid_length"])
+        )
+        return DataLoader(
+            data_iterable=TransformedDataset(
+                Cyclic(data), train_transform, is_train=True
+            ),
+            batch_size=self.batch_size,
+            stack_fn=self._stack_fn(),
+            decode_fn=partial(as_in_context, ctx=self.trainer.ctx),
+        )
+
+    def create_validation_data_loader(
+        self,
+        data: Dataset,
+        **kwargs,
+    ) -> DataLoader:
+        validation_transform = (
+            self._create_instance_splitter("validation")
+            + self._create_post_split_transform()
+            + SelectFields(["past_target", "valid_length"])
+        )
+        return DataLoader(
+            data_iterable=TransformedDataset(
+                data, validation_transform, is_train=True
+            ),
+            batch_size=self.batch_size,
+            stack_fn=self._stack_fn(),
+            decode_fn=partial(as_in_context, ctx=self.trainer.ctx),
+        )
+
+    def create_training_network(self) -> DeepRenewalTrainingNetwork:
+        return DeepRenewalTrainingNetwork(
+            context_length=self.context_length,
+            prediction_length=self.prediction_length,
+            num_cells=self.num_cells,
+            num_layers=self.num_layers,
+            dropout_rate=self.dropout_rate,
+            interval_distr_output=self.interval_distr_output,
+            size_distr_output=self.size_distr_output,
+        )
+
+    def create_predictor(
+        self, transformation: Transformation, trained_network: HybridBlock
+    ) -> Predictor:
+        prediction_transform = (
+            self._create_instance_splitter("test")
+            + self._create_post_split_transform()
+        )
+
+        prediction_network = DeepRenewalPredictionNetwork(
+            num_parallel_samples=self.num_parallel_samples,
+            context_length=self.context_length,
+            prediction_length=self.prediction_length,
+            num_cells=self.num_cells,
+            num_layers=self.num_layers,
+            dropout_rate=self.dropout_rate,
+            interval_distr_output=self.interval_distr_output,
+            size_distr_output=self.size_distr_output,
+        )
+
+        copy_parameters(trained_network, prediction_network)
+
+        return DeepRenewalProcessPredictor(
+            input_transform=transformation + prediction_transform,
+            prediction_net=prediction_network,
+            batch_size=self.batch_size,
+            freq=self.freq,
+            prediction_length=self.prediction_length,
+            ctx=self.trainer.ctx,
+            input_names=["past_target", "time_remaining"],
+        )

--- a/src/gluonts/model/renewal/_network.py
+++ b/src/gluonts/model/renewal/_network.py
@@ -1,0 +1,348 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from typing import Optional, Tuple
+
+import mxnet as mx
+from gluonts.core.component import validated
+from gluonts.mx import Tensor
+from gluonts.mx.distribution import Distribution, DistributionOutput
+from gluonts.mx.distribution.distribution import getF
+from mxnet import nd, gluon
+
+
+class DeepRenewalNetwork(gluon.HybridBlock):
+    def __init__(
+        self,
+        prediction_length: int,
+        context_length: int,
+        interval_distr_output: DistributionOutput,
+        size_distr_output: DistributionOutput,
+        num_cells: int,
+        num_layers: int,
+        dropout_rate: float = 0.1,
+        **kwargs,
+    ):
+        super(DeepRenewalNetwork, self).__init__(**kwargs)
+
+        self.prediction_length = prediction_length
+        self.context_length = context_length
+        self.interval_distr_output = interval_distr_output
+        self.size_distr_output = size_distr_output
+        self.num_cells = num_cells
+        self.num_layers = num_layers
+
+        with self.name_scope():
+            self.rnn_cell = mx.gluon.rnn.LSTM(
+                hidden_size=num_cells,
+                num_layers=num_layers,
+                layout="NTC",
+                dropout=dropout_rate,
+                h2h_weight_initializer=mx.init.Xavier(),
+                h2r_weight_initializer=mx.init.Xavier(),
+            )
+            self.dense = mx.gluon.nn.Dense(
+                units=2,
+                activation="softrelu",
+                flatten=False,
+                weight_initializer=mx.init.Xavier(),
+                bias_initializer=mx.init.Constant(5.0),
+            )
+
+        # add constant learnable parameters if the distributions require
+        # more than the conditional mean
+        with self.name_scope():
+            if len(self.interval_distr_output.args_dim) > 1:
+                self.interval_alpha_bias = self.params.get(
+                    "interval_alpha_bias",
+                    shape=(1,),
+                    init=mx.init.Constant(2),
+                )
+            if len(self.size_distr_output.args_dim) > 1:
+                self.size_alpha_bias = self.params.get(
+                    "size_alpha_bias",
+                    shape=(1,),
+                    init=mx.init.Constant(2),
+                )
+
+    def begin_state(self, batch_size: int) -> Tuple[Tensor, Tensor]:
+        return self.rnn_cell.begin_state(batch_size=batch_size)
+
+    def distribution(
+        self,
+        cond_mean: Tensor,
+        interval_alpha_bias: Optional[Tensor] = None,
+        size_alpha_bias: Optional[Tensor] = None,
+    ) -> Tuple[Distribution, ...]:
+        F = getF(cond_mean)
+
+        cond_interval, cond_size = F.split(cond_mean, num_outputs=2, axis=-1)
+
+        alpha_biases = [
+            F.broadcast_mul(F.ones_like(cond_interval), bias)
+            if bias is not None
+            else None
+            for bias in [interval_alpha_bias, size_alpha_bias]
+        ]
+
+        distr_params = zip(
+            [self.interval_distr_output, self.size_distr_output],
+            [cond_interval, cond_size],
+            alpha_biases,
+        )
+
+        return tuple(
+            (
+                do.distribution(mean)
+                if len(do.args_dim) == 1
+                else do.distribution(
+                    [mean, F.Activation(alpha_bias, "softrelu") + 1e-5]
+                )
+            )
+            for ix, (do, mean, alpha_bias) in enumerate(distr_params)
+        )
+
+    @staticmethod
+    def forwardshift(A):
+        """
+        Shift an array's content forward by 1 time step along the first axis,
+        keeping the shape identical by repeating the first element.
+
+        Parameters
+        ----------
+        A : nd.NDArray
+            Shape (N, T, ...), the tensor in which the entries will be shifted
+            forward by one
+        """
+        F = getF(A)
+        return F.Concat(
+            F.slice_axis(A, axis=1, begin=0, end=1),
+            F.slice_axis(A, axis=1, begin=0, end=-1),
+            dim=1,
+        )
+
+    def mu_map(
+        self,
+        data: Tensor,
+        shift: bool = True,
+        state=None,
+    ) -> Tensor:
+        """
+        Map a given (N, T, 2) tensor to conditional interval and size
+        means of the next time step.
+
+        Parameters
+        ----------
+        data: Tensor
+            tensor of shape (N, T, 2) containing the past target, with the
+            first array along the last dimension containing intervals, and
+            the second array containing demand sizes.
+        shift: bool
+            if True, the past data will be shifted forward by one time step
+        state
+            RNN cell state if available
+
+        Returns
+        -------
+        conditional_means: Tensor
+            tensor of shape (N, T, 2) containing conditional means for intervals
+            and sizes respectively
+        rnn_out_state
+            output state of the RNN, returned only if the input `state` is not
+            None
+        """
+        data = self.forwardshift(data) if shift else data
+
+        if state is not None:
+            rnn_out, rnn_out_state = self.rnn_cell(data, state)
+        else:
+            rnn_out = self.rnn_cell(data)
+
+        dense_out = self.dense(rnn_out)
+        model_mu = dense_out + 1e-5
+
+        return model_mu if state is None else (model_mu, rnn_out_state)
+
+
+class DeepRenewalTrainingNetwork(DeepRenewalNetwork):
+    def hybrid_forward(
+        self,
+        F,
+        past_target,
+        valid_length,
+        interval_alpha_bias=None,
+        size_alpha_bias=None,
+        **kwargs,
+    ) -> Tensor:
+        """
+        Compute negative log likelihood losses for given data.
+
+        Parameters
+        ----------
+        F
+        past_target
+            shape (batch_size, history_length, 2). Expects a right-aligned
+            ragged tensor containing the past data in an interval-size
+            format.
+        valid_length
+            number of valid data points in each array of the batch. i.e.,
+            non-valid points will be masked out. shape (batch_size, 1)
+        interval_alpha_bias
+        size_alpha_bias
+
+        Returns
+        -------
+        loss
+            negative log likelihood with shape (batch_size, history_length)
+        """
+        cond_mean = self.mu_map(past_target, shift=True)
+        dist_interval, dist_size = self.distribution(
+            cond_mean, interval_alpha_bias, size_alpha_bias
+        )
+        data_interval, data_size = F.split(past_target, num_outputs=2, axis=-1)
+
+        log_prob = F.add_n(
+            dist_interval.log_prob(
+                data_interval - 1
+            ),  # adjusting since data is 1-indexed and distributions aren't
+            dist_size.log_prob(data_size - 1),
+        ).squeeze(-1)
+
+        reverse_lengths = F.maximum(
+            F.ones_like(valid_length),
+            F.broadcast_sub(F.max(valid_length), valid_length),
+        ).squeeze(-1)
+        mask = F.SequenceMask(
+            F.ones_like(log_prob),
+            reverse_lengths,
+            use_sequence_length=True,
+            axis=1,
+        )
+        loss = -F.where(1 - mask, log_prob, F.zeros_like(log_prob))
+
+        return loss
+
+
+class DeepRenewalPredictionNetwork(DeepRenewalNetwork):
+    @validated()
+    def __init__(self, num_parallel_samples: int = 100, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.num_parallel_samples = num_parallel_samples
+
+    def sampling_decoder(
+        self,
+        F,
+        past_target: Tensor,
+        interval_alpha_bias: Optional[Tensor] = None,
+        size_alpha_bias: Optional[Tensor] = None,
+        time_remaining: Optional[Tensor] = None,
+    ) -> Tensor:
+        """
+        Sample a trajectory of interval-size pairs from the model given past target.
+
+        Parameters
+        ----------
+        past_target
+            (batch_size, history_length, 2) shaped tensor containing the past time series
+            in an interval-size representation.
+        time_remaining
+            (batch_size,) shaped tensor containing the number of time steps that were zero
+            before the start of the forecast horizon
+
+        Returns
+        -------
+        samples
+            samples of shape (batch_size, num_parallel_samples, 2, sequence_length)
+        """
+        if time_remaining is None:
+            time_remaining = F.broadcast_like(
+                F.zeros((1,)), past_target, lhs_axes=(0,), rhs_axes=(0,)
+            )
+
+        repeated_past_target = past_target.repeat(
+            repeats=self.num_parallel_samples, axis=0
+        )  # (N * samples, T, 2)
+        repeated_time_remaining = time_remaining.repeat(
+            repeats=self.num_parallel_samples, axis=0
+        )  # (N * samples, 1)
+
+        interval_samples = []
+        size_samples = []
+
+        for t in range(self.prediction_length):
+            cond_mean = self.mu_map(repeated_past_target, shift=False)
+            cond_mean_last = F.slice_axis(
+                cond_mean, axis=1, begin=-1, end=None
+            ).squeeze(1)
+
+            dist_interval, dist_size = self.distribution(
+                cond_mean_last, interval_alpha_bias, size_alpha_bias
+            )
+
+            # initial samples for interval should be taken conditionally
+            # we achieve this via (leaky) rejection sampling
+            if t == 0:
+                interval_sample = F.zeros_like(repeated_time_remaining)
+                for j in range(50):
+                    interval_sample = F.where(
+                        interval_sample > repeated_time_remaining,
+                        interval_sample,
+                        dist_interval.sample() + 1,
+                    )
+                interval_sample = F.where(
+                    interval_sample == 0,
+                    repeated_time_remaining + 1,
+                    interval_sample,
+                )
+            else:
+                interval_sample = dist_interval.sample() + 1
+            size_sample = dist_size.sample() + 1
+
+            interval_samples.append(interval_sample)
+            size_samples.append(size_sample)
+
+            repeated_past_target = F.concat(
+                repeated_past_target,
+                F.concat(interval_sample, size_sample, dim=-1).expand_dims(1),
+                dim=1,
+            )
+
+        interval_samples[0] = interval_samples[0] - repeated_time_remaining
+        samples = F.concat(
+            *[
+                F.concat(x, y, dim=-1).expand_dims(1)
+                for x, y in zip(interval_samples, size_samples)
+            ],
+            dim=1,
+        )
+
+        return samples.reshape(
+            shape=(-1, self.num_parallel_samples) + samples.shape[1:]
+        ).swapaxes(2, 3)
+
+    def hybrid_forward(
+        self,
+        F,
+        past_target,
+        time_remaining,
+        interval_alpha_bias=None,
+        size_alpha_bias=None,
+        **kwargs,
+    ) -> Tensor:
+        return self.sampling_decoder(
+            F,
+            past_target=past_target,
+            interval_alpha_bias=interval_alpha_bias,
+            size_alpha_bias=size_alpha_bias,
+            time_remaining=time_remaining,
+        )

--- a/src/gluonts/model/renewal/_network.py
+++ b/src/gluonts/model/renewal/_network.py
@@ -211,6 +211,8 @@ class DeepRenewalTrainingNetwork(DeepRenewalNetwork):
         )
         data_interval, data_size = F.split(past_target, num_outputs=2, axis=-1)
 
+        # TODO: on windows, operators below may produce NaN values
+
         log_prob = F.squeeze(
             dist_interval.log_prob(data_interval - 1)
             + dist_size.log_prob(data_size - 1),

--- a/src/gluonts/model/renewal/_network.py
+++ b/src/gluonts/model/renewal/_network.py
@@ -211,16 +211,13 @@ class DeepRenewalTrainingNetwork(DeepRenewalNetwork):
         )
         data_interval, data_size = F.split(past_target, num_outputs=2, axis=-1)
 
-        log_prob = F.add_n(
-            dist_interval.log_prob(
-                data_interval - 1
-            ),  # adjusting since data is 1-indexed and distributions aren't
-            dist_size.log_prob(data_size - 1),
-        ).squeeze(-1)
-
-        reverse_lengths = F.maximum(
-            F.ones_like(valid_length),
-            F.broadcast_sub(F.max(valid_length), valid_length),
+        log_prob = F.squeeze(
+            dist_interval.log_prob(data_interval - 1)
+            + dist_size.log_prob(data_size - 1),
+            axis=-1,
+        )
+        reverse_lengths = F.broadcast_sub(
+            F.max(valid_length), valid_length
         ).squeeze(-1)
         mask = F.SequenceMask(
             F.ones_like(log_prob),

--- a/src/gluonts/model/renewal/_predictor.py
+++ b/src/gluonts/model/renewal/_predictor.py
@@ -56,19 +56,7 @@ class DeepRenewalProcessSampleOutputTransform:
             t, s = times[i, j], sizes[i, j]
             ix = t[t < max_time].astype(int).tolist()
             if len(ix) > 0:
-                try:
-                    out[i, j, ix] = s[: len(ix)]
-                except IndexError:
-                    raise IndexError(
-                        f"""
-                    ix: {ix} 
-                    t: {t}
-                    s: {s}
-                    i, j: {(i, j)}
-                    ia: {ia_times[i, j]}
-                    max_time: {max_time}
-                    """
-                    )
+                out[i, j, ix] = s[: len(ix)]
 
         return out
 

--- a/src/gluonts/model/renewal/_predictor.py
+++ b/src/gluonts/model/renewal/_predictor.py
@@ -59,8 +59,7 @@ class DeepRenewalProcessSampleOutputTransform:
                 try:
                     out[i, j, ix] = s[: len(ix)]
                 except IndexError:
-                    print(ix)
-                    print(t)
+                    raise IndexError(f"ix: {ix}, t: {t}")
 
         return out
 

--- a/src/gluonts/model/renewal/_predictor.py
+++ b/src/gluonts/model/renewal/_predictor.py
@@ -1,0 +1,143 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import itertools
+from functools import partial
+from pathlib import Path
+from typing import List, Optional, Callable, Iterator
+
+import mxnet as mx
+import numpy as np
+
+from gluonts.core.component import DType
+from gluonts.core.serde import load_json
+from gluonts.dataset.common import DataEntry, Dataset
+from gluonts.dataset.loader import InferenceDataLoader
+from gluonts.model.forecast import Forecast
+from gluonts.model.forecast_generator import (
+    ForecastGenerator,
+    SampleForecastGenerator,
+)
+from gluonts.mx.batchify import batchify
+from gluonts.mx.model.predictor import RepresentableBlockPredictor
+from gluonts.transform import Transformation
+
+
+class DeepRenewalProcessSampleOutputTransform:
+    """
+    Convert a deep renewal process sample that is composed of dense interval-size
+    samples to a sparse forecast.
+
+    In practice, this often only means taking the first few time steps of each sample
+    trajectory and converting them to the sparse (intermittent) representation.
+    Converts a (N, S, 2, T) array corresponding to the interval-size format to
+    a (N, S, T) array.
+    """
+
+    def __call__(self, entry: DataEntry, output: np.ndarray) -> np.ndarray:
+        ia_times, sizes = output[:, :, 0], output[:, :, 1]
+        batch_size, num_samples, max_time = ia_times.shape
+        max_time = ia_times.shape[-1]
+        out = np.zeros_like(ia_times)
+
+        times = np.cumsum(ia_times, axis=-1) - 1
+
+        for i, j in itertools.product(range(batch_size), range(num_samples)):
+            t, s = times[i, j], sizes[i, j]
+            ix = t[t < max_time].astype(int)
+            out[i, j, ix] = s[: len(ix)]
+
+        return out
+
+
+class DeepRenewalProcessPredictor(RepresentableBlockPredictor):
+    BlockType = mx.gluon.Block
+
+    def __init__(
+        self,
+        prediction_net: BlockType,
+        batch_size: int,
+        prediction_length: int,
+        freq: str,
+        ctx: mx.Context,
+        input_transform: Transformation,
+        input_names: Optional[List[str]] = None,
+        lead_time: int = 0,
+        forecast_generator: ForecastGenerator = SampleForecastGenerator(),
+        output_transform: Optional[
+            Callable[[DataEntry, np.ndarray], np.ndarray]
+        ] = DeepRenewalProcessSampleOutputTransform(),
+        dtype: DType = np.float32,
+    ) -> None:
+        super().__init__(
+            prediction_net=prediction_net,
+            batch_size=batch_size,
+            prediction_length=prediction_length,
+            freq=freq,
+            ctx=ctx,
+            input_transform=input_transform,
+            lead_time=lead_time,
+            forecast_generator=forecast_generator,
+            output_transform=output_transform,
+            dtype=dtype,
+        )
+        if input_names is not None:
+            self.input_names = input_names
+
+    def predict(
+        self,
+        dataset: Dataset,
+        num_samples: Optional[int] = None,
+        **kwargs,
+    ) -> Iterator[Forecast]:
+        stack_fn = partial(
+            batchify,
+            ctx=self.ctx,
+            dtype=self.dtype,
+            variable_length=True,
+            is_right_pad=False,
+        )
+        inference_data_loader = InferenceDataLoader(
+            dataset,
+            transform=self.input_transform,
+            batch_size=self.batch_size,
+            stack_fn=stack_fn,
+        )
+        with mx.Context(self.ctx):
+            yield from self.forecast_generator(
+                inference_data_loader=inference_data_loader,
+                prediction_net=self.prediction_net,
+                input_names=self.input_names,
+                freq=self.freq,
+                output_transform=self.output_transform,
+                num_samples=num_samples,
+            )
+
+    @classmethod
+    def deserialize(
+        cls, path: Path, ctx: Optional[mx.Context] = None
+    ) -> "DeepRenewalProcessPredictor":
+        repr_predictor = super().deserialize(path, ctx)
+        ctx = repr_predictor.ctx
+
+        with mx.Context(ctx):
+            # deserialize constructor parameters
+            with (path / "parameters.json").open("r") as fp:
+                parameters = load_json(fp.read())
+            parameters["ctx"] = ctx
+
+            return DeepRenewalProcessPredictor(
+                input_transform=repr_predictor.input_transform,
+                prediction_net=repr_predictor.prediction_net,
+                **parameters,
+            )

--- a/src/gluonts/model/renewal/_predictor.py
+++ b/src/gluonts/model/renewal/_predictor.py
@@ -55,7 +55,8 @@ class DeepRenewalProcessSampleOutputTransform:
         for i, j in itertools.product(range(batch_size), range(num_samples)):
             t, s = times[i, j], sizes[i, j]
             ix = t[t < max_time].astype(int)
-            out[i, j, ix] = s[: len(ix)]
+            if len(ix) > 0:
+                out[i, j, ix] = s[: len(ix)]
 
         return out
 

--- a/src/gluonts/model/renewal/_predictor.py
+++ b/src/gluonts/model/renewal/_predictor.py
@@ -54,9 +54,13 @@ class DeepRenewalProcessSampleOutputTransform:
 
         for i, j in itertools.product(range(batch_size), range(num_samples)):
             t, s = times[i, j], sizes[i, j]
-            ix = t[t < max_time].astype(int)
+            ix = t[t < max_time].astype(int).tolist()
             if len(ix) > 0:
-                out[i, j, ix] = s[: len(ix)]
+                try:
+                    out[i, j, ix] = s[: len(ix)]
+                except IndexError:
+                    print(ix)
+                    print(t)
 
         return out
 

--- a/src/gluonts/model/renewal/_predictor.py
+++ b/src/gluonts/model/renewal/_predictor.py
@@ -59,7 +59,16 @@ class DeepRenewalProcessSampleOutputTransform:
                 try:
                     out[i, j, ix] = s[: len(ix)]
                 except IndexError:
-                    raise IndexError(f"ix: {ix}, t: {t}")
+                    raise IndexError(
+                        f"""
+                    ix: {ix} 
+                    t: {t}
+                    s: {s}
+                    i, j: {(i, j)}
+                    ia: {ia_times[i, j]}
+                    max_time: {max_time}
+                    """
+                    )
 
         return out
 

--- a/src/gluonts/model/renewal/_transform.py
+++ b/src/gluonts/model/renewal/_transform.py
@@ -1,0 +1,61 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import numpy as np
+from gluonts.core.component import validated
+
+from gluonts.dataset.common import DataEntry
+from gluonts.dataset.field_names import FieldName
+from gluonts.transform import SimpleTransformation
+
+
+class AddAxisLength(SimpleTransformation):
+    """
+    Add the "length" of an array along the specified axis.
+
+    For example, if target field in the input DataEntry has a shape
+    of (32, 24, 3), the axis can be specified as 1 to return 24 for
+    the output field. If the target field is a list instead, its
+    length will be added.
+
+    Parameters
+    ----------
+    target_field
+        Field with target values (array) of time series
+    axis
+        Axis to output lengths (dimensions) on. Default 0.
+    output_field
+        Name of newly created field
+    """
+
+    @validated()
+    def __init__(
+        self,
+        target_field: str = FieldName.TARGET,
+        axis: int = 0,
+        output_field: str = "valid_length",
+    ) -> None:
+        self.target_field = target_field
+        self.axis = axis
+        self.output_field = output_field
+
+    def transform(self, data: DataEntry) -> DataEntry:
+        target = data[self.target_field]
+        data[self.output_field] = np.array(
+            [
+                len(target)
+                if isinstance(target, list)
+                else target.shape[self.axis]
+            ]
+        )
+        return data

--- a/src/gluonts/transform/feature.py
+++ b/src/gluonts/transform/feature.py
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -560,9 +560,12 @@ class AddAggregateLags(MapTransformation):
 class CountTrailingZeros(SimpleTransformation):
     """
     Add the number of 'trailing' zeros in each univariate time series as a feature, to be
-    used when dealing with sparse (intermittent) time series. For
-    example, for a time series `[0, 0, 2, 3, 0]`, the number of trailing
-    zeros will be 1.
+    used when dealing with sparse (intermittent) time series.
+
+    For example, for 1-d a time series `[0, 0, 2, 3, 0]`, the number of trailing
+    zeros will be 1. If an n-dimensional array is provided, the first 1-d array along the `axis`
+    dimension will be checked for trailing zeros. For example, if axis is set to 1 for a
+    3-d array A, the transformation will return the number of trailing zeros in `A[0, :, 0]`.
 
     Parameters
     ----------
@@ -571,19 +574,33 @@ class CountTrailingZeros(SimpleTransformation):
         zeros.
     target_field
         Field with target values (array) of time series
+    as_array
+        if True, the returned field will be a numpy array of shape (1,)
     """
 
+    @validated()
     def __init__(
         self,
         new_field: str = "trailing_zeros",
         target_field: str = "target",
+        axis: int = -1,
+        as_array: bool = False,
     ) -> None:
         self.target_field = target_field
         self.new_field = new_field
+        self.axis = axis
+        self.as_array = as_array
 
     def transform(self, data: DataEntry) -> DataEntry:
         target = data[self.target_field]
         if len(target) == 0:
             return data
-        data[self.new_field] = len(target) - len(np.trim_zeros(target, "b"))
+        while target.ndim > 1:
+            slice_: List[Union[int, slice]] = [0] * target.ndim
+            slice_[self.axis] = slice(None)
+            target = target[slice_]
+        trailing_zeros = len(target) - len(np.trim_zeros(target, "b"))
+        data[self.new_field] = (
+            np.array([trailing_zeros]) if self.as_array else trailing_zeros
+        )
         return data

--- a/test/model/renewal/__init__.py
+++ b/test/model/renewal/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.

--- a/test/model/renewal/test_model.py
+++ b/test/model/renewal/test_model.py
@@ -28,6 +28,12 @@ def hyperparameters():
 
 
 @pytest.mark.parametrize("hybridize", [True, False])
+def test_accuracy_smoke_test(accuracy_test, hyperparameters, hybridize):
+    hyperparameters.update(num_batches_per_epoch=80, hybridize=hybridize)
+    accuracy_test(DeepRenewalProcessEstimator, hyperparameters, accuracy=10)
+
+
+@pytest.mark.parametrize("hybridize", [True, False])
 def test_repr(repr_test, hyperparameters, hybridize):
     hyperparameters.update(hybridize=hybridize)
     repr_test(DeepRenewalProcessEstimator, hyperparameters)

--- a/test/model/renewal/test_model.py
+++ b/test/model/renewal/test_model.py
@@ -10,6 +10,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
+import sys
 
 import pytest
 
@@ -26,6 +27,7 @@ def hyperparameters():
     )
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="don't run on windows")
 @pytest.mark.parametrize("hybridize", [True, False])
 def test_accuracy_smoke_test(accuracy_test, hyperparameters, hybridize):
     hyperparameters.update(num_batches_per_epoch=80, hybridize=hybridize)

--- a/test/model/renewal/test_model.py
+++ b/test/model/renewal/test_model.py
@@ -1,0 +1,39 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import pytest
+
+from gluonts.model.renewal import DeepRenewalProcessEstimator
+from gluonts.mx.trainer import Trainer
+
+
+@pytest.fixture()
+def hyperparameters():
+    return dict(
+        num_cells=10,
+        num_layers=3,
+        context_length=10,
+        epochs=1,
+    )
+
+
+@pytest.mark.parametrize("hybridize", [True, False])
+def test_repr(repr_test, hyperparameters, hybridize):
+    hyperparameters.update(hybridize=hybridize)
+    repr_test(DeepRenewalProcessEstimator, hyperparameters)
+
+
+@pytest.mark.parametrize("hybridize", [True, False])
+def test_serialize(serialize_test, hyperparameters, hybridize):
+    hyperparameters.update(hybridize=hybridize)
+    serialize_test(DeepRenewalProcessEstimator, hyperparameters)

--- a/test/model/renewal/test_model.py
+++ b/test/model/renewal/test_model.py
@@ -14,7 +14,6 @@
 import pytest
 
 from gluonts.model.renewal import DeepRenewalProcessEstimator
-from gluonts.mx.trainer import Trainer
 
 
 @pytest.fixture()

--- a/test/model/renewal/test_predictor.py
+++ b/test/model/renewal/test_predictor.py
@@ -1,0 +1,65 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import numpy as np
+import pytest
+
+from gluonts.model.renewal._predictor import (
+    DeepRenewalProcessSampleOutputTransform,
+)
+
+
+@pytest.mark.parametrize(
+    "input, expected",
+    [
+        (
+            [[[[3, 1, 2, 3, 1, 1, 1], [3, 5, 4, 1, 1, 1, 1]]]],
+            [[[0, 0, 3, 5, 0, 4, 0]]],
+        ),
+        (
+            [[[[7, 1, 2, 3, 1, 1, 1], [3, 5, 4, 1, 1, 1, 1]]]],
+            [[[0, 0, 0, 0, 0, 0, 3]]],
+        ),
+        (
+            [[[[1, 9, 2, 3, 1, 1, 1], [14, 5, 4, 1, 1, 1, 1]]]],
+            [[[14, 0, 0, 0, 0, 0, 0]]],
+        ),
+        (
+            [[[[8, 1, 2, 3, 1, 1, 1], [3, 5, 4, 1, 1, 1, 1]]]],
+            [[[0, 0, 0, 0, 0, 0, 0]]],
+        ),
+        (
+            [
+                [
+                    [[3, 1, 2, 3, 1, 1, 1], [3, 5, 4, 1, 1, 1, 1]],
+                    [[3, 1, 2, 3, 1, 1, 1], [3, 5, 4, 1, 1, 1, 1]],
+                ]
+            ],
+            [[[0, 0, 3, 5, 0, 4, 0], [0, 0, 3, 5, 0, 4, 0]]],
+        ),
+        (
+            [
+                [[[3, 1, 2, 3, 1, 1, 1], [3, 5, 4, 1, 1, 1, 1]]],
+                [[[3, 2, 1, 1, 1, 1, 1], [6, 7, 8, 9, 1, 1, 1]]],
+            ],
+            [[[0, 0, 3, 5, 0, 4, 0]], [[0, 0, 6, 0, 7, 8, 9]]],
+        ),
+    ],
+)
+def test_output_transform(input, expected):
+    expected = np.array(expected)
+    tf = DeepRenewalProcessSampleOutputTransform()
+    out = tf({}, np.array(input))
+
+    assert np.allclose(out, expected)
+    assert out.shape == expected.shape


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR implements deep renewal processes for intermittent demand forecasting, introduced [here](https://arxiv.org/pdf/2010.01550.pdf).

In short, deep renewal processes are neural probabilistic forecasting models that operate on the bivariate interval-size process (i.e., the time between each positive demand point, and the sizes of positive demand) as is common in the intermittent demand literature, instead of directly operating on the sparse univariate demand process. This allows the process to naturally represent patterns such as quasi-periodicity.

This PR adds the estimator and network components, as well as custom (i) transform, (ii) output transform, and (iii) predictor objects that are able to handle variable-length arrays. It also introduces some fixes to an earlier component added in #1421 .

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup