### PR TITLE
Fix scaling for pytorch negative binomial output

### DIFF
--- a/src/gluonts/torch/modules/distribution_output.py
+++ b/src/gluonts/torch/modules/distribution_output.py
@@ -281,6 +281,22 @@ class NegativeBinomialOutput(DistributionOutput):
         total_count, logits = distr_args
         return self.distr_cls(total_count=total_count, logits=logits)
 
+    # Overwrites the parent class method.
+    # We cannot scale using the affine transformation since negative binomial should return integers.
+    # Instead we scale the parameters.
+    def distribution(
+        self,
+        distr_args,
+        loc: Optional[torch.Tensor] = None,
+        scale: Optional[torch.Tensor] = None,
+    ) -> Distribution:
+        total_count, logits = distr_args
+
+        if scale is not None:
+            logits += scale.log()
+
+        return NegativeBinomial(total_count=total_count, logits=logits)
+
     @property
     def event_shape(self) -> Tuple:
         return ()


### PR DESCRIPTION
scale neg bin parameters as it should return integers.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup