### PR TITLE
add dummy estimator for seasonal_naive

### DIFF
--- a/src/gluonts/model/seasonal_naive/_estimator.py
+++ b/src/gluonts/model/seasonal_naive/_estimator.py
@@ -11,12 +11,15 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from ._estimator import SeasonalNaiveEstimator
+from gluonts.core.component import validated
+from gluonts.model.estimator import DummyEstimator
+
 from ._predictor import SeasonalNaivePredictor
 
-__all__ = ["SeasonalNaiveEstimator", "SeasonalNaivePredictor"]
 
-# fix Sphinx issues, see https://bit.ly/2K2eptM
-for item in __all__:
-    if hasattr(item, "__module__"):
-        setattr(item, "__module__", __name__)
+class SeasonalNaiveEstimator(DummyEstimator):
+    @validated(
+        getattr(SeasonalNaivePredictor.__init__, "Model")
+    )  # Reuse the model Predictor model
+    def __init__(self, **kwargs) -> None:
+        super().__init__(predictor_cls=SeasonalNaivePredictor, **kwargs)


### PR DESCRIPTION
*Issue #, if available:*

Addition of dummy estimator for Seasonal Naive. This allows to use seasonal naive from the shell.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup