### PR TITLE
Add "LSF" as an alternative name to "QRX"

### DIFF
--- a/src/gluonts/model/rotbaum/_model.py
+++ b/src/gluonts/model/rotbaum/_model.py
@@ -404,6 +404,7 @@ class QRX:
             )
         return predicted_samples
 
-LSF = QRX # LSF stands for "Level Set Forecaster". This name emphasizes that
+
+LSF = QRX  # LSF stands for "Level Set Forecaster". This name emphasizes that
 # the underlying algorithm can be used with any point forecasting algorithm,
 # not just XGBoost.

--- a/src/gluonts/model/rotbaum/_model.py
+++ b/src/gluonts/model/rotbaum/_model.py
@@ -403,3 +403,7 @@ class QRX:
                 self.id_to_bins[self.preds_to_id[closest_pred]]
             )
         return predicted_samples
+
+LSF = QRX # LSF stands for "Level Set Forecaster". This name emphasizes that
+# the underlying algorithm can be used with any point forecasting algorithm,
+# not just XGBoost.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Made it so QRX can be imported using the name LSF. LSF stands for "Level Set Forecasting", and emphasizes that QRX can be used with any point forecasting algorithm, not just XGBoost.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup