### PR TITLE
Hierarchical: replace linalg_gemm2 by dot

### DIFF
--- a/src/gluonts/model/deepvar_hierarchical/_estimator.py
+++ b/src/gluonts/model/deepvar_hierarchical/_estimator.py
@@ -85,7 +85,7 @@ class DeepVARHierarchicalEstimator(DeepVAREstimator):
     prediction_length
         Length of the prediction horizon
     target_dim
-        Dimensionality of the input dataset
+        Dimensionality of the input dataset (i.e., the total number of time series in the hierarchical dataset).
     S
         Summation or aggregation matrix.
     num_samples_for_loss
@@ -112,10 +112,11 @@ class DeepVARHierarchicalEstimator(DeepVAREstimator):
         Specifies the epoch (as a fraction of total number of epochs) from when to start enforcing coherence during
         training.
     seq_axis
-        Specifies the list of axes that should be processed sequentially. This is useful if batch processing is not
-        possible because of insufficient memory. The reference axes are: (samples, batch, seq_length, target_dim).
-        For large datasets, use seq_axis = [0] or [0, 1].
-        By default, all are processeed in parallel.
+        Specifies the list of axes that should be processed sequentially (only during training).
+        The reference axes are: (num_samples_for_loss, batch, seq_length, target_dim).
+        This is useful if batch processing is not possible because of insufficient memory (e.g. if both
+        num_samples_for_loss and target_dim are very large). In such cases, use seq_axis = [1].
+        By default, all axes are processeed in parallel.
     assert_reconciliation
         Flag to indicate whether to assert if the (projected) samples generated during prediction are coherent.
     trainer

--- a/src/gluonts/model/deepvar_hierarchical/_network.py
+++ b/src/gluonts/model/deepvar_hierarchical/_network.py
@@ -93,21 +93,20 @@ class DeepVARHierarchicalNetwork(DeepVARNetwork):
 
         """
         if self.seq_axis:
-            # bring the axis to iterate in the beginning
+            # In this case, reconcile samples by going over each index in `seq_axis` iteratively.
+            # Note that `seq_axis` can be more than one dimension.
+            num_seq_axes = len(self.seq_axis)
+
+            # bring the axes to iterate in the beginning
             samples = mx.nd.moveaxis(
-                samples, self.seq_axis, list(range(len(self.seq_axis)))
+                samples, self.seq_axis, list(range(num_seq_axes))
             )
 
+            seq_axes_sizes = samples.shape[:num_seq_axes]
             out = [
                 mx.nd.dot(samples[idx], self.M, transpose_b=True)
-                for idx in product(
-                    *[
-                        range(x)
-                        for x in [
-                            samples.shape[d] for d in range(len(self.seq_axis))
-                        ]
-                    ]
-                )
+                # get the sequential index from the cross-product of their sizes.
+                for idx in product(*[range(size) for size in seq_axes_sizes])
             ]
 
             # put the axis in the correct order again


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In the hierarchical forecaster, use `dot` instead of `linalg_gemm2` for matrix-vector multiplication since for the latter one needs to expand and broadcast dimensions of the projection matrix (unnecessarily resulting in memory issues).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup