### PR TITLE
Fix NegativeBinomial constructor args in NegativeBinomialOutput

### DIFF
--- a/src/gluonts/torch/modules/distribution_output.py
+++ b/src/gluonts/torch/modules/distribution_output.py
@@ -112,6 +112,9 @@ class DistributionOutput(Output):
     def __init__(self) -> None:
         pass
 
+    def _base_distribution(self, distr_args):
+        return self.distr_cls(*distr_args)
+
     def distribution(
         self,
         distr_args,
@@ -133,19 +136,15 @@ class DistributionOutput(Output):
             Optional tensor, of the same shape as the
             batch_shape+event_shape of the resulting distribution.
         """
+        distr = self._base_distribution(distr_args)
         if loc is None and scale is None:
-            return self.distr_cls(*distr_args)
+            return distr
         else:
-            distr = self.distr_cls(*distr_args)
-            return TransformedDistribution(
-                distr,
-                [
-                    AffineTransform(
-                        loc=0.0 if loc is None else loc,
-                        scale=1.0 if scale is None else scale,
-                    )
-                ],
+            transform = AffineTransform(
+                loc=0.0 if loc is None else loc,
+                scale=1.0 if scale is None else scale,
             )
+            return TransformedDistribution(distr, [transform])
 
     @property
     def event_shape(self) -> Tuple:
@@ -277,6 +276,10 @@ class NegativeBinomialOutput(DistributionOutput):
     def domain_map(cls, total_count: torch.Tensor, logits: torch.Tensor):
         total_count = F.softplus(total_count)
         return total_count.squeeze(-1), logits.squeeze(-1)
+
+    def _base_distribution(self, distr_args) -> Distribution:
+        total_count, logits = distr_args
+        return self.distr_cls(total_count=total_count, logits=logits)
 
     @property
     def event_shape(self) -> Tuple:

--- a/test/torch/modules/test_torch_distribution_inference.py
+++ b/test/torch/modules/test_torch_distribution_inference.py
@@ -273,8 +273,13 @@ def test_poisson(rate: float) -> None:
     ), f"rate did not match: rate = {rate}, rate_hat = {rate_hat}"
 
 
-# The following parameters match the Gluon-based test, adjusted for the different parametrization
-@pytest.mark.parametrize("total_count, logit", [(1 / 0.7, np.log(2.5 * 0.7))])
+@pytest.mark.parametrize(
+    "total_count, logit",
+    [
+        (1.4, 0.56),
+        (1.4, 2.0),
+    ],
+)
 @pytest.mark.flaky(max_runs=5, min_passes=1)
 def test_neg_binomial(total_count: float, logit: float) -> None:
     """


### PR DESCRIPTION
*Issue #, if available:* Fixes #1646

*Description of changes:* `NegativeBinomialOutput` was calling `torch.distributions.NegativeBinomial` with the wrong constructor argument (second positional argument). This PR makes sure the right argument `logits` is passed. Ideally, the `domain_map` from `DistributionOutput` should return a dictionary of kwargs for the distribution class; however, modifying that would require some broader changes, so this solution is simpler. We can decide to change the API of `DistributionOutput` at a later stage, if we thing that's necessary.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup