### PR TITLE
Adding IQF to remove quantile crossing and required retraining for ne…

### DIFF
--- a/src/gluonts/model/seq2seq/_forking_estimator.py
+++ b/src/gluonts/model/seq2seq/_forking_estimator.py
@@ -418,6 +418,7 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
                     if not self.enable_decoder_dynamic_feature
                     else []
                 ),
+                prediction_time_decoder_exclude=[FieldName.OBSERVED_VALUES],
             )
         )
 

--- a/src/gluonts/model/seq2seq/_forking_network.py
+++ b/src/gluonts/model/seq2seq/_forking_network.py
@@ -312,7 +312,6 @@ class ForkingSeq2SeqPredictionNetwork(ForkingSeq2SeqNetworkBase):
         )
 
         # We only care about the output of the decoder for the last time step
-        # shape: (batch_size, decoder_length, decoder_mlp_dim_seq[0])
         # shape: (batch_size = num_test_ts, decoder_length = prediction_length, num_quantiles)
         fcst_output = F.squeeze(
             self.quantile_proj(

--- a/src/gluonts/model/seq2seq/_forking_network.py
+++ b/src/gluonts/model/seq2seq/_forking_network.py
@@ -298,7 +298,7 @@ class ForkingSeq2SeqPredictionNetwork(ForkingSeq2SeqNetworkBase):
 
         Returns
         -------
-        prediction tensor with shape (batch_size, prediction_length)
+        prediction tensor with shape (num_test_ts, num_quantiles, prediction_length)
         """
 
         # shape: (batch_size, num_forking, decoder_length, decoder_mlp_dim_seq[0])
@@ -313,13 +313,16 @@ class ForkingSeq2SeqPredictionNetwork(ForkingSeq2SeqNetworkBase):
 
         # We only care about the output of the decoder for the last time step
         # shape: (batch_size, decoder_length, decoder_mlp_dim_seq[0])
-        fcst_output = F.slice_axis(dec_output, axis=1, begin=-1, end=None)
-        fcst_output = F.squeeze(fcst_output, axis=1)
+        # shape: (batch_size = num_test_ts, decoder_length = prediction_length, num_quantiles)
+        fcst_output = F.squeeze(
+            self.quantile_proj(
+                F.slice_axis(dec_output, axis=1, begin=-1, end=None)
+            ),
+            axis=1,
+        )
 
-        # shape: (batch_size, len(quantiles), decoder_length = prediction_length)
-        predictions = self.quantile_proj(fcst_output).swapaxes(2, 1)
-
-        return predictions
+        # shape: (num_test_ts, num_quantiles, prediction_length)
+        return fcst_output.swapaxes(2, 1)
 
 
 class ForkingSeq2SeqDistributionPredictionNetwork(ForkingSeq2SeqNetworkBase):

--- a/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
+++ b/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
@@ -180,7 +180,6 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
         self.kernel_size_seq = (
             kernel_size_seq if kernel_size_seq is not None else [7, 3, 3]
         )
-
         self.quantiles = (
             quantiles
             if (quantiles is not None) or (distr_output is not None)
@@ -220,7 +219,11 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
             prefix="decoder_",
         )
 
-        quantile_output = QuantileOutput(self.quantiles, is_iqf=self.is_iqf)
+        quantile_output = (
+            QuantileOutput(self.quantiles, is_iqf=self.is_iqf)
+            if self.quantiles
+            else None
+        )
 
         super().__init__(
             encoder=encoder,
@@ -369,7 +372,11 @@ class MQRNNEstimator(ForkingSeq2SeqEstimator):
             prefix="decoder_",
         )
 
-        quantile_output = QuantileOutput(self.quantiles, is_iqf=self.is_iqf)
+        quantile_output = (
+            QuantileOutput(self.quantiles, is_iqf=self.is_iqf)
+            if self.quantiles
+            else None
+        )
 
         super().__init__(
             encoder=encoder,

--- a/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
+++ b/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
@@ -185,6 +185,7 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
             if (quantiles is not None) or (distr_output is not None)
             else [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
         )
+        self.is_iqf = is_iqf
 
         assert (
             len(self.channels_seq)
@@ -219,7 +220,6 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
         )
 
         quantile_output = QuantileOutput(self.quantiles, is_iqf=self.is_iqf)
-        self.is_iqf = is_iqf
 
         super().__init__(
             encoder=encoder,

--- a/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
+++ b/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
@@ -180,8 +180,9 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
         self.kernel_size_seq = (
             kernel_size_seq if kernel_size_seq is not None else [7, 3, 3]
         )
+
         self.quantiles = (
-            sorted(quantiles, reverse=False)  # ascending order
+            quantiles
             if (quantiles is not None) or (distr_output is not None)
             else [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
         )
@@ -343,7 +344,7 @@ class MQRNNEstimator(ForkingSeq2SeqEstimator):
             decoder_mlp_dim_seq if decoder_mlp_dim_seq is not None else [30]
         )
         self.quantiles = (
-            sorted(quantiles, reverse=False)  # ascending order
+            quantiles
             if (quantiles is not None) or (distr_output is not None)
             else [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
         )

--- a/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
+++ b/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
@@ -109,6 +109,8 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
         Decides how much forking to do in the decoder. 1 reduces to seq2seq and enc_len reduces to MQ-CNN.
     max_ts_len
         Returns the length of the longest time series in the dataset to be used in bounding context_length.
+    is_iqf
+        Determines whether to use IQF or QF. (default: True).
     batch_size
         The size of the batches to be used training and prediction.
     """
@@ -141,6 +143,7 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
         scaling_decoder_dynamic_feature: bool = False,
         num_forking: Optional[int] = None,
         max_ts_len: Optional[int] = None,
+        is_iqf: bool = True,
         batch_size: int = 32,
     ) -> None:
 
@@ -178,7 +181,7 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
             kernel_size_seq if kernel_size_seq is not None else [7, 3, 3]
         )
         self.quantiles = (
-            quantiles
+            sorted(quantiles, reverse=False)  # ascending order
             if (quantiles is not None) or (distr_output is not None)
             else [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
         )
@@ -215,9 +218,8 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
             prefix="decoder_",
         )
 
-        quantile_output = (
-            QuantileOutput(self.quantiles) if self.quantiles else None
-        )
+        quantile_output = QuantileOutput(self.quantiles, is_iqf=self.is_iqf)
+        self.is_iqf = is_iqf
 
         super().__init__(
             encoder=encoder,
@@ -323,6 +325,7 @@ class MQRNNEstimator(ForkingSeq2SeqEstimator):
         scaling: Optional[bool] = None,
         scaling_decoder_dynamic_feature: bool = False,
         num_forking: Optional[int] = None,
+        is_iqf: bool = True,
         batch_size: int = 32,
     ) -> None:
 
@@ -340,10 +343,11 @@ class MQRNNEstimator(ForkingSeq2SeqEstimator):
             decoder_mlp_dim_seq if decoder_mlp_dim_seq is not None else [30]
         )
         self.quantiles = (
-            quantiles
+            sorted(quantiles, reverse=False)  # ascending order
             if (quantiles is not None) or (distr_output is not None)
             else [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
         )
+        self.is_iqf = is_iqf
 
         # `use_static_feat` and `use_dynamic_feat` always True because network
         # always receives input; either from the input data or constants
@@ -364,9 +368,7 @@ class MQRNNEstimator(ForkingSeq2SeqEstimator):
             prefix="decoder_",
         )
 
-        quantile_output = (
-            QuantileOutput(self.quantiles) if self.quantiles else None
-        )
+        quantile_output = QuantileOutput(self.quantiles, is_iqf=self.is_iqf)
 
         super().__init__(
             encoder=encoder,

--- a/src/gluonts/model/seq2seq/_transform.py
+++ b/src/gluonts/model/seq2seq/_transform.py
@@ -11,15 +11,12 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# Standard library imports
 from collections import Counter
 from typing import Iterator, List, Optional
 
-# Third-party imports
 import numpy as np
 from numpy.lib.stride_tricks import as_strided
 
-# First-party imports
 from gluonts.core.component import validated
 from gluonts.dataset.common import DataEntry
 from gluonts.dataset.field_names import FieldName

--- a/src/gluonts/model/seq2seq/_transform.py
+++ b/src/gluonts/model/seq2seq/_transform.py
@@ -42,6 +42,7 @@ class ForkingSequenceSplitter(FlatMapTransformation):
         is_pad_out: str = "is_pad",
         start_input_field: str = "start",
     ) -> None:
+        super().__init__()
 
         assert enc_len > 0, "The value of `enc_len` should be > 0"
         assert dec_len > 0, "The value of `dec_len` should be > 0"

--- a/src/gluonts/model/seq2seq/_transform.py
+++ b/src/gluonts/model/seq2seq/_transform.py
@@ -107,9 +107,7 @@ class ForkingSequenceSplitter(FlatMapTransformation):
             if len(target) < self.dec_len:
                 return
 
-            sampling_indices = self.instance_sampler(
-                target, 0, len(target) - self.dec_len
-            )
+            sampling_indices = self.instance_sampler(target)
         else:
             sampling_indices = [len(target)]
 

--- a/src/gluonts/model/seq2seq/_transform.py
+++ b/src/gluonts/model/seq2seq/_transform.py
@@ -11,11 +11,15 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# Standard library imports
+from collections import Counter
 from typing import Iterator, List, Optional
 
+# Third-party imports
 import numpy as np
 from numpy.lib.stride_tricks import as_strided
 
+# First-party imports
 from gluonts.core.component import validated
 from gluonts.dataset.common import DataEntry
 from gluonts.dataset.field_names import FieldName
@@ -28,7 +32,7 @@ class ForkingSequenceSplitter(FlatMapTransformation):
     @validated()
     def __init__(
         self,
-        instance_sampler,
+        train_sampler,
         enc_len: int,
         dec_len: int,
         num_forking: Optional[int] = None,
@@ -37,15 +41,15 @@ class ForkingSequenceSplitter(FlatMapTransformation):
         decoder_series_fields: Optional[List[str]] = None,
         encoder_disabled_fields: Optional[List[str]] = None,
         decoder_disabled_fields: Optional[List[str]] = None,
+        prediction_time_decoder_exclude: Optional[List[str]] = None,
         is_pad_out: str = "is_pad",
         start_input_field: str = "start",
     ) -> None:
-        super().__init__()
 
         assert enc_len > 0, "The value of `enc_len` should be > 0"
         assert dec_len > 0, "The value of `dec_len` should be > 0"
 
-        self.instance_sampler = instance_sampler
+        self.train_sampler = train_sampler
         self.enc_len = enc_len
         self.dec_len = dec_len
         self.num_forking = (
@@ -76,6 +80,13 @@ class ForkingSequenceSplitter(FlatMapTransformation):
             else []
         )
 
+        # Fields that are not used at prediction time for the decoder
+        self.prediction_time_decoder_exclude = (
+            prediction_time_decoder_exclude + [self.target_field]
+            if prediction_time_decoder_exclude is not None
+            else [self.target_field]
+        )
+
         self.is_pad_out = is_pad_out
         self.start_in = start_input_field
 
@@ -90,19 +101,33 @@ class ForkingSequenceSplitter(FlatMapTransformation):
     ) -> Iterator[DataEntry]:
         target = data[self.target_field]
 
-        sampled_indices = self.instance_sampler(target)
+        if is_train:
+            # We currently cannot handle time series that are shorter than the
+            # prediction length during training, so we just skip these.
+            # If we want to include them we would need to pad and to mask
+            # the loss.
+            if len(target) < self.dec_len:
+                return
 
-        ts_fields = set(
-            self.encoder_series_fields + self.decoder_series_fields
+            sampling_indices = self.train_sampler(
+                target, 0, len(target) - self.dec_len
+            )
+        else:
+            sampling_indices = [len(target)]
+
+        # Loops over all encoder and decoder fields even those that are disabled to
+        # set to dummy zero fields in those cases
+        ts_fields_counter = Counter(
+            set(self.encoder_series_fields + self.decoder_series_fields)
         )
 
-        for idx in sampled_indices:
+        for sampling_idx in sampling_indices:
             # irrelevant data should have been removed by now in the
             # transformation chain, so copying everything is ok
             out = data.copy()
 
-            enc_len_diff = idx - self.enc_len
-            dec_len_diff = idx - self.num_forking
+            enc_len_diff = sampling_idx - self.enc_len
+            dec_len_diff = sampling_idx - self.num_forking
 
             # ensure start indices are not negative
             start_idx_enc = max(0, enc_len_diff)
@@ -112,21 +137,31 @@ class ForkingSequenceSplitter(FlatMapTransformation):
             pad_length_enc = max(0, -enc_len_diff)
             pad_length_dec = max(0, -dec_len_diff)
 
-            for ts_field in ts_fields:
+            for ts_field in list(ts_fields_counter.keys()):
 
                 # target is 1d, this ensures ts is always 2d
                 ts = np.atleast_2d(out[ts_field]).T
                 ts_len = ts.shape[1]
 
-                del out[ts_field]
+                if ts_fields_counter[ts_field] == 1:
+                    del out[ts_field]
+                else:
+                    ts_fields_counter[ts_field] -= 1
 
                 out[self._past(ts_field)] = np.zeros(
                     shape=(self.enc_len, ts_len), dtype=ts.dtype
                 )
                 if ts_field not in self.encoder_disabled_fields:
                     out[self._past(ts_field)][pad_length_enc:] = ts[
-                        start_idx_enc:idx, :
+                        start_idx_enc:sampling_idx, :
                     ]
+
+                # exclude some fields at prediction time
+                if (
+                    not is_train
+                    and ts_field in self.prediction_time_decoder_exclude
+                ):
+                    continue
 
                 if ts_field in self.decoder_series_fields:
                     out[self._future(ts_field)] = np.zeros(
@@ -137,7 +172,9 @@ class ForkingSequenceSplitter(FlatMapTransformation):
                         # This is where some of the forking magic happens:
                         # For each of the num_forking time-steps at which the decoder is applied we slice the
                         # corresponding inputs called decoder_fields to the appropriate dec_len
-                        decoder_fields = ts[start_idx_dec + 1 : idx + 1, :]
+                        decoder_fields = ts[
+                            start_idx_dec + 1 : sampling_idx + 1, :
+                        ]
                         # For default row-major arrays, strides = (dtype*n_cols, dtype). Since this array is transposed,
                         # it is stored in column-major (Fortran) ordering with strides = (dtype, dtype*n_rows)
                         stride = decoder_fields.strides
@@ -170,7 +207,7 @@ class ForkingSequenceSplitter(FlatMapTransformation):
 
             # So far pad forecast_start not in use
             out[FieldName.FORECAST_START] = shift_timestamp(
-                out[self.start_in], idx
+                out[self.start_in], sampling_idx
             )
 
             yield out

--- a/src/gluonts/model/seq2seq/_transform.py
+++ b/src/gluonts/model/seq2seq/_transform.py
@@ -29,7 +29,7 @@ class ForkingSequenceSplitter(FlatMapTransformation):
     @validated()
     def __init__(
         self,
-        train_sampler,
+        instance_sampler,
         enc_len: int,
         dec_len: int,
         num_forking: Optional[int] = None,
@@ -46,7 +46,7 @@ class ForkingSequenceSplitter(FlatMapTransformation):
         assert enc_len > 0, "The value of `enc_len` should be > 0"
         assert dec_len > 0, "The value of `dec_len` should be > 0"
 
-        self.train_sampler = train_sampler
+        self.instance_sampler = instance_sampler
         self.enc_len = enc_len
         self.dec_len = dec_len
         self.num_forking = (
@@ -106,7 +106,7 @@ class ForkingSequenceSplitter(FlatMapTransformation):
             if len(target) < self.dec_len:
                 return
 
-            sampling_indices = self.train_sampler(
+            sampling_indices = self.instance_sampler(
                 target, 0, len(target) - self.dec_len
             )
         else:

--- a/src/gluonts/mx/block/quantile_output.py
+++ b/src/gluonts/mx/block/quantile_output.py
@@ -296,7 +296,7 @@ class QuantileOutput:
         quantile_weights: Optional[List[float]] = None,
         is_iqf: bool = False,
     ) -> None:
-        self.quantiles = quantiles
+        self.quantiles = sorted(quantiles)
         self.num_quantiles = len(self.quantiles)
         self.quantile_weights = quantile_weights
         self.is_iqf = is_iqf

--- a/src/gluonts/mx/block/quantile_output.py
+++ b/src/gluonts/mx/block/quantile_output.py
@@ -155,22 +155,24 @@ class QuantileLoss(Loss):
         Math:
         Let quantiles = [q_1, ..., q_n] with quantile estimates [z_1, ..., z_n].
         Then, approximated CRPS with the linear interpolation is
+
         .. math::
             :nowrap:
 
-            \begin{aligned}
-                CRPS = \sum_{i=1}^{n-1} 0.5 * (q_{i+1} - q_{i}) * (z_{i+1} + z_{i}).
-             \end{aligned}
+                \begin{aligned}
+                    CRPS = \sum_{i=1}^{n-1} 0.5 * (q_{i+1} - q_{i}) * (z_{i+1} + z_{i}).
+                \end{aligned}
 
         Reordering w.r.t. e_j for j=1, ..., n, gives
         .. math::
             :nowrap:
+
             \begin{aligned}
-            CRPS = 0.5 * (q_2 - q_1) z_1
-            + 0.5 * (q_3 - q_1)  z_2
-            + ....
-            + 0.5 * (q_n - q_{n-2}) z_{n-1}
-            + 0.5 * (q_n - q_{n-1}) z_n
+                CRPS = 0.5 * (q_2 - q_1) z_1
+                + 0.5 * (q_3 - q_1)  z_2
+                + ....
+                + 0.5 * (q_n - q_{n-2}) z_{n-1}
+                + 0.5 * (q_n - q_{n-1}) z_n
             \end{aligned}
         , where each coefficient of z_j is quantile weight w_j.
 
@@ -179,14 +181,15 @@ class QuantileLoss(Loss):
         where quantile weight w_j is
         .. math::
             :nowrap:
-            \begin{aligned}
-            w_j =
-            \begin{cases}
-                0.5 * (q_{j+1} - q_j)       & j=1   \\
-                0.5 * (q_{j+1} - q_{j-1})   & j=2,..., n-1  \\
-                0.5 * (q_j - q_{j-1})       & j=n
-            \end{cases}.
-         \end{aligned}
+
+                \begin{aligned}
+                    w_j =
+                    \begin{cases}
+                        0.5 * (q_{j+1} - q_j)       & j=1   \\
+                        0.5 * (q_{j+1} - q_{j-1})   & j=2,..., n-1  \\
+                        0.5 * (q_j - q_{j-1})       & j=n
+                    \end{cases}.
+                \end{aligned}
 
         Return
         ----------

--- a/src/gluonts/mx/block/quantile_output.py
+++ b/src/gluonts/mx/block/quantile_output.py
@@ -25,10 +25,10 @@ class QuantileLoss(Loss):
     def __init__(
         self,
         quantiles: List[float],
-        quantile_weights: List[float] = None,
+        quantile_weights: Optional[List[float]] = None,
         is_equal_weights: bool = True,
-        weight=None,
-        batch_axis=0,
+        weight: Optional[float] = None,
+        batch_axis: int = 0,
         **kwargs,
     ) -> None:
         """

--- a/src/gluonts/mx/block/quantile_output.py
+++ b/src/gluonts/mx/block/quantile_output.py
@@ -159,37 +159,29 @@ class QuantileLoss(Loss):
         .. math::
             :nowrap:
 
-                \begin{aligned}
-                    CRPS = \sum_{i=1}^{n-1} 0.5 * (q_{i+1} - q_{i}) * (z_{i+1} + z_{i}).
-                \end{aligned}
+                    CRPS = sum_{i=1}^{n-1} 0.5 * (q_{i+1} - q_{i}) * (z_{i+1} + z_{i}).
 
         Reordering w.r.t. e_j for j=1, ..., n, gives
         .. math::
             :nowrap:
 
-            \begin{aligned}
                 CRPS = 0.5 * (q_2 - q_1) z_1
                 + 0.5 * (q_3 - q_1)  z_2
                 + ....
                 + 0.5 * (q_n - q_{n-2}) z_{n-1}
                 + 0.5 * (q_n - q_{n-1}) z_n
-            \end{aligned}
         , where each coefficient of z_j is quantile weight w_j.
 
         Thus,
-        CRPS = \sum_{j=1}^n w_j z_j
+        CRPS = sum_{j=1}^n w_j z_j
         where quantile weight w_j is
         .. math::
             :nowrap:
 
-                \begin{aligned}
                     w_j =
-                    \begin{cases}
                         0.5 * (q_{j+1} - q_j)       & j=1   \\
                         0.5 * (q_{j+1} - q_{j-1})   & j=2,..., n-1  \\
                         0.5 * (q_j - q_{j-1})       & j=n
-                    \end{cases}.
-                \end{aligned}
 
         Return
         ----------

--- a/src/gluonts/mx/block/quantile_output.py
+++ b/src/gluonts/mx/block/quantile_output.py
@@ -25,9 +25,10 @@ class QuantileLoss(Loss):
     def __init__(
         self,
         quantiles: List[float],
-        quantile_weights: Optional[List[float]] = None,
-        weight: Optional[float] = None,
-        batch_axis: int = 0,
+        quantile_weights: List[float] = None,
+        is_equal_weights: bool = True,
+        weight=None,
+        batch_axis=0,
         **kwargs,
     ) -> None:
         """
@@ -35,26 +36,31 @@ class QuantileLoss(Loss):
 
         Parameters
         ----------
-        quantiles
+        quantiles:
             list of quantiles to compute loss over.
 
-        quantile_weights
+        quantile_weights:
             weights of the quantiles.
 
-        weight
+        is_equal_weights:
+            use equally quantiles weights or not
+
+        weight:
             weighting of the loss.
 
-        batch_axis
+        batch_axis:
             indicates axis that represents the batch.
         """
         super().__init__(weight, batch_axis, **kwargs)
 
         self.quantiles = quantiles
         self.num_quantiles = len(quantiles)
+        self.is_equal_weights = is_equal_weights
+
         self.quantile_weights = (
-            [1.0 / self.num_quantiles for i in range(self.num_quantiles)]
-            if not quantile_weights
-            else quantile_weights
+            quantile_weights
+            if quantile_weights
+            else self.compute_quantile_weights()
         )
 
     # noinspection PyMethodOverriding
@@ -142,6 +148,61 @@ class QuantileLoss(Loss):
 
         return qt_loss
 
+    def compute_quantile_weights(self):
+        """
+        Compute weight of each quantile
+
+        Math:
+        Let quantiles = [q_1, ..., q_n] with quantile estimates [z_1, ..., z_n].
+        Then, approximated CRPS with the linear interpolation is
+        CRPS =
+        \[
+            \sum_{i=1}^{n-1} 0.5 * (q_{i+1} - q_{i}) * (z_{i+1} + z_{i}).
+        \]
+
+        Reordering w.r.t. e_j for j=1, ..., n, gives
+        CRPS = 0.5 * (q_2 - q_1) z_1
+            + 0.5 * (q_3 - q_1)  z_2
+            + ....
+            + 0.5 * (q_n - q_{n-2}) z_{n-1}
+            + 0.5 * (q_n - q_{n-1}) z_n
+        , where each coefficient of z_j is quantile weight w_j.
+
+        Thus,
+        CRPS = \sum_{j=1}^n w_j z_j
+        where quantile weight w_j is
+        \[
+            w_j =
+            \begin{cases}
+                0.5 * (q_{j+1} - q_j)       & j=1   \\
+                0.5 * (q_{j+1} - q_{j-1})   & j=2,..., n-1  \\
+                0.5 * (q_j - q_{j-1})       & j=n
+            \end{cases}.
+        \]
+
+        Return
+        ----------
+        quantile_weights:
+            weights of the quantiles.
+        """
+        assert (
+            self.num_quantiles >= 0
+        ), f"invalid num_quantiles: {self.num_quantiles}"
+        if self.num_quantiles == 0:  # edge case
+            quantile_weights = []
+        elif self.is_equal_weights or self.num_quantiles == 1:
+            quantile_weights = [1.0 / self.num_quantiles] * self.num_quantiles
+        else:  # self.is_equal_weights= False and self.num_quantiles > 1
+            quantile_weights = (
+                [0.5 * (self.quantiles[1] - self.quantiles[0])]
+                + [
+                    0.5 * (self.quantiles[i + 1] - self.quantiles[i - 1])
+                    for i in range(1, self.num_quantiles - 1)
+                ]
+                + [0.5 * (self.quantiles[-1] - self.quantiles[-2])]
+            )
+        return quantile_weights
+
 
 class ProjectParams(nn.HybridBlock):
     """
@@ -150,16 +211,31 @@ class ProjectParams(nn.HybridBlock):
 
     Parameters
     ----------
-    num_quantiles
+    num_quantiles:
         number of quantiles to compute the projection.
+    is_iqf:
+        determines whether to use IQF or QF.
     """
 
     @validated()
-    def __init__(self, num_quantiles, **kwargs):
+    def __init__(self, num_quantiles: int, is_iqf: bool = False, **kwargs):
         super().__init__(**kwargs)
 
+        self.num_quantiles = num_quantiles
+        self.is_iqf = is_iqf
         with self.name_scope():
-            self.projection = nn.Dense(units=num_quantiles, flatten=False)
+            if self.is_iqf:
+                self.proj_intrcpt = nn.Dense(1, flatten=False)
+                if self.num_quantiles > 1:
+                    self.proj_incrmnt = nn.Dense(
+                        self.num_quantiles - 1,
+                        flatten=False,
+                        activation="relu",
+                    )  # increments between quantile estimates
+            else:
+                self.projection = nn.Dense(
+                    units=self.num_quantiles, flatten=False
+                )
 
     # noinspection PyMethodOverriding,PyPep8Naming
     def hybrid_forward(self, F, x: Tensor) -> Tuple[Tensor, Tensor, Tensor]:
@@ -178,7 +254,22 @@ class ProjectParams(nn.HybridBlock):
         Tensor
             output of the projection layer
         """
-        return self.projection(x)
+        return (
+            (
+                self.proj_intrcpt(x)
+                if self.num_quantiles == 1
+                else (
+                    F.cumsum(
+                        F.concat(
+                            self.proj_intrcpt(x), self.proj_incrmnt(x), dim=-1
+                        ),
+                        axis=3,
+                    )
+                )
+            )
+            if self.is_iqf
+            else self.projection(x)
+        )
 
 
 class QuantileOutput:
@@ -188,11 +279,14 @@ class QuantileOutput:
 
     Parameters
     ----------
-        quantiles
+        quantiles:
             list of quantiles to compute loss over.
 
-        quantile_weights
+        quantile_weights:
             weights of the quantiles.
+
+        is_iqf:
+            determines whether to use IQF or QF.
     """
 
     @validated()
@@ -200,9 +294,13 @@ class QuantileOutput:
         self,
         quantiles: List[float],
         quantile_weights: Optional[List[float]] = None,
+        is_iqf: bool = False,
     ) -> None:
         self.quantiles = quantiles
+        self.num_quantiles = len(self.quantiles)
         self.quantile_weights = quantile_weights
+        self.is_iqf = is_iqf
+        self.is_equal_weights = False if self.is_iqf else True
 
     def get_loss(self) -> nn.HybridBlock:
         """
@@ -212,7 +310,9 @@ class QuantileOutput:
             constructs quantile loss object.
         """
         return QuantileLoss(
-            quantiles=self.quantiles, quantile_weights=self.quantile_weights
+            quantiles=self.quantiles,
+            quantile_weights=self.quantile_weights,
+            is_equal_weights=self.is_equal_weights,
         )
 
     def get_quantile_proj(self, **kwargs) -> nn.HybridBlock:
@@ -223,4 +323,4 @@ class QuantileOutput:
             constructs projection parameter object.
 
         """
-        return ProjectParams(len(self.quantiles), **kwargs)
+        return ProjectParams(self.num_quantiles, self.is_iqf, **kwargs)

--- a/src/gluonts/mx/block/quantile_output.py
+++ b/src/gluonts/mx/block/quantile_output.py
@@ -155,30 +155,38 @@ class QuantileLoss(Loss):
         Math:
         Let quantiles = [q_1, ..., q_n] with quantile estimates [z_1, ..., z_n].
         Then, approximated CRPS with the linear interpolation is
-        CRPS =
-        \[
-            \sum_{i=1}^{n-1} 0.5 * (q_{i+1} - q_{i}) * (z_{i+1} + z_{i}).
-        \]
+        .. math::
+            :nowrap:
+
+            \begin{aligned}
+                CRPS = \sum_{i=1}^{n-1} 0.5 * (q_{i+1} - q_{i}) * (z_{i+1} + z_{i}).
+             \end{aligned}
 
         Reordering w.r.t. e_j for j=1, ..., n, gives
-        CRPS = 0.5 * (q_2 - q_1) z_1
+        .. math::
+            :nowrap:
+            \begin{aligned}
+            CRPS = 0.5 * (q_2 - q_1) z_1
             + 0.5 * (q_3 - q_1)  z_2
             + ....
             + 0.5 * (q_n - q_{n-2}) z_{n-1}
             + 0.5 * (q_n - q_{n-1}) z_n
+            \end{aligned}
         , where each coefficient of z_j is quantile weight w_j.
 
         Thus,
         CRPS = \sum_{j=1}^n w_j z_j
         where quantile weight w_j is
-        \[
+        .. math::
+            :nowrap:
+            \begin{aligned}
             w_j =
             \begin{cases}
                 0.5 * (q_{j+1} - q_j)       & j=1   \\
                 0.5 * (q_{j+1} - q_{j-1})   & j=2,..., n-1  \\
                 0.5 * (q_j - q_{j-1})       & j=n
             \end{cases}.
-        \]
+         \end{aligned}
 
         Return
         ----------

--- a/src/gluonts/shell/train.py
+++ b/src/gluonts/shell/train.py
@@ -147,18 +147,6 @@ def run_test(
         else None
     )
 
-    forecast_generator = getattr(predictor, "forecast_generator", None)
-    if isinstance(forecast_generator, QuantileForecastGenerator):
-        predictor_quantiles = forecast_generator.quantiles
-        if test_quantiles is None:
-            test_quantiles = predictor_quantiles
-        elif not set(test_quantiles).issubset(predictor_quantiles):
-            logger.warning(
-                f"Some of the evaluation quantiles `{test_quantiles}` are "
-                f"not in the computed quantile forecasts `{predictor_quantiles}`."
-            )
-            test_quantiles = predictor_quantiles
-
     if test_quantiles is not None:
         logger.info(f"Using quantiles `{test_quantiles}` for evaluation.")
         evaluator = Evaluator(quantiles=test_quantiles)

--- a/src/gluonts/shell/train.py
+++ b/src/gluonts/shell/train.py
@@ -23,7 +23,6 @@ from gluonts.dataset.common import Dataset
 from gluonts.evaluation import Evaluator, backtest
 from gluonts.model.estimator import Estimator
 from gluonts.model.forecast import Quantile
-from gluonts.model.forecast_generator import QuantileForecastGenerator
 from gluonts.model.predictor import Predictor
 from gluonts.support.util import maybe_len
 from gluonts.transform import FilterTransformation

--- a/src/gluonts/support/util.py
+++ b/src/gluonts/support/util.py
@@ -175,3 +175,242 @@ def erfinv(x: np.array) -> np.array:
         p = c + p * w
 
     return p * x
+
+
+class Interpolation:
+    """
+    Interpolation based on trained quantile predictions
+
+    Parameters
+    ----------
+    quantile_predictions
+        Dict with key = str(quantile) and value is np.array with size prediction_length
+    interpolation_type
+
+    """
+
+    def __init__(
+            self, quantile_predictions: dict, interpolation_type: str = "linear"
+    ):
+        self.quantile_predictions = quantile_predictions
+        self.quantiles = sorted(map(float, self.quantile_predictions))
+        self.num_quantiles = len(self.quantile_predictions)
+        self.interpolation_type = interpolation_type
+
+    def __call__(self, inference_quantile):
+        if self.interpolation_type == "linear":
+            return self.linear_interpolation(inference_quantile)
+        else:
+            raise NotImplementedError(
+                f"unknown interpolation type {self.interpolation_type}"
+            )
+
+    def linear_interpolation(self, inference_quantile: float):
+        """
+        If inference quantile is out of interpolation range,
+        return smallest or largest value.
+        Otherwise, find two nearest points [q_1, x_1], [q_2, x_2] and
+        return its linear interpolation
+        x = (q_2 - q)/(q_2 - q_1) * x_1 + (q - q_1)/(q_2 - q_1) * x_2.
+
+
+        Returns
+        -------
+        same type and shape as any value of quantile_predictions dict,
+        i.e., type=np.array, shape = (prediction_length, )
+
+        """
+        if self.quantiles[0] >= inference_quantile:
+            return self.quantile_predictions[str(self.quantiles[0])]
+        elif self.quantiles[-1] <= inference_quantile:
+            return self.quantile_predictions[str(self.quantiles[-1])]
+        else:
+            for (current_quantile, next_quantile) in zip(
+                    self.quantiles, self.quantiles[1:]
+            ):
+                if (
+                        current_quantile <= inference_quantile
+                        and inference_quantile < next_quantile
+                ):
+                    weights = [
+                        (next_quantile - inference_quantile)
+                        / (next_quantile - current_quantile),
+                        (inference_quantile - current_quantile)
+                        / (next_quantile - current_quantile),
+                    ]
+                    return (
+                            weights[0]
+                            * self.quantile_predictions[str(current_quantile)]
+                            + weights[1]
+                            * self.quantile_predictions[str(next_quantile)]
+                    )
+
+
+class TailApproximation:
+    """
+    Apporoximate quantile function on tails based on trained quantile predictions
+    and make a inference on query point.
+    Can be used for either interpolation or extrapolation on tails
+
+    Parameters
+    ----------
+    quantile_predictions
+        Dict with key = str(quantile) and value is np.array with size prediction_length
+    approximation_type
+        str of tail approximation type
+
+    """
+
+    def __init__(
+            self,
+            quantile_predictions: dict,
+            approximation_type: str = "exponential",
+            tol: float = 1e-8,
+    ):
+        self.quantile_predictions = quantile_predictions
+        self.quantiles = sorted(map(float, self.quantile_predictions))
+        self.num_quantiles = len(self.quantile_predictions)
+        self.approximation_type = (
+            approximation_type if self.num_quantiles > 1 else None
+        )
+        self.tol = tol
+        (self.tail_function_left, self.tail_function_right) = (None, None)
+        if not self.approximation_type:
+            pass
+        elif self.approximation_type == "exponential":
+            self.init_exponential_tail_weights()
+            self.tail_function_left = self.exponential_tail_left
+            self.tail_function_right = self.exponential_tail_right
+        else:
+            raise NotImplementedError(
+                f"unknown approximation type {self.approximation_type}"
+            )
+
+    def left(self, inference_quantile: float):
+        """
+        Call left tail approximation
+
+        Parameters
+        -------
+        inference_quantile
+            float
+
+        Returns
+        -------
+        same type and shape as any value of quantile_predictions dict,
+        i.e., type=np.array, shape = (prediction_length, )
+        """
+        if not self.approximation_type:
+            return self.quantile_predictions[str(self.quantiles[0])]
+        else:
+            return self.tail_function_left(inference_quantile)
+
+    def right(self, inference_quantile: float):
+        """
+        Call right tail approximation
+
+        Parameters
+        -------
+        inference_quantile
+            float
+
+        Returns
+        -------
+        same type and shape as any value of quantile_predictions dict,
+        i.e., type=np.array, shape = (prediction_length, )
+        """
+        if not self.approximation_type:
+            return self.quantile_predictions[str(self.quantiles[-1])]
+        else:
+            return self.tail_function_right(inference_quantile)
+
+    def init_exponential_tail_weights(self):
+        """
+        Initialize the weight of exponentially decaying tail functions
+        based on two extreme points on the left and right respectively
+        """
+        assert (
+                self.num_quantiles >= 2
+        ), f" Need at least two predicted quantiles for exponential approximation"
+        q_log_diff = np.log(
+            (self.quantiles[1] + self.tol) / (self.quantiles[0] + self.tol)
+            + self.tol
+        )
+        x_diff = (
+                self.quantile_predictions[str(self.quantiles[1])]
+                - self.quantile_predictions[str(self.quantiles[0])]
+        )
+        self.beta_inv_left = x_diff / q_log_diff
+
+        z_log_diff = np.log(
+            (1 - self.quantiles[-2] + self.tol)
+            / (1 - self.quantiles[-1] + self.tol)
+            + self.tol
+        )  # z = 1/(1-q)
+        x_diff = (
+                self.quantile_predictions[str(self.quantiles[-1])]
+                - self.quantile_predictions[str(self.quantiles[-2])]
+        )
+        self.beta_inv_right = x_diff / z_log_diff
+
+    def exponential_tail_left(self, inference_quantile: float):
+        """
+        Return the inference made on exponentially decaying tail functions
+        For left tail, x = exp(beta * (q - alpha))
+        For right tail, x = 1 - exp(-beta * (q - alpha))
+
+        E.g. for inference_quantile = self.quantiles[0] or self.quantiles[1] ,
+        return value is exactly self.quantile_predictions[str(self.quantiles[0])]
+        or self.quantile_predictions[str(self.quantiles[1])] respectively.
+
+        """
+        return (
+                       self.beta_inv_left
+                       * np.log(
+                   (inference_quantile + self.tol)
+                   / (self.quantiles[1] + self.tol)
+                   + self.tol
+               )
+               ) + self.quantile_predictions[str(self.quantiles[1])]
+
+    def exponential_tail_right(self, inference_quantile: float):
+        """
+        Return the inference made on exponentially decaying tail functions
+        For left tail, x = exp(beta * (q - alpha))
+        For right tail, x = 1 - exp(-beta * (q - alpha))
+
+        E.g. for inference_quantile = self.quantiles[-1] or self.quantiles[-2] ,
+        return value is exactly self.quantile_predictions[str(self.quantiles[-1])]
+        or self.quantile_predictions[str(self.quantiles[-2])] respectively.
+        """
+        return (
+                       self.beta_inv_right
+                       * np.log(
+                   (1 - self.quantiles[-2] + self.tol)
+                   / (1 - inference_quantile + self.tol)
+                   + self.tol
+               )
+               ) + self.quantile_predictions[str(self.quantiles[-2])]
+
+    def tail_range(
+            self, default_left_tail_quantile=0.1, default_right_tail_quantile=0.9
+    ):
+        """
+        Return an effective range of left and right tails
+
+        """
+        if self.approximation_type == "exponential":
+            left_tail_quantile = max(
+                self.quantiles[0],
+                min(self.quantiles[1], default_left_tail_quantile),
+            )
+            right_tail_quantile = min(
+                self.quantiles[-1],
+                max(self.quantiles[-2], default_right_tail_quantile),
+            )
+        else:
+            (left_tail_quantile, right_tail_quantile) = (
+                default_left_tail_quantile,
+                default_right_tail_quantile,
+            )
+        return (left_tail_quantile, right_tail_quantile)

--- a/src/gluonts/support/util.py
+++ b/src/gluonts/support/util.py
@@ -190,7 +190,7 @@ class Interpolation:
     """
 
     def __init__(
-            self, quantile_predictions: dict, interpolation_type: str = "linear"
+        self, quantile_predictions: dict, interpolation_type: str = "linear"
     ):
         self.quantile_predictions = quantile_predictions
         self.quantiles = sorted(map(float, self.quantile_predictions))
@@ -226,11 +226,11 @@ class Interpolation:
             return self.quantile_predictions[str(self.quantiles[-1])]
         else:
             for (current_quantile, next_quantile) in zip(
-                    self.quantiles, self.quantiles[1:]
+                self.quantiles, self.quantiles[1:]
             ):
                 if (
-                        current_quantile <= inference_quantile
-                        and inference_quantile < next_quantile
+                    current_quantile <= inference_quantile
+                    and inference_quantile < next_quantile
                 ):
                     weights = [
                         (next_quantile - inference_quantile)
@@ -239,10 +239,10 @@ class Interpolation:
                         / (next_quantile - current_quantile),
                     ]
                     return (
-                            weights[0]
-                            * self.quantile_predictions[str(current_quantile)]
-                            + weights[1]
-                            * self.quantile_predictions[str(next_quantile)]
+                        weights[0]
+                        * self.quantile_predictions[str(current_quantile)]
+                        + weights[1]
+                        * self.quantile_predictions[str(next_quantile)]
                     )
 
 
@@ -262,10 +262,10 @@ class TailApproximation:
     """
 
     def __init__(
-            self,
-            quantile_predictions: dict,
-            approximation_type: str = "exponential",
-            tol: float = 1e-8,
+        self,
+        quantile_predictions: dict,
+        approximation_type: str = "exponential",
+        tol: float = 1e-8,
     ):
         self.quantile_predictions = quantile_predictions
         self.quantiles = sorted(map(float, self.quantile_predictions))
@@ -330,15 +330,15 @@ class TailApproximation:
         based on two extreme points on the left and right respectively
         """
         assert (
-                self.num_quantiles >= 2
+            self.num_quantiles >= 2
         ), f" Need at least two predicted quantiles for exponential approximation"
         q_log_diff = np.log(
             (self.quantiles[1] + self.tol) / (self.quantiles[0] + self.tol)
             + self.tol
         )
         x_diff = (
-                self.quantile_predictions[str(self.quantiles[1])]
-                - self.quantile_predictions[str(self.quantiles[0])]
+            self.quantile_predictions[str(self.quantiles[1])]
+            - self.quantile_predictions[str(self.quantiles[0])]
         )
         self.beta_inv_left = x_diff / q_log_diff
 
@@ -348,8 +348,8 @@ class TailApproximation:
             + self.tol
         )  # z = 1/(1-q)
         x_diff = (
-                self.quantile_predictions[str(self.quantiles[-1])]
-                - self.quantile_predictions[str(self.quantiles[-2])]
+            self.quantile_predictions[str(self.quantiles[-1])]
+            - self.quantile_predictions[str(self.quantiles[-2])]
         )
         self.beta_inv_right = x_diff / z_log_diff
 
@@ -365,13 +365,13 @@ class TailApproximation:
 
         """
         return (
-                       self.beta_inv_left
-                       * np.log(
-                   (inference_quantile + self.tol)
-                   / (self.quantiles[1] + self.tol)
-                   + self.tol
-               )
-               ) + self.quantile_predictions[str(self.quantiles[1])]
+            self.beta_inv_left
+            * np.log(
+                (inference_quantile + self.tol)
+                / (self.quantiles[1] + self.tol)
+                + self.tol
+            )
+        ) + self.quantile_predictions[str(self.quantiles[1])]
 
     def exponential_tail_right(self, inference_quantile: float):
         """
@@ -384,16 +384,16 @@ class TailApproximation:
         or self.quantile_predictions[str(self.quantiles[-2])] respectively.
         """
         return (
-                       self.beta_inv_right
-                       * np.log(
-                   (1 - self.quantiles[-2] + self.tol)
-                   / (1 - inference_quantile + self.tol)
-                   + self.tol
-               )
-               ) + self.quantile_predictions[str(self.quantiles[-2])]
+            self.beta_inv_right
+            * np.log(
+                (1 - self.quantiles[-2] + self.tol)
+                / (1 - inference_quantile + self.tol)
+                + self.tol
+            )
+        ) + self.quantile_predictions[str(self.quantiles[-2])]
 
     def tail_range(
-            self, default_left_tail_quantile=0.1, default_right_tail_quantile=0.9
+        self, default_left_tail_quantile=0.1, default_right_tail_quantile=0.9
     ):
         """
         Return an effective range of left and right tails

--- a/src/gluonts/support/util.py
+++ b/src/gluonts/support/util.py
@@ -274,7 +274,6 @@ class TailApproximation:
             approximation_type if self.num_quantiles > 1 else None
         )
         self.tol = tol
-        (self.tail_function_left, self.tail_function_right) = (None, None)
         if not self.approximation_type:
             pass
         elif self.approximation_type == "exponential":

--- a/src/gluonts/support/util.py
+++ b/src/gluonts/support/util.py
@@ -330,7 +330,7 @@ class TailApproximation:
         """
         assert (
             self.num_quantiles >= 2
-        ), f" Need at least two predicted quantiles for exponential approximation"
+        ), "Need at least two predicted quantiles for exponential approximation"
         q_log_diff = np.log(
             (self.quantiles[1] + self.tol) / (self.quantiles[0] + self.tol)
             + self.tol

--- a/test/model/seq2seq/test_model.py
+++ b/test/model/seq2seq/test_model.py
@@ -268,8 +268,7 @@ def test_serialize(Estimator, serialize_test, hyperparameters, is_iqf):
     serialize_test(Estimator, hyperparameters)
 
 
-@pytest.mark.parametrize("use_feat_dynamic_real", [True, False])
-def test_backwards_compatibility(use_feat_dynamic_real):
+def test_backwards_compatibility():
     hps = {
         "freq": "D",
         "context_length": 5,
@@ -278,7 +277,7 @@ def test_backwards_compatibility(use_feat_dynamic_real):
         "quantiles": [0.5, 0.1],
         "epochs": 3,
         "num_batches_per_epoch": 3,
-        "use_feat_dynamic_real": use_feat_dynamic_real,
+        "use_feat_dynamic_real": True,
         "use_past_feat_dynamic_real": True,
         "enable_encoder_dynamic_feature": True,
         "enable_decoder_dynamic_feature": True,

--- a/test/model/seq2seq/test_model.py
+++ b/test/model/seq2seq/test_model.py
@@ -207,7 +207,7 @@ def test_inference_quantile_prediction(quantiles, inference_quantiles):
         ), f"quantile-crossing occurred"
 
 
-@pytest.mark.parametrize("is_iqf", [None, True, False])
+@pytest.mark.parametrize("is_iqf", [True, False])
 def test_is_iqf(is_iqf):
     hps = {
         "seed": 42,
@@ -233,13 +233,13 @@ def test_is_iqf(is_iqf):
     assert len(forecasts) == len(dataset_test)
 
 
-@pytest.mark.parametrize("is_iqf", [None, True, False])
+@pytest.mark.parametrize("is_iqf", [True, False])
 def test_repr(Estimator, repr_test, hyperparameters, is_iqf):
     hyperparameters.update(is_iqf=is_iqf)
     repr_test(Estimator, hyperparameters)
 
 
-@pytest.mark.parametrize("is_iqf", [None, True, False])
+@pytest.mark.parametrize("is_iqf", [True, False])
 def test_serialize(Estimator, serialize_test, hyperparameters, is_iqf):
     hyperparameters.update(is_iqf=is_iqf)
     serialize_test(Estimator, hyperparameters)

--- a/test/model/seq2seq/test_model.py
+++ b/test/model/seq2seq/test_model.py
@@ -14,7 +14,6 @@
 import pytest
 
 from gluonts.model.seq2seq import MQCNNEstimator, MQRNNEstimator
-from gluonts.mx.distribution import GaussianOutput
 from gluonts.testutil.dummy_datasets import make_dummy_datasets_with_features
 
 
@@ -28,6 +27,7 @@ def hyperparameters(dsinfo):
         context_length=dsinfo.prediction_length,
         num_forking=1,
         num_batches_per_epoch=1,
+        quantiles=[0.1, 0.5, 0.9],
         use_symbol_block_predictor=True,
     )
 
@@ -39,29 +39,20 @@ def Estimator(request):
     return request.param
 
 
+@pytest.mark.parametrize("quantiles", [[0.1, 0.5, 0.9], [0.5]])
 @pytest.mark.parametrize("hybridize", [True, False])
-@pytest.mark.parametrize(
-    "quantiles, distr_output",
-    [([0.1, 0.5, 0.9], None), (None, GaussianOutput())],
-)
+@pytest.mark.parametrize("is_iqf", [True, False])
 def test_accuracy(
-    Estimator,
-    accuracy_test,
-    hyperparameters,
-    hybridize,
-    quantiles,
-    distr_output,
+    Estimator, accuracy_test, hyperparameters, hybridize, quantiles, is_iqf
 ):
     hyperparameters.update(
         num_batches_per_epoch=100,
         hybridize=hybridize,
         quantiles=quantiles,
-        distr_output=distr_output,
+        is_iqf=is_iqf,
     )
 
-    accuracy_test(
-        Estimator, hyperparameters, accuracy=0.20 if quantiles else 0.70
-    )
+    accuracy_test(Estimator, hyperparameters, accuracy=0.20)
 
 
 @pytest.mark.parametrize("use_past_feat_dynamic_real", [True, False])
@@ -71,13 +62,7 @@ def test_accuracy(
 @pytest.mark.parametrize("enable_encoder_dynamic_feature", [True, False])
 @pytest.mark.parametrize("enable_decoder_dynamic_feature", [True, False])
 @pytest.mark.parametrize("hybridize", [True, False])
-@pytest.mark.parametrize(
-    "quantiles, distr_output",
-    [
-        ([0.5, 0.1], None),
-        (None, GaussianOutput()),
-    ],
-)
+@pytest.mark.parametrize("is_iqf", [True, False])
 def test_mqcnn_covariate_smoke_test(
     use_past_feat_dynamic_real,
     use_feat_dynamic_real,
@@ -86,16 +71,14 @@ def test_mqcnn_covariate_smoke_test(
     enable_encoder_dynamic_feature,
     enable_decoder_dynamic_feature,
     hybridize,
-    quantiles,
-    distr_output,
+    is_iqf,
 ):
     hps = {
         "seed": 42,
         "freq": "Y",
         "context_length": 5,
         "prediction_length": 3,
-        "quantiles": quantiles,
-        "distr_output": distr_output,
+        "quantiles": [0.5, 0.1],
         "epochs": 3,
         "num_batches_per_epoch": 3,
         "use_past_feat_dynamic_real": use_past_feat_dynamic_real,
@@ -105,6 +88,7 @@ def test_mqcnn_covariate_smoke_test(
         "enable_encoder_dynamic_feature": enable_encoder_dynamic_feature,
         "enable_decoder_dynamic_feature": enable_decoder_dynamic_feature,
         "hybridize": hybridize,
+        "is_iqf": is_iqf,
     }
 
     dataset_train, dataset_test = make_dummy_datasets_with_features(
@@ -177,15 +161,92 @@ def test_mqcnn_scaling_smoke_test(scaling, scaling_decoder_dynamic_feature):
     assert len(forecasts) == len(dataset_test)
 
 
-def test_repr(Estimator, repr_test, hyperparameters):
+@pytest.mark.parametrize(
+    "quantiles, inference_quantiles",
+    [([0.5, 0.1, 0.9], [0.01, 0.1, 0.3, 0.5, 0.7, 0.9, 0.99])],
+)
+def test_inference_quantile_prediction(quantiles, inference_quantiles):
+    hps = {
+        "seed": 42,
+        "freq": "D",
+        "prediction_length": 3,
+        "quantiles": quantiles,
+        "epochs": 3,
+        "num_batches_per_epoch": 3,
+        "is_iqf": True,
+    }
+
+    dataset_train, dataset_test = make_dummy_datasets_with_features(
+        cardinality=[3, 10],
+        num_feat_dynamic_real=2,
+        freq=hps["freq"],
+        prediction_length=hps["prediction_length"],
+    )
+
+    estimator = MQCNNEstimator.from_inputs(dataset_train, **hps)
+
+    predictor = estimator.train(dataset_train, num_workers=None)
+    forecasts = list(predictor.predict(dataset_test))
+    assert len(forecasts) == len(dataset_test)
+    item_id = 0
+    for inference_quantile in inference_quantiles:
+        assert (
+            len(forecasts[item_id].quantile(inference_quantile))
+            == hps["prediction_length"]
+        )
+    inference_quantile = sorted(inference_quantiles)
+    previous_quantile_prediction = forecasts[item_id].quantile(
+        inference_quantile[0]
+    )
+    for inference_quantile in inference_quantiles[1:]:
+        assert all(
+            previous_quantile_prediction[i] <= pred
+            for (i, pred) in enumerate(
+                forecasts[item_id].quantile(inference_quantile)
+            )
+        ), f"quantile-crossing occurred"
+
+
+@pytest.mark.parametrize("is_iqf", [None, True, False])
+def test_is_iqf(is_iqf):
+    hps = {
+        "seed": 42,
+        "freq": "D",
+        "prediction_length": 3,
+        "quantiles": [0.5, 0.1],
+        "epochs": 3,
+        "num_batches_per_epoch": 3,
+        "is_iqf": is_iqf,
+    }
+
+    dataset_train, dataset_test = make_dummy_datasets_with_features(
+        cardinality=[3, 10],
+        num_feat_dynamic_real=2,
+        freq=hps["freq"],
+        prediction_length=hps["prediction_length"],
+    )
+
+    estimator = MQCNNEstimator.from_inputs(dataset_train, **hps)
+
+    predictor = estimator.train(dataset_train, num_workers=None)
+    forecasts = list(predictor.predict(dataset_test))
+    assert len(forecasts) == len(dataset_test)
+
+
+@pytest.mark.parametrize("is_iqf", [None, True, False])
+def test_repr(Estimator, repr_test, hyperparameters, is_iqf):
+    hyperparameters.update(is_iqf=is_iqf)
     repr_test(Estimator, hyperparameters)
 
 
-def test_serialize(Estimator, serialize_test, hyperparameters):
+@pytest.mark.parametrize("is_iqf", [None, True, False])
+def test_serialize(Estimator, serialize_test, hyperparameters, is_iqf):
+    hyperparameters.update(is_iqf=is_iqf)
     serialize_test(Estimator, hyperparameters)
 
 
-def test_backwards_compatibility():
+@pytest.mark.parametrize("use_feat_dynamic_real", [True, False])
+def test_backwards_compatibility(use_feat_dynamic_real):
     hps = {
         "freq": "D",
         "context_length": 5,
@@ -194,7 +255,7 @@ def test_backwards_compatibility():
         "quantiles": [0.5, 0.1],
         "epochs": 3,
         "num_batches_per_epoch": 3,
-        "use_feat_dynamic_real": True,
+        "use_feat_dynamic_real": use_feat_dynamic_real,
         "use_past_feat_dynamic_real": True,
         "enable_encoder_dynamic_feature": True,
         "enable_decoder_dynamic_feature": True,

--- a/test/model/seq2seq/test_model.py
+++ b/test/model/seq2seq/test_model.py
@@ -40,7 +40,6 @@ def Estimator(request):
     return request.param
 
 
-@pytest.mark.parametrize("quantiles", [[0.1, 0.5, 0.9], [0.5]])
 @pytest.mark.parametrize("hybridize", [True, False])
 @pytest.mark.parametrize(
     "quantiles, distr_output",
@@ -65,8 +64,8 @@ def test_accuracy(
     )
 
     accuracy_test(
-        Estimator, hyperparameters, accuracy=0.20
-    ) if quantiles else 0.70
+        Estimator, hyperparameters, accuracy=0.20 if quantiles else 0.70
+    )
 
 
 @pytest.mark.parametrize("use_past_feat_dynamic_real", [True, False])

--- a/test/model/seq2seq/test_quantile_loss.py
+++ b/test/model/seq2seq/test_quantile_loss.py
@@ -11,10 +11,15 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# Third-party imports
 from mxnet import nd
 import pytest
+import numpy as np
+from pandas import Timestamp
 
+# First-party imports
 from gluonts.mx.block.quantile_output import QuantileLoss
+from gluonts.model.forecast import QuantileForecast
 
 
 @pytest.mark.parametrize(
@@ -47,3 +52,111 @@ def test_compute_quantile_loss(quantile_weights, correct_qt_loss) -> None:
         assert (
             nd.mean(loss(y_true, y_pred)) - correct_qt_loss < tol
         ), f"computing weighted quantile loss fails!"
+
+
+@pytest.mark.parametrize(
+    "quantiles, true_quantile_weight",
+    [
+        ([], []),
+        ([0.5], [1]),
+        ([0.5, 0.9], [0.2, 0.2]),
+        ([0.1, 0.5, 0.9], [0.2, 0.4, 0.2]),
+        ([0.3, 0.5, 0.9], [0.1, 0.3, 0.2]),
+        (
+            [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
+            [0.05, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.05],
+        ),
+    ],
+)
+def test_compute_quantile_weights(quantiles, true_quantile_weight) -> None:
+    assert len(quantiles) == len(true_quantile_weight), (
+        f"length quantiles {quantiles} "
+        f"and quantile_weights {true_quantile_weight} "
+        f"do not match."
+    )
+    tol = 1e-5
+    quantile_weights = QuantileLoss(
+        quantiles, is_equal_weights=False
+    ).compute_quantile_weights()
+    assert (
+        sum(
+            abs(quantile_weights[i] - true_quantile_weight[i])
+            for i in range(len(quantiles))
+        )
+        < tol
+    ), f"inaccurate computation of quantile weights"
+
+
+@pytest.mark.parametrize(
+    "quantile_predictions, inference_quantiles, inferred_quantile_predictions",
+    [
+        (
+            {
+                "0.5": np.array([0.0, 0.0]),
+            },
+            [0.1, 0.5, 0.9],
+            {
+                "0.1": np.array([np.nan, np.nan]),
+                "0.5": np.array([0.0, 0.0]),
+                "0.9": np.array([np.nan, np.nan]),
+            },
+        ),
+        (
+            {
+                "0.1": np.array([-0.4, -0.8]),
+                "0.5": np.array([0.0, 0.0]),
+                "0.9": np.array([0.4, 0.8]),
+            },
+            [0.01, 0.1, 0.3, 0.5, 0.7, 0.9, 0.99],
+            {
+                "0.01": np.array([-0.97227044, -1.94454088]),
+                "0.1": np.array([-0.4, -0.8]),
+                "0.3": np.array([-0.2, -0.4]),
+                "0.5": np.array([0.0, 0.0]),
+                "0.7": np.array([0.2, 0.4]),
+                "0.9": np.array([0.4, 0.8]),
+                "0.99": np.array([0.97227044, 1.94454088]),
+            },
+        ),
+    ],
+)
+def test_infer_quantile_forecast(
+    quantile_predictions,
+    inference_quantiles,
+    inferred_quantile_predictions,
+):
+    tol = 1e-5
+    forecast_keys = []
+    output = []
+    for key, value in quantile_predictions.items():
+        forecast_keys.append(key)
+        output.append(value)
+    output = np.array(output)
+    quantile_forecast = QuantileForecast(
+        output,
+        start_date=Timestamp(0),
+        freq="h",
+        forecast_keys=forecast_keys,
+    )
+    if len(forecast_keys) == 1:
+        for q in inference_quantiles:
+            if forecast_keys[0] == str(q):
+                assert (
+                    sum(
+                        inferred_quantile_predictions[str(q)]
+                        - quantile_forecast.quantile(q)
+                    )
+                    < tol
+                ), f"infer_quantile_forecast failed for singleton quantile."
+
+    else:
+        assert (
+            sum(
+                sum(
+                    inferred_quantile_predictions[str(q)]
+                    - quantile_forecast.quantile(q)
+                )
+                for q in inference_quantiles
+            )
+            < tol
+        ), f"infer_quantile_forecast failed."


### PR DESCRIPTION
…w quantiles for MQ-CNN

*Issue #, if available:*
- Remove the quantile crossing issue associated with MQ-CNN

*Description of changes:*
- Use the Incremental Quantile Function (IQF) method to remove the quantile crossing associated with MQ-CNN
- Add linear interpolation between knots and exponential extrapolation at the tails to remove the retraining for MQ-CNN with new query quantiles.
-  Add `is_iqf` hyperparameters to MQ-CNN to toggle between the original QF and new IQF


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup