### PR TITLE
Fix frequency in metadata for lstnet datasets

### DIFF
--- a/src/gluonts/dataset/repository/_lstnet.py
+++ b/src/gluonts/dataset/repository/_lstnet.py
@@ -120,21 +120,16 @@ datasets_info = {
 def generate_lstnet_dataset(dataset_path: Path, dataset_name: str):
     ds_info = datasets_info[dataset_name]
 
+    ds_metadata = metadata(
+        cardinality=ds_info.num_series,
+        freq=ds_info.freq if ds_info.agg_freq is None else ds_info.agg_freq,
+        prediction_length=ds_info.prediction_length,
+    )
+
     os.makedirs(dataset_path, exist_ok=True)
 
     with open(dataset_path / "metadata.json", "w") as f:
-        f.write(
-            json.dumps(
-                metadata(
-                    cardinality=ds_info.num_series,
-                    freq=ds_info.freq,
-                    prediction_length=ds_info.prediction_length,
-                )
-            )
-        )
-
-    train_file = dataset_path / "train" / "data.json"
-    test_file = dataset_path / "test" / "data.json"
+        json.dump(ds_metadata, f)
 
     time_index = pd.date_range(
         start=ds_info.start_date,
@@ -172,7 +167,7 @@ def generate_lstnet_dataset(dataset_path: Path, dataset_name: str):
 
     assert len(train_ts) == ds_info.num_series
 
-    save_to_file(train_file, train_ts)
+    save_to_file(dataset_path / "train" / "data.json", train_ts)
 
     # time of the first prediction
     prediction_dates = [
@@ -199,4 +194,4 @@ def generate_lstnet_dataset(dataset_path: Path, dataset_name: str):
 
     assert len(test_ts) == ds_info.num_series * ds_info.rolling_evaluations
 
-    save_to_file(test_file, test_ts)
+    save_to_file(dataset_path / "test" / "data.json", test_ts)


### PR DESCRIPTION
*Description of changes:*

The following snippet

```python
from gluonts.dataset.repository.datasets import get_dataset
solar = get_dataset("solar-energy", regenerate=True)
next(iter(solar.train))["start"].freq
```

prints out `<10 * Minutes>` but the data is actually aggregated hourly via `sum` via [this](https://github.com/awslabs/gluon-ts/blob/1e9e8f07aa6921f6f8eba4f366a71a6fcf933916/src/gluonts/dataset/repository/_lstnet.py#L115) and [that](https://github.com/awslabs/gluon-ts/blob/1e9e8f07aa6921f6f8eba4f366a71a6fcf933916/src/gluonts/dataset/repository/_lstnet.py#L42-L43).

The issue is caused by the wrong frequency being stored in the metadata whenever some aggregation frequency is specified. This appears to be the case only for `solar-energy`. After the fix, the above snippet correctly prints out `<Hour>`. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup