### PR TITLE
Add additional datasets from the Monash Time Series Forecasting Repository

### DIFF
--- a/src/gluonts/dataset/repository/_artificial.py
+++ b/src/gluonts/dataset/repository/_artificial.py
@@ -13,6 +13,7 @@
 
 import json
 from pathlib import Path
+from typing import Optional
 
 from gluonts.dataset.artificial import ArtificialDataset
 from gluonts.dataset.artificial.generate_synthetic import generate_sf2
@@ -20,7 +21,9 @@ from gluonts.dataset.common import serialize_data_entry
 
 
 def generate_artificial_dataset(
-    dataset_path: Path, dataset: ArtificialDataset
+    dataset_path: Path,
+    dataset: ArtificialDataset,
+    prediction_length: Optional[int] = None,
 ) -> None:
     dataset_path_train = dataset_path / "train"
     dataset_path_test = dataset_path / "test"
@@ -31,6 +34,8 @@ def generate_artificial_dataset(
 
     ds = dataset.generate()
     assert ds.test is not None
+    if prediction_length is not None:
+        ds.metadata.prediction_length = prediction_length
 
     with (dataset_path / "metadata.json").open("w") as fp:
         json.dump(ds.metadata.dict(), fp, indent=2, sort_keys=True)

--- a/src/gluonts/dataset/repository/_gp_copula_2019.py
+++ b/src/gluonts/dataset/repository/_gp_copula_2019.py
@@ -103,12 +103,16 @@ datasets_info = {
 }
 
 
-def generate_gp_copula_dataset(dataset_path: Path, dataset_name: str):
+def generate_gp_copula_dataset(
+    dataset_path: Path,
+    dataset_name: str,
+    prediction_length: Optional[int] = None,
+):
     ds_info = datasets_info[dataset_name]
     os.makedirs(dataset_path, exist_ok=True)
 
     download_dataset(dataset_path.parent, ds_info)
-    save_metadata(dataset_path, ds_info)
+    save_metadata(dataset_path, ds_info, prediction_length)
     save_dataset(dataset_path / "train", ds_info)
     save_dataset(dataset_path / "test", ds_info)
     clean_up_dataset(dataset_path, ds_info)
@@ -121,14 +125,19 @@ def download_dataset(dataset_path: Path, ds_info: GPCopulaDataset):
         tar.extractall(path=dataset_path)
 
 
-def save_metadata(dataset_path: Path, ds_info: GPCopulaDataset):
+def save_metadata(
+    dataset_path: Path,
+    ds_info: GPCopulaDataset,
+    prediction_length: Optional[int],
+):
     with open(dataset_path / "metadata.json", "w") as f:
         f.write(
             json.dumps(
                 metadata(
                     cardinality=ds_info.num_series,
                     freq=ds_info.freq,
-                    prediction_length=ds_info.prediction_length,
+                    prediction_length=prediction_length
+                    or ds_info.prediction_length,
                 )
             )
         )

--- a/src/gluonts/dataset/repository/_lstnet.py
+++ b/src/gluonts/dataset/repository/_lstnet.py
@@ -117,13 +117,17 @@ datasets_info = {
 }
 
 
-def generate_lstnet_dataset(dataset_path: Path, dataset_name: str):
+def generate_lstnet_dataset(
+    dataset_path: Path,
+    dataset_name: str,
+    prediction_length: Optional[int] = None,
+):
     ds_info = datasets_info[dataset_name]
 
     ds_metadata = metadata(
         cardinality=ds_info.num_series,
         freq=ds_info.freq if ds_info.agg_freq is None else ds_info.agg_freq,
-        prediction_length=ds_info.prediction_length,
+        prediction_length=prediction_length or ds_info.prediction_length,
     )
 
     os.makedirs(dataset_path, exist_ok=True)

--- a/src/gluonts/dataset/repository/_m3.py
+++ b/src/gluonts/dataset/repository/_m3.py
@@ -16,7 +16,7 @@ import os
 import re
 import warnings
 from pathlib import Path
-from typing import NamedTuple
+from typing import NamedTuple, Optional
 
 import numpy as np
 import pandas as pd
@@ -77,7 +77,9 @@ class M3Setting(NamedTuple):
     freq: str
 
 
-def generate_m3_dataset(dataset_path: Path, m3_freq: str):
+def generate_m3_dataset(
+    dataset_path: Path, m3_freq: str, prediction_length: Optional[int] = None
+):
     from gluonts.dataset.repository.datasets import default_dataset_path
 
     m3_xls_path = default_dataset_path / "M3C.xls"
@@ -180,7 +182,8 @@ def generate_m3_dataset(dataset_path: Path, m3_freq: str):
                 metadata(
                     cardinality=[len(train_data), len(categories)],
                     freq=subset.freq,
-                    prediction_length=subset.prediction_length,
+                    prediction_length=prediction_length
+                    or subset.prediction_length,
                 )
             )
         )

--- a/src/gluonts/dataset/repository/_tsf_datasets.py
+++ b/src/gluonts/dataset/repository/_tsf_datasets.py
@@ -13,16 +13,17 @@
 
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import List, Dict, NamedTuple
+from typing import Dict, List, NamedTuple, Optional
 from urllib import request
 from zipfile import ZipFile
 
 from gluonts import json
 from gluonts.dataset import jsonl
+from gluonts.dataset.field_names import FieldName
 from gluonts.gluonts_tqdm import tqdm
 
-from ._tsf_reader import frequency_converter, TSFReader
-from ._util import metadata, to_dict, request_retrieve_hook
+from ._tsf_reader import TSFReader, frequency_converter
+from ._util import metadata, request_retrieve_hook, to_dict
 
 
 class Dataset(NamedTuple):
@@ -95,6 +96,50 @@ datasets = {
         file_name="tourism_yearly_dataset.zip",
         record="4656103",
     ),
+    "cif_2016": Dataset(
+        file_name="cif_2016_dataset.zip",
+        record="4656042",
+    ),
+    "london_smart_meters_without_missing": Dataset(
+        file_name="london_smart_meters_dataset_without_missing_values.zip",
+        record="4656091",
+    ),
+    "wind_farms_without_missing": Dataset(
+        file_name="wind_farms_minutely_dataset_without_missing_values.zip",
+        record="4654858",
+    ),
+    "car_parts_without_missing": Dataset(
+        file_name="car_parts_dataset_without_missing_values.zip",
+        record="4656021",
+    ),
+    "dominick": Dataset(
+        file_name="dominick_dataset.zip",
+        record="4654802",
+    ),
+    "fred_md": Dataset(
+        file_name="fred_md_dataset.zip",
+        record="4654833",
+    ),
+    "pedestrian_counts": Dataset(
+        file_name="pedestrian_counts_dataset.zip",
+        record="4656626",
+    ),
+    "hospital": Dataset(
+        file_name="hospital_dataset.zip",
+        record="4656014",
+    ),
+    "covid_deaths": Dataset(
+        file_name="covid_deaths_dataset.zip",
+        record="4656009",
+    ),
+    "kdd_cup_2018_without_missing": Dataset(
+        file_name="kdd_cup_2018_dataset_without_missing_values.zip",
+        record="4656756",
+    ),
+    "weather": Dataset(
+        file_name="weather_dataset.zip",
+        record="4654822",
+    ),
 }
 
 
@@ -136,7 +181,11 @@ def save_datasets(path: Path, data: List[Dict], train_offset: int):
             jsonl.dump([dic], train_fp)
 
 
-def generate_forecasting_dataset(dataset_path: Path, dataset_name: str):
+def generate_forecasting_dataset(
+    dataset_path: Path,
+    dataset_name: str,
+    prediction_length: Optional[int] = None,
+):
     dataset = datasets[dataset_name]
     dataset_path.mkdir(exist_ok=True)
 
@@ -150,13 +199,39 @@ def generate_forecasting_dataset(dataset_path: Path, dataset_name: str):
         reader = TSFReader(temp_path / archive.namelist()[0])
         meta, data = reader.read()
 
-    prediction_length = int(meta.forecast_horizon)
+    freq = frequency_converter(meta.frequency)
+    if prediction_length is None:
+        if hasattr(meta, "forecast_horizon"):
+            prediction_length = int(meta.forecast_horizon)
+        else:
+            prediction_length = default_prediction_length_from_frequency(freq)
 
-    save_metadata(
-        dataset_path,
-        len(data),
-        frequency_converter(meta.frequency),
-        prediction_length,
-    )
+    save_metadata(dataset_path, len(data), freq, prediction_length)
 
+    # Impute missing start dates with unix epoch and remove time series whose
+    # length is less than or equal to the prediction length
+    data = [
+        {**d, "start_timestamp": d.get("start_timestamp", "1970-01-01")}
+        for d in data
+        if len(d[FieldName.TARGET]) > prediction_length
+    ]
     save_datasets(dataset_path, data, prediction_length)
+
+
+def default_prediction_length_from_frequency(freq: str) -> int:
+    freq = freq.strip("0123456789").upper()
+    if freq == "MIN":
+        return 60
+    if freq == "H":
+        return 48
+    if freq == "D":
+        return 30
+    if freq == "W":
+        return 8
+    if freq == "M":
+        return 12
+    if freq == "Y":
+        return 4
+    raise ValueError(
+        f"Cannot obtain default prediction length from frequency `{freq}`."
+    )

--- a/src/gluonts/dataset/repository/_tsf_datasets.py
+++ b/src/gluonts/dataset/repository/_tsf_datasets.py
@@ -17,6 +17,8 @@ from typing import Dict, List, NamedTuple, Optional
 from urllib import request
 from zipfile import ZipFile
 
+from pandas.tseries.frequencies import to_offset
+
 from gluonts import json
 from gluonts.dataset import jsonl
 from gluonts.dataset.field_names import FieldName
@@ -219,19 +221,18 @@ def generate_forecasting_dataset(
 
 
 def default_prediction_length_from_frequency(freq: str) -> int:
-    freq = freq.strip("0123456789").upper()
-    if freq == "MIN":
-        return 60
-    if freq == "H":
-        return 48
-    if freq == "D":
-        return 30
-    if freq == "W":
-        return 8
-    if freq == "M":
-        return 12
-    if freq == "Y":
-        return 4
-    raise ValueError(
-        f"Cannot obtain default prediction length from frequency `{freq}`."
-    )
+    prediction_length_map = {
+        "T": 60,
+        "H": 48,
+        "D": 30,
+        "W": 8,
+        "M": 12,
+        "Y": 4,
+    }
+    try:
+        freq = to_offset(freq).name
+        return prediction_length_map[freq]
+    except KeyError as err:
+        raise ValueError(
+            f"Cannot obtain default prediction length from frequency `{freq}`."
+        ) from err

--- a/src/gluonts/dataset/repository/_tsf_reader.py
+++ b/src/gluonts/dataset/repository/_tsf_reader.py
@@ -49,7 +49,7 @@ def frequency_converter(freq: str):
 
 def convert_base(text: str) -> str:
     if text.lower() == "minutely":
-        return "MIN"
+        return "T"
     return text[0].upper()
 
 

--- a/src/gluonts/dataset/repository/_tsf_reader.py
+++ b/src/gluonts/dataset/repository/_tsf_reader.py
@@ -17,9 +17,10 @@ from multiprocessing import cpu_count
 from types import SimpleNamespace
 
 import numpy as np
+from toolz import compose_left
+
 from gluonts import json
 from gluonts.nursery import glide
-from toolz import compose_left
 
 parse_bool = compose_left(strtobool, bool)
 
@@ -40,9 +41,24 @@ def parse_attribute(ty, value: str):
 def frequency_converter(freq: str):
     parts = freq.split("_")
     if len(parts) == 1:
-        return freq[0].upper()
-    if len(parts) == 2 and parts[0].isnumeric():
-        return f"{parts[0]}{parts[1].upper()}"
+        return convert_base(parts[0])
+    if len(parts) == 2:
+        return convert_multiple(parts[0]) + convert_base(parts[1])
+    raise ValueError(f"Invalid frequency string {freq}.")
+
+
+def convert_base(text: str) -> str:
+    if text.lower() == "minutely":
+        return "MIN"
+    return text[0].upper()
+
+
+def convert_multiple(text: str) -> str:
+    if text.isnumeric():
+        return text
+    if text == "half":
+        return "0.5"
+    raise ValueError(f"Unknown frequency multiple {text}.")
 
 
 class TSFReader:

--- a/src/gluonts/dataset/repository/datasets.py
+++ b/src/gluonts/dataset/repository/datasets.py
@@ -21,14 +21,16 @@ from typing import Optional
 from gluonts.dataset.artificial import ConstantDataset
 from gluonts.dataset.common import TrainDatasets, load_datasets
 from gluonts.dataset.repository._artificial import generate_artificial_dataset
-from gluonts.dataset.repository._gp_copula_2019 import \
-    generate_gp_copula_dataset
+from gluonts.dataset.repository._gp_copula_2019 import (
+    generate_gp_copula_dataset,
+)
 from gluonts.dataset.repository._lstnet import generate_lstnet_dataset
 from gluonts.dataset.repository._m3 import generate_m3_dataset
 from gluonts.dataset.repository._m4 import generate_m4_dataset
 from gluonts.dataset.repository._m5 import generate_m5_dataset
-from gluonts.dataset.repository._tsf_datasets import \
-    generate_forecasting_dataset
+from gluonts.dataset.repository._tsf_datasets import (
+    generate_forecasting_dataset,
+)
 from gluonts.support.util import get_download_path
 
 dataset_recipes = OrderedDict(

--- a/src/gluonts/dataset/repository/datasets.py
+++ b/src/gluonts/dataset/repository/datasets.py
@@ -12,23 +12,23 @@
 # permissions and limitations under the License.
 
 import logging
+import shutil
 from collections import OrderedDict
 from functools import partial
 from pathlib import Path
+from typing import Optional
 
 from gluonts.dataset.artificial import ConstantDataset
 from gluonts.dataset.common import TrainDatasets, load_datasets
 from gluonts.dataset.repository._artificial import generate_artificial_dataset
-from gluonts.dataset.repository._gp_copula_2019 import (
-    generate_gp_copula_dataset,
-)
+from gluonts.dataset.repository._gp_copula_2019 import \
+    generate_gp_copula_dataset
 from gluonts.dataset.repository._lstnet import generate_lstnet_dataset
 from gluonts.dataset.repository._m3 import generate_m3_dataset
 from gluonts.dataset.repository._m4 import generate_m4_dataset
 from gluonts.dataset.repository._m5 import generate_m5_dataset
-from gluonts.dataset.repository._tsf_datasets import (
-    generate_forecasting_dataset,
-)
+from gluonts.dataset.repository._tsf_datasets import \
+    generate_forecasting_dataset
 from gluonts.support.util import get_download_path
 
 dataset_recipes = OrderedDict(
@@ -105,6 +105,43 @@ dataset_recipes = OrderedDict(
         "tourism_yearly": partial(
             generate_forecasting_dataset, dataset_name="tourism_yearly"
         ),
+        "cif_2016": partial(
+            generate_forecasting_dataset, dataset_name="cif_2016"
+        ),
+        "london_smart_meters_without_missing": partial(
+            generate_forecasting_dataset,
+            dataset_name="london_smart_meters_without_missing",
+        ),
+        "wind_farms_without_missing": partial(
+            generate_forecasting_dataset,
+            dataset_name="wind_farms_without_missing",
+        ),
+        "car_parts_without_missing": partial(
+            generate_forecasting_dataset,
+            dataset_name="car_parts_without_missing",
+        ),
+        "dominick": partial(
+            generate_forecasting_dataset, dataset_name="dominick"
+        ),
+        "fred_md": partial(
+            generate_forecasting_dataset, dataset_name="fred_md"
+        ),
+        "pedestrian_counts": partial(
+            generate_forecasting_dataset, dataset_name="pedestrian_counts"
+        ),
+        "hospital": partial(
+            generate_forecasting_dataset, dataset_name="hospital"
+        ),
+        "covid_deaths": partial(
+            generate_forecasting_dataset, dataset_name="covid_deaths"
+        ),
+        "kdd_cup_2018_without_missing": partial(
+            generate_forecasting_dataset,
+            dataset_name="kdd_cup_2018_without_missing",
+        ),
+        "weather": partial(
+            generate_forecasting_dataset, dataset_name="weather"
+        ),
         "m3_monthly": partial(generate_m3_dataset, m3_freq="monthly"),
         "m3_quarterly": partial(generate_m3_dataset, m3_freq="quarterly"),
         "m3_yearly": partial(generate_m3_dataset, m3_freq="yearly"),
@@ -160,6 +197,7 @@ def materialize_dataset(
     dataset_name: str,
     path: Path = default_dataset_path,
     regenerate: bool = False,
+    prediction_length: Optional[int] = None,
 ) -> Path:
     """
     Ensures that the dataset is materialized under the `path / dataset_name`
@@ -168,16 +206,21 @@ def materialize_dataset(
     Parameters
     ----------
     dataset_name
-        name of the dataset, for instance "m4_hourly"
+        Name of the dataset, for instance "m4_hourly".
     regenerate
-        whether to regenerate the dataset even if a local file is present.
+        Whether to regenerate the dataset even if a local file is present.
         If this flag is False and the file is present, the dataset will not
         be downloaded again.
     path
-        where the dataset should be saved
+        Where the dataset should be saved.
+    prediction_length
+        The prediction length to be used for the dataset. If None, the default
+        prediction length will be used. The prediction length might not be
+        available for all datasets.
+
     Returns
     -------
-        the path where the dataset is materialized
+        The path where the dataset is materialized
     """
     assert dataset_name in dataset_recipes.keys(), (
         f"{dataset_name} is not present, please choose one from "
@@ -191,7 +234,15 @@ def materialize_dataset(
 
     if not dataset_path.exists() or regenerate:
         logging.info(f"downloading and processing {dataset_name}")
-        dataset_recipe(dataset_path=dataset_path)
+        if dataset_path.exists():
+            # If regenerating, we need to remove the directory contents
+            shutil.rmtree(dataset_path)
+            dataset_path.mkdir()
+
+        dataset_recipe(
+            dataset_path=dataset_path,
+            prediction_length=prediction_length,
+        )
     else:
         logging.info(
             f"using dataset already processed in path {dataset_path}."
@@ -204,30 +255,48 @@ def get_dataset(
     dataset_name: str,
     path: Path = default_dataset_path,
     regenerate: bool = False,
+    prediction_length: Optional[int] = None,
 ) -> TrainDatasets:
     """
     Get a repository dataset.
 
     The datasets that can be obtained through this function have been used
     with different processing over time by several papers (e.g., [SFG17]_,
-    [LCY+18]_, and [YRD15]_).
+    [LCY+18]_, and [YRD15]_) or are obtained through the `Monash Time Series
+    Forecasting Repository <https://forecastingdata.org/>`_.
 
     Parameters
     ----------
     dataset_name
-        name of the dataset, for instance "m4_hourly"
+        Name of the dataset, for instance "m4_hourly".
     regenerate
-        whether to regenerate the dataset even if a local file is present.
+        Whether to regenerate the dataset even if a local file is present.
         If this flag is False and the file is present, the dataset will not
         be downloaded again.
     path
-        where the dataset should be saved
+        Where the dataset should be saved.
+    prediction_length
+        The prediction length to be used for the dataset. If None, the default
+        prediction length will be used. If the dataset is already materialized,
+        setting this option to a different value does not have an effect.
+        Make sure to set `regenerate=True` in this case. Note that some
+        datasets from the Monash Time Series Forecasting Repository do not
+        actually have a default prediction length -- the default then depends
+        on the frequency of the data:
+            - Minutely data --> prediction length of 60 (one hour)
+            - Hourly data --> prediction length of 48 (two days)
+            - Daily data --> prediction length of 30 (one month)
+            - Weekly data --> prediction length of 8 (two months)
+            - Monthly data --> prediction length of 12 (one year)
+            - Yearly data --> prediction length of 4 (four years)
 
     Returns
     -------
-        dataset obtained by either downloading or reloading from local file.
+        Dataset obtained by either downloading or reloading from local file.
     """
-    dataset_path = materialize_dataset(dataset_name, path, regenerate)
+    dataset_path = materialize_dataset(
+        dataset_name, path, regenerate, prediction_length
+    )
 
     return load_datasets(
         metadata=dataset_path,
@@ -241,4 +310,4 @@ if __name__ == "__main__":
         print(f"generate {dataset}")
         ds = get_dataset(dataset, regenerate=True)
         print(ds.metadata)
-        print(sum(1 for _ in list(iter(ds.train))))
+        print(len(ds.train))

--- a/src/gluonts/dataset/repository/datasets.py
+++ b/src/gluonts/dataset/repository/datasets.py
@@ -287,12 +287,12 @@ def get_dataset(
         datasets from the Monash Time Series Forecasting Repository do not
         actually have a default prediction length -- the default then depends
         on the frequency of the data:
-            - Minutely data --> prediction length of 60 (one hour)
-            - Hourly data --> prediction length of 48 (two days)
-            - Daily data --> prediction length of 30 (one month)
-            - Weekly data --> prediction length of 8 (two months)
-            - Monthly data --> prediction length of 12 (one year)
-            - Yearly data --> prediction length of 4 (four years)
+        - Minutely data --> prediction length of 60 (one hour)
+        - Hourly data --> prediction length of 48 (two days)
+        - Daily data --> prediction length of 30 (one month)
+        - Weekly data --> prediction length of 8 (two months)
+        - Monthly data --> prediction length of 12 (one year)
+        - Yearly data --> prediction length of 4 (four years)
 
     Returns
     -------

--- a/src/gluonts/dataset/repository/datasets.py
+++ b/src/gluonts/dataset/repository/datasets.py
@@ -21,14 +21,16 @@ from typing import Any, Dict, Optional
 from gluonts.dataset.artificial import ConstantDataset
 from gluonts.dataset.common import TrainDatasets, load_datasets
 from gluonts.dataset.repository._artificial import generate_artificial_dataset
-from gluonts.dataset.repository._gp_copula_2019 import \
-    generate_gp_copula_dataset
+from gluonts.dataset.repository._gp_copula_2019 import (
+    generate_gp_copula_dataset,
+)
 from gluonts.dataset.repository._lstnet import generate_lstnet_dataset
 from gluonts.dataset.repository._m3 import generate_m3_dataset
 from gluonts.dataset.repository._m4 import generate_m4_dataset
 from gluonts.dataset.repository._m5 import generate_m5_dataset
-from gluonts.dataset.repository._tsf_datasets import \
-    generate_forecasting_dataset
+from gluonts.dataset.repository._tsf_datasets import (
+    generate_forecasting_dataset,
+)
 from gluonts.support.util import get_download_path
 
 dataset_recipes = OrderedDict(

--- a/src/gluonts/dataset/repository/datasets.py
+++ b/src/gluonts/dataset/repository/datasets.py
@@ -16,21 +16,19 @@ import shutil
 from collections import OrderedDict
 from functools import partial
 from pathlib import Path
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from gluonts.dataset.artificial import ConstantDataset
 from gluonts.dataset.common import TrainDatasets, load_datasets
 from gluonts.dataset.repository._artificial import generate_artificial_dataset
-from gluonts.dataset.repository._gp_copula_2019 import (
-    generate_gp_copula_dataset,
-)
+from gluonts.dataset.repository._gp_copula_2019 import \
+    generate_gp_copula_dataset
 from gluonts.dataset.repository._lstnet import generate_lstnet_dataset
 from gluonts.dataset.repository._m3 import generate_m3_dataset
 from gluonts.dataset.repository._m4 import generate_m4_dataset
 from gluonts.dataset.repository._m5 import generate_m5_dataset
-from gluonts.dataset.repository._tsf_datasets import (
-    generate_forecasting_dataset,
-)
+from gluonts.dataset.repository._tsf_datasets import \
+    generate_forecasting_dataset
 from gluonts.support.util import get_download_path
 
 dataset_recipes = OrderedDict(
@@ -241,10 +239,12 @@ def materialize_dataset(
             shutil.rmtree(dataset_path)
             dataset_path.mkdir()
 
-        dataset_recipe(
-            dataset_path=dataset_path,
-            prediction_length=prediction_length,
-        )
+        # Optionally pass prediction length to not override any non-None
+        # defaults (e.g. for M4)
+        kwargs: Dict[str, Any] = {"dataset_path": dataset_path}
+        if prediction_length is not None:
+            kwargs["prediction_length"] = prediction_length
+        dataset_recipe(**kwargs)
     else:
         logging.info(
             f"using dataset already processed in path {dataset_path}."


### PR DESCRIPTION
*Description of changes:*

This PR adds 11 more datasets from the [Monash Time Series Forecasting Repository](https://forecastingdata.org/). It uses a default prediction length whenever none is available, depending on the frequency of the data. Additionally, this PR includes the following changes:

- Users are able to specify a custom `prediction_length` in the `get_dataset` function. This will override any defaults and takes effect whenever `regenerate=True` or the dataset is generated for the first time.
- The PR fixes a bug in the frequency calculation for the Monash datasets where (1) a minutely frequency was parsed as monthly and (2) `half_<frequency>` couldn't be parsed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.