### PR TITLE
support Min freq for get_seasonality() method

### DIFF
--- a/src/gluonts/time_feature/seasonality.py
+++ b/src/gluonts/time_feature/seasonality.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 DEFAULT_SEASONALITIES = {
+    "T": 1440,
     "H": 24,
     "D": 1,
     "W": 1,

--- a/test/time_feature/test_seasonality.py
+++ b/test/time_feature/test_seasonality.py
@@ -19,6 +19,7 @@ from gluonts.time_feature import get_seasonality
 @pytest.mark.parametrize(
     "freq, expected_seasonality",
     [
+        ("30min", 48),
         ("1H", 24),
         ("H", 24),
         ("2H", 12),


### PR DESCRIPTION
*Issue #, if available:*

`get_seasonality` does not support min freq at the moment.

*Description of changes:*
Added a default seasonality for min, namely `60*24`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup