### PR TITLE
Add batch_size attribute to MQCNNEstimator and MQRNNEstimator

### DIFF
--- a/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
+++ b/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
@@ -109,6 +109,8 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
         Decides how much forking to do in the decoder. 1 reduces to seq2seq and enc_len reduces to MQ-CNN.
     max_ts_len
         Returns the length of the longest time series in the dataset to be used in bounding context_length.
+    batch_size
+        The size of the batches to be used training and prediction.
     """
 
     @validated()
@@ -139,6 +141,7 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
         scaling_decoder_dynamic_feature: bool = False,
         num_forking: Optional[int] = None,
         max_ts_len: Optional[int] = None,
+        batch_size: int = 32,
     ) -> None:
 
         assert (distr_output is None) or (quantiles is None)
@@ -238,6 +241,7 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
             scaling_decoder_dynamic_feature=scaling_decoder_dynamic_feature,
             num_forking=num_forking,
             max_ts_len=max_ts_len,
+            batch_size=batch_size,
         )
 
     @classmethod
@@ -319,6 +323,7 @@ class MQRNNEstimator(ForkingSeq2SeqEstimator):
         scaling: Optional[bool] = None,
         scaling_decoder_dynamic_feature: bool = False,
         num_forking: Optional[int] = None,
+        batch_size: int = 32,
     ) -> None:
 
         assert (
@@ -375,4 +380,5 @@ class MQRNNEstimator(ForkingSeq2SeqEstimator):
             scaling=scaling,
             scaling_decoder_dynamic_feature=scaling_decoder_dynamic_feature,
             num_forking=num_forking,
+            batch_size=batch_size,
         )


### PR DESCRIPTION
*Issue #1644*

*Description of changes:*
[MQCNNEstimator](https://github.com/awslabs/gluon-ts/blob/eb89e4ee2dd7308842381b6c425197bb3ae6eed6/src/gluonts/model/seq2seq/_mq_dnn_estimator.py#L34) and [MQRNNEstimator](https://github.com/awslabs/gluon-ts/blob/eb89e4ee2dd7308842381b6c425197bb3ae6eed6/src/gluonts/model/seq2seq/_mq_dnn_estimator.py#L303) were missing the `batch_size` attribute (after this attribute was removed from `Trainer`).

This PR only add the `batch_size` attribute to the 2 classes and call their parent constructor [ForkingSeq2SeqEstimator](https://github.com/awslabs/gluon-ts/blob/eb89e4ee2dd7308842381b6c425197bb3ae6eed6/src/gluonts/model/seq2seq/_forking_estimator.py#L72) with the batch_size attribute.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Label: bug fix