### PR TITLE
Fix test workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Docs
 on: [push, pull_request]
 
 jobs:
-  build:
+  docs-build:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/mxnet_nightly.yml
+++ b/.github/workflows/mxnet_nightly.yml
@@ -2,12 +2,10 @@ name: MXNet nightly
 
 on:
   schedule:
-    # * is a special character in YAML so you have to quote this string
-    # nightly:
     - cron:  '0 0 * * *'
 
 jobs:
-  build:
+  test-mxnet-nightly:
 
     strategy:
       max-parallel: 4

--- a/.github/workflows/style_type_checks.yml
+++ b/.github/workflows/style_type_checks.yml
@@ -3,7 +3,7 @@ name: Style and type checks
 on: [push, pull_request]
 
 jobs:
-  build:
+  style-type-checks:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test_release_unix_nightly.yml
+++ b/.github/workflows/test_release_unix_nightly.yml
@@ -2,12 +2,10 @@ name: Test latest release nightly Ubuntu
 
 on:
   schedule:
-    # * is a special character in YAML so you have to quote this string
-    # nightly:
     - cron:  '0 0 * * *'
 
 jobs:
-  build:
+  test-stable-ubuntu:
 
     strategy:
       max-parallel: 4
@@ -35,6 +33,7 @@ jobs:
         pip install -r requirements/requirements-extras-m-competitions.txt
         pip install -r requirements/requirements-rotbaum.txt
         pip install -r requirements/requirements-extras-anomaly-evaluation.txt
+        pip install -r requirements/requirements-extras-autogluon.txt
     - name: Test with pytest
       run: |
         cd gluon-ts

--- a/.github/workflows/test_release_win32_nightly.yml
+++ b/.github/workflows/test_release_win32_nightly.yml
@@ -2,12 +2,10 @@ name: Test latest release nightly Windows
 
 on:
   schedule:
-    # * is a special character in YAML so you have to quote this string
-    # nightly:
     - cron:  '0 0 * * *'
 
 jobs:
-  build:
+  test-stable-windows:
 
     strategy:
       max-parallel: 4
@@ -37,6 +35,7 @@ jobs:
         pip install -r requirements/requirements-extras-m-competitions.txt
         pip install -r requirements/requirements-rotbaum.txt
         pip install -r requirements/requirements-extras-anomaly-evaluation.txt
+        pip install -r requirements/requirements-extras-autogluon.txt
       shell: powershell
     - name: Test with pytest
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,14 +3,14 @@ name: Tests
 on: [push, pull_request]
 
 jobs:
-  build:
+  test:
 
     strategy:
       max-parallel: 4
       fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        platform: [ubuntu-latest, windows-latest]
+        platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
* Disable tests on Windows (too flaky, they slow down development; we run nightly jobs on the latest release and that's OK for now)
* Give relevant names to workflows jobs (instead of just "build")
* Add missing Autogluon dependency in nightly workflows (they have been failing for ~3 weeks due to this)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup