### PR TITLE
R fixes for methods that produce point forecasts or prediction intervals directly

### DIFF
--- a/src/gluonts/model/r_forecast/R/forecast_methods.R
+++ b/src/gluonts/model/r_forecast/R/forecast_methods.R
@@ -69,7 +69,7 @@ croston <- function(ts, params) {
 tbats <- function(ts, params) {
     model <- forecast::tbats(ts)
 
-    # R doesn't allow `simulate` on the tbats model. We generate prediction intervals directly.
+    # R doesn't allow `simulate` on tbats model. We obtain prediction intervals directly.
     forecasts <- forecast::forecast(model, h=params$prediction_length, level=unlist(params$intervals))
     handleQuantileForecast(forecasts, params)
 }
@@ -83,6 +83,7 @@ mlp <- function(ts, params) {
 }
 
 thetaf <- function(ts, params) {
+    # For thetaf, we obtain prediction intervals directly.
     forecasts <- forecast::thetaf(y=ts, h=params$prediction_length, level=unlist(params$intervals))
     handleQuantileForecast(forecasts, params)
 }

--- a/src/gluonts/model/r_forecast/R/forecast_methods.R
+++ b/src/gluonts/model/r_forecast/R/forecast_methods.R
@@ -39,10 +39,10 @@ handlePointForecast <- function(forecasts, params) {
     outputs = list()
     output_types = params$output_types
     if ("samples" %in% output_types) {
-        print("This forecasting method only produces point forecasts!")
+        print("This forecasting method only produces point forecasts! Use mean as (only) output type.")
     }
     if("quantiles" %in% output_types) {
-        print("This forecasting method only produces point forecasts!")
+        print("This forecasting method only produces point forecasts! Use mean as (only) output type.")
     }
     if("mean" %in% output_types) {
         outputs$mean <- forecasts$mean

--- a/src/gluonts/model/r_forecast/R/forecast_methods.R
+++ b/src/gluonts/model/r_forecast/R/forecast_methods.R
@@ -16,6 +16,40 @@ handleForecast <- function(model, params) {
     outputs
 }
 
+handleQuantileForecast <- function(forecasts, params) {
+    outputs = list()
+    output_types = params$output_types
+    if ("samples" %in% output_types) {
+        print("Generating samples are not supported by ``forecast'' package for this forecasting method!
+        Use quantiles as output type and pass prediction intervals in the parameters.")
+    }
+    if("quantiles" %in% output_types) {
+        f_upper_matrix <- forecasts$upper
+        f_lower_matrix <- forecasts$lower
+        outputs$upper_quantiles  <- split(f_upper_matrix, col(f_upper_matrix))
+        outputs$lower_quantiles  <- split(f_lower_matrix, col(f_lower_matrix))
+    }
+    if("mean" %in% output_types) {
+        outputs$mean <- forecasts$mean
+    }
+    outputs
+}
+
+handlePointForecast <- function(forecasts, params) {
+    outputs = list()
+    output_types = params$output_types
+    if ("samples" %in% output_types) {
+        print("This forecasting method only produces point forecasts!")
+    }
+    if("quantiles" %in% output_types) {
+        print("This forecasting method only produces point forecasts!")
+    }
+    if("mean" %in% output_types) {
+        outputs$mean <- forecasts$mean
+    }
+    outputs
+}
+
 
 arima <- function(ts, params) {
     model <- forecast::auto.arima(ts, trace=TRUE)
@@ -28,42 +62,27 @@ ets <- function(ts, params) {
 }
 
 croston <- function(ts, params) {
-    model <- forecast::croston(ts)
-    handleForecast(model, params)
+    forecasts <- forecast::croston(ts, h=params$prediction_length)
+    handlePointForecast(forecasts, params)
 }
 
 tbats <- function(ts, params) {
     model <- forecast::tbats(ts)
-    handleForecast(model, params)
+
+    # R doesn't allow `simulate` on the tbats model. We generate prediction intervals directly.
+    forecasts <- forecast::forecast(model, h=params$prediction_length, level=unlist(params$intervals))
+    handleQuantileForecast(forecasts, params)
 }
 
 mlp <- function(ts, params) {
     model <- nnfor::mlp(ts, hd.auto.type="valid")
-    handleForecast(model, params)
-}
 
-handleForecastTheta <- function(forecasts, params) {
-    outputs = list()
-    output_types = params$output_types
-    if ("samples" %in% output_types) {
-        outputs$samples <- lapply(1:params$num_samples, function(n) {forecasts$mean} )
-    }
-    if("quantiles" %in% output_types) {
-        f_matrix <- forecasts$upper
-        outputs$quantiles <- split(f_matrix, col(f_matrix))
-    }
-    if("mean" %in% output_types) {
-        outputs$mean <- forecasts$mean
-    }
-    outputs
+    # `mlp` is a point forecast method.
+    forecasts <- forecast::forecast(model, h=params$prediction_length)
+    handleForecast(forecasts, params)
 }
 
 thetaf <- function(ts, params) {
-  if("quantiles" %in% params$output_types) {
-        forecasts <- forecast::thetaf(y=ts, h=params$prediction_length, level=unlist(params$levels))
-  } else {
-        forecasts <- forecast::thetaf(y=ts, h=params$prediction_length)
-
-  }
-    handleForecastTheta(forecasts, params)
+    forecasts <- forecast::thetaf(y=ts, h=params$prediction_length, level=unlist(params$intervals))
+    handleQuantileForecast(forecasts, params)
 }

--- a/src/gluonts/model/r_forecast/__init__.py
+++ b/src/gluonts/model/r_forecast/__init__.py
@@ -23,8 +23,6 @@ __all__ = [
     "RForecastPredictor",
     "R_IS_INSTALLED",
     "RPY2_IS_INSTALLED",
-    SUPPORTED_METHODS,
-    QUANTILE_FORECAST_METHODS,
 ]
 
 # fix Sphinx issues, see https://bit.ly/2K2eptM

--- a/src/gluonts/model/r_forecast/__init__.py
+++ b/src/gluonts/model/r_forecast/__init__.py
@@ -23,6 +23,8 @@ __all__ = [
     "RForecastPredictor",
     "R_IS_INSTALLED",
     "RPY2_IS_INSTALLED",
+    "SUPPORTED_METHODS",
+    "QUANTILE_FORECAST_METHODS",
 ]
 
 # fix Sphinx issues, see https://bit.ly/2K2eptM

--- a/src/gluonts/model/r_forecast/__init__.py
+++ b/src/gluonts/model/r_forecast/__init__.py
@@ -11,9 +11,21 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from ._predictor import RForecastPredictor
+from ._predictor import (
+    RForecastPredictor,
+    R_IS_INSTALLED,
+    RPY2_IS_INSTALLED,
+    SUPPORTED_METHODS,
+    QUANTILE_FORECAST_METHODS,
+)
 
-__all__ = ["RForecastPredictor"]
+__all__ = [
+    "RForecastPredictor",
+    "R_IS_INSTALLED",
+    "RPY2_IS_INSTALLED",
+    SUPPORTED_METHODS,
+    QUANTILE_FORECAST_METHODS,
+]
 
 # fix Sphinx issues, see https://bit.ly/2K2eptM
 for item in __all__:

--- a/src/gluonts/model/r_forecast/_predictor.py
+++ b/src/gluonts/model/r_forecast/_predictor.py
@@ -13,9 +13,8 @@
 
 import os
 from pathlib import Path
-from typing import Dict, Iterator, Optional, List, Union
+from typing import Dict, Optional, List, Union
 
-from joblib import Parallel, delayed
 import numpy as np
 
 from gluonts.core.component import validated

--- a/src/gluonts/model/r_forecast/_predictor.py
+++ b/src/gluonts/model/r_forecast/_predictor.py
@@ -132,6 +132,10 @@ class RForecastPredictor(RepresentablePredictor):
         else:
             self.quantlie_forecasts = False
 
+        assert not (
+            self.point_forecasts and self.quantlie_forecasts
+        ), "A method can be either a point-forecast method or a quantile forecast method but not both!"
+
         self._stats_pkg = rpackages.importr("stats")
         self._r_method = robjects.r[method_name]
 
@@ -242,6 +246,7 @@ class RForecastPredictor(RepresentablePredictor):
             elif self.quantlie_forecasts:
                 params["output_types"] = ["quantiles", "mean"]
                 if intervals is None:
+                    # This corresponds to quantiles: 0.05 to 0.95 in steps of 0.05.
                     params["intervals"] = list(range(0, 100, 10))
                 else:
                     params["intervals"] = np.sort(intervals).tolist()

--- a/src/gluonts/model/r_forecast/_predictor.py
+++ b/src/gluonts/model/r_forecast/_predictor.py
@@ -13,13 +13,14 @@
 
 import os
 from pathlib import Path
-from typing import Dict, Iterator, Optional
+from typing import Dict, Iterator, Optional, List, Union
 
+from joblib import Parallel, delayed
 import numpy as np
 
 from gluonts.core.component import validated
 from gluonts.dataset.common import Dataset
-from gluonts.model.forecast import SampleForecast
+from gluonts.model.forecast import SampleForecast, QuantileForecast
 from gluonts.model.predictor import RepresentablePredictor
 from gluonts.support.pandas import forecast_start
 from gluonts.time_feature import get_seasonality
@@ -111,11 +112,25 @@ class RForecastPredictor(RepresentablePredictor):
             "mlp",
             "thetaf",
         ]
+
         assert (
             method_name in supported_methods
         ), f"method {method_name} is not supported please use one of {supported_methods}"
 
         self.method_name = method_name
+
+        point_forecast_methods = ["croston", "mlp"]
+        quantile_forecast_methods = ["tbats", "thetaf"]
+
+        if self.method_name in point_forecast_methods:
+            self.point_forecasts = True
+        else:
+            self.point_forecasts = False
+
+        if self.method_name in quantile_forecast_methods:
+            self.quantlie_forecasts = True
+        else:
+            self.quantlie_forecasts = False
 
         self._stats_pkg = rpackages.importr("stats")
         self._r_method = robjects.r[method_name]
@@ -162,9 +177,42 @@ class RForecastPredictor(RepresentablePredictor):
         forecast_dict = dict(
             zip(forecast.names, map(self._unlist, list(forecast)))
         )
-        # FOR NOW ONLY SAMPLES...
-        # if "quantiles" in forecast_dict:
-        #     forecast_dict["quantiles"] = dict(zip(params["quantiles"], forecast_dict["quantiles"]))
+
+        if "quantiles" in forecast_dict or "upper_quantiles" in forecast_dict:
+
+            def from_interval_to_level(interval: int, side: str):
+                if side == "upper":
+                    level = 50 + interval / 2
+                elif side == "lower":
+                    level = 50 - interval / 2
+                else:
+                    raise ValueError
+                return level / 100
+
+            # Post-processing quantiles on then Python side for the convenience of asserting and debugging.
+            upper_quantiles = [
+                str(from_interval_to_level(interval, side="upper"))
+                for interval in params["intervals"]
+            ]
+
+            lower_quantiles = [
+                str(from_interval_to_level(interval, side="lower"))
+                for interval in params["intervals"]
+            ]
+
+            # Median forecasts would be available at two places: Lower 0 and Higher 0 (0-prediction interval)
+            forecast_dict["quantiles"] = dict(
+                zip(
+                    lower_quantiles + upper_quantiles[1:],
+                    forecast_dict["lower_quantiles"]
+                    + forecast_dict["upper_quantiles"][1:],
+                )
+            )
+
+            # `QuantileForecast` allows "mean" as the key; we store them as well since they can differ from median.
+            forecast_dict["quantiles"].update(
+                {"mean": forecast_dict.pop("mean")}
+            )
 
         self._rinterface.set_writeconsole_regular(
             self._rinterface.consolePrint
@@ -178,38 +226,69 @@ class RForecastPredictor(RepresentablePredictor):
         self,
         dataset: Dataset,
         num_samples: int = 100,
+        intervals: Optional[List] = None,
         save_info: bool = False,
         **kwargs,
-    ) -> Iterator[SampleForecast]:
-        for entry in dataset:
-            if isinstance(entry, dict):
-                data = entry
-            else:
-                data = entry.data
-                if self.trunc_length:
-                    data = data[-self.trunc_length :]
+    ) -> Union[SampleForecast, QuantileForecast]:
+        for data in dataset:
+            if self.trunc_length:
+                data["target"] = data["target"][-self.trunc_length :]
 
             params = self.params.copy()
             params["num_samples"] = num_samples
+
+            if self.point_forecasts:
+                params["output_types"] = ["mean"]
+            elif self.quantlie_forecasts:
+                params["output_types"] = ["quantiles", "mean"]
+                if intervals is None:
+                    params["intervals"] = list(range(0, 100, 10))
+                else:
+                    params["intervals"] = np.sort(intervals).tolist()
 
             forecast_dict, console_output = self._run_r_forecast(
                 data, params, save_info=save_info
             )
 
-            samples = np.array(forecast_dict["samples"])
-            expected_shape = (params["num_samples"], self.prediction_length)
-            assert (
-                samples.shape == expected_shape
-            ), f"Expected shape {expected_shape} but found {samples.shape}"
-            info = (
-                {"console_output": "\n".join(console_output)}
-                if save_info
-                else None
-            )
-            yield SampleForecast(
-                samples,
-                forecast_start(data),
-                self.freq,
-                info=info,
-                item_id=entry.get("item_id", None),
-            )
+            if self.quantlie_forecasts:
+                quantile_forecasts_dict = forecast_dict["quantiles"]
+
+                yield QuantileForecast(
+                    forecast_arrays=np.array(
+                        list(quantile_forecasts_dict.values())
+                    ),
+                    forecast_keys=list(quantile_forecasts_dict.keys()),
+                    start_date=forecast_start(data),
+                    freq=self.freq,
+                    item_id=data.get("item_id", None),
+                )
+            else:
+                if self.point_forecasts:
+                    # Handling special cases outside of R is better, since it is more visible and is easier to change.
+                    # Repeat mean forecasts `num_samples` times.
+                    samples = np.reshape(
+                        forecast_dict["mean"] * params["num_samples"],
+                        (params["num_samples"], self.prediction_length),
+                    )
+                else:
+                    samples = np.array(forecast_dict["samples"])
+
+                expected_shape = (
+                    params["num_samples"],
+                    self.prediction_length,
+                )
+                assert (
+                    samples.shape == expected_shape
+                ), f"Expected shape {expected_shape} but found {samples.shape}"
+                info = (
+                    {"console_output": "\n".join(console_output)}
+                    if save_info
+                    else None
+                )
+                yield SampleForecast(
+                    samples,
+                    forecast_start(data),
+                    self.freq,
+                    info=info,
+                    item_id=data.get("item_id", None),
+                )

--- a/test/model/r_forecast/test_r_predictor.py
+++ b/test/model/r_forecast/test_r_predictor.py
@@ -1,0 +1,92 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import numpy as np
+import pytest
+
+from gluonts.core import serde
+from gluonts.dataset.common import ListDataset
+from gluonts.model.forecast import SampleForecast, QuantileForecast
+from gluonts.model.r_forecast import (
+    RForecastPredictor,
+    R_IS_INSTALLED,
+    RPY2_IS_INSTALLED,
+    SUPPORTED_METHODS,
+    QUANTILE_FORECAST_METHODS,
+)
+from gluonts.support.pandas import forecast_start
+
+
+# conditionally skip these tests if `R` and `rpy2` are not installed
+if not R_IS_INSTALLED or not RPY2_IS_INSTALLED:
+    skip_message = "Skipping test because `R` and `rpy2` are not installed!"
+    pytest.skip(msg=skip_message, allow_module_level=True)
+
+
+@pytest.mark.parametrize("method_name", SUPPORTED_METHODS)
+def test_forecast_structure(method_name):
+    if method_name == "mlp":
+        # https://stackoverflow.com/questions/56254321/error-in-ifncol-matrix-rep-argument-is-of-length-zero
+        # https://cran.r-project.org/web/packages/neuralnet/index.html
+        #   published before the bug fix: https://github.com/bips-hb/neuralnet/pull/21
+        # The issue is still open on nnfor package: https://github.com/trnnick/nnfor/issues/8
+        # TODO: look for a workaround.
+        pytest.xfail(
+            "MLP currently does not work because "
+            "the `neuralnet` package is not yet updated with a known bug fix in ` bips-hb/neuralnet`"
+        )
+
+    freq = "1D"
+    prediction_length = 10
+    params = dict(
+        freq=freq, prediction_length=prediction_length, method_name=method_name
+    )
+
+    dataset = ListDataset(
+        data_iter=[
+            {"start": "2017-01-01", "target": np.array([1.0] * 3)},
+            {"start": "2007-09-28", "target": np.array([2.0] * 3)},
+            {"start": "2020-07-20", "target": np.array([3.0] * 3)},
+            {"start": "1947-08-15", "target": np.array([4.0] * 3)},
+        ],
+        freq=params["freq"],
+    )
+
+    predictor = RForecastPredictor(**params)
+    predictions = list(predictor.predict(dataset))
+
+    forecast_type = (
+        QuantileForecast
+        if method_name in QUANTILE_FORECAST_METHODS
+        else SampleForecast
+    )
+    assert all(
+        isinstance(prediction, forecast_type) for prediction in predictions
+    )
+
+    assert all(prediction.freq == freq for prediction in predictions)
+
+    assert all(
+        prediction.prediction_length == prediction_length
+        for prediction in predictions
+    )
+
+    assert all(
+        prediction.start_date == forecast_start(data)
+        for data, prediction in zip(dataset, predictions)
+    )
+
+
+def test_r_predictor_serialization():
+    predictor = RForecastPredictor(freq="1D", prediction_length=3)
+    assert predictor == serde.decode(serde.encode(predictor))


### PR DESCRIPTION
*Issue #, if available:  [255](https://github.com/awslabs/gluon-ts/issues/255)*

*Description of changes:*
Several fixes:

* For `thetaf`, instead of repeating mean forecasts, the fix now returns quantile forecasts correctly by first obtaining prediction intervals
* `simulate` is not defined on tbats model; returns quantile forecasts by first obtaining prediction intervals
* Fixes the non-functional `Croston` and `MLP` methods; need to pass prediction length to obtain forecasts directly.
* On the python-side, allows obtaining quantile forecasts from R instead of samples-based forecast.

This worked on the following versions:
* R version 3.6.3 (2020-02-29) and `forecast` version 8.15
* R version 4.1.0 (2021-05-18) and `forecast` version 8.14

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
