### PR TITLE
Fixed bug: ".values()" to ".values"

### DIFF
--- a/src/gluonts/model/rotbaum/_model.py
+++ b/src/gluonts/model/rotbaum/_model.py
@@ -203,7 +203,7 @@ class QRX:
 
         df = pd.DataFrame({"preds": self.sorted_train_preds})
         df["bin_ids"] = df["preds"].apply(lambda x: self.preds_to_id[x])
-        bin_ids = df["bin_ids"].drop_duplicates().values()
+        bin_ids = df["bin_ids"].drop_duplicates().values
         final_id, penultimate_id = bin_ids[-1], bin_ids[-2]
         if len(self.id_to_bins[final_id]) < self.min_bin_size:
             self.id_to_bins[final_id] += self.id_to_bins[penultimate_id]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixed a tiny but significant bug, whereby pandas series had ".values()" but should have had ".values".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup