### PR TITLE
Cap numba<0.54, ipykernel<6.2.0

### DIFF
--- a/requirements/requirements-docs.txt
+++ b/requirements/requirements-docs.txt
@@ -1,5 +1,5 @@
 ipython
-ipykernel
+ipykernel<6.2.0
 nbconvert~=5.6.1
 nbsphinx>=0.3.4,<0.4
 notedown

--- a/requirements/requirements-extras-anomaly-evaluation.txt
+++ b/requirements/requirements-extras-anomaly-evaluation.txt
@@ -1,2 +1,2 @@
-numba~=0.51
+numba~=0.51,<0.54
 scikit-learn~=0.22


### PR DESCRIPTION
Some issue started occurring since `numba==0.54` was released (released August 20) and `ipykernel==6.2.0`:

```
ImportError: numpy.core.multiarray failed to import  # because of numba
[...]
TypeError: 'coroutine' object is not subscriptable  # because of ipykernel
```

This PR is capping it temporarily.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup