### PR TITLE
Fix indentation

### DIFF
--- a/src/gluonts/dataset/multivariate_grouper.py
+++ b/src/gluonts/dataset/multivariate_grouper.py
@@ -39,12 +39,12 @@ class MultivariateGrouper:
     padded to produce an array of shape (dim, num_time_steps)
 
     Test: The test dataset might have multiple start dates (usually because
-          the test dataset mimics a rolling evaluation scenario). In this case,
-          the univariate dataset will be split into n multivariate time series,
-          where n is the number of evaluation dates. Again, the
-          time series will be grouped but only left padded. Note that the
-          padded value will influence the prediction if the context length is
-          longer than the length of the time series.
+    the test dataset mimics a rolling evaluation scenario). In this case,
+    the univariate dataset will be split into n multivariate time series,
+    where n is the number of evaluation dates. Again, the
+    time series will be grouped but only left padded. Note that the
+    padded value will influence the prediction if the context length is
+    longer than the length of the time series.
 
     Rules for padding for training and test datasets can be specified by the
     user.


### PR DESCRIPTION
*Issue #, if available:*
In the [API documentation](https://ts.gluon.ai/api/gluonts/gluonts.dataset.multivariate_grouper.html), the first line in the Test paragraph is bold.

*Description of changes:*
Fixes indentation of API documentation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** other change