### PR TITLE
Fix docs build on mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ docs: release
 		IPYNB_BASENAME=`echo $$BASENAME | sed 's/md/ipynb/'` ; \
 		TARGET_HTML="docs/_build/html/$$DIR/$$HTML_BASENAME" ; \
 		echo "processing" $$BASENAME ; \
-		sed -i "s/$$IPYNB_BASENAME/$$BASENAME/g" $$TARGET_HTML; \
+		sed -i "" "s/$$IPYNB_BASENAME/$$BASENAME/g" $$TARGET_HTML; \
 	done;
 	sed -i.bak 's/33\,150\,243/23\,141\,201/g' docs/_build/html/_static/material-design-lite-1.3.0/material.blue-deep_orange.min.css;
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Docs build on macs fails (unless one uses GNU sed)  because `-i` option of `sed` command is [not optional on macs](https://stackoverflow.com/questions/16745988/sed-command-with-i-option-in-place-editing-works-fine-on-ubuntu-but-not-mac). 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


