### PR TITLE
Hierarchical: Compute relative reconciliation error and add tests

### DIFF
--- a/src/gluonts/model/deepvar_hierarchical/__init__.py
+++ b/src/gluonts/model/deepvar_hierarchical/__init__.py
@@ -12,7 +12,17 @@
 # permissions and limitations under the License.
 
 # Relative imports
-from ._estimator import constraint_mat, DeepVARHierarchicalEstimator
-from ._network import reconciliation_error
+from ._estimator import (
+    constraint_mat,
+    null_space_projection_mat,
+    DeepVARHierarchicalEstimator,
+)
+from ._network import reconcile_samples, reconciliation_error
 
-__all__ = ["constraint_mat", "DeepVARHierarchicalEstimator", "reconciliation_error"]
+__all__ = [
+    "DeepVARHierarchicalEstimator",
+    "constraint_mat",
+    "null_space_projection_mat",
+    "reconcile_samples",
+    "reconciliation_error",
+]

--- a/src/gluonts/model/deepvar_hierarchical/__init__.py
+++ b/src/gluonts/model/deepvar_hierarchical/__init__.py
@@ -12,6 +12,7 @@
 # permissions and limitations under the License.
 
 # Relative imports
-from ._estimator import DeepVARHierarchicalEstimator
+from ._estimator import constraint_mat, DeepVARHierarchicalEstimator
+from ._network import reconciliation_error
 
-__all__ = ["DeepVARHierarchicalEstimator"]
+__all__ = ["constraint_mat", "DeepVARHierarchicalEstimator", "reconciliation_error"]

--- a/src/gluonts/model/deepvar_hierarchical/_estimator.py
+++ b/src/gluonts/model/deepvar_hierarchical/_estimator.py
@@ -12,7 +12,7 @@
 # permissions and limitations under the License.
 
 # Standard library imports
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 import numpy as np
 from mxnet.gluon import HybridBlock

--- a/src/gluonts/model/deepvar_hierarchical/_estimator.py
+++ b/src/gluonts/model/deepvar_hierarchical/_estimator.py
@@ -135,6 +135,8 @@ class DeepVARHierarchicalEstimator(DeepVAREstimator):
         By default, all axes are processeed in parallel.
     assert_reconciliation
         Flag to indicate whether to assert if the (projected) samples generated during prediction are coherent.
+    reconciliation_tol
+        Tolerance for the reconciliation error.
     trainer
         Trainer object to be used (default: Trainer())
     context_length
@@ -204,6 +206,7 @@ class DeepVARHierarchicalEstimator(DeepVAREstimator):
         lags_seq: Optional[List[int]] = None,
         time_features: Optional[List[TimeFeature]] = None,
         batch_size: int = 32,
+        reconciliation_tol: float = 1e-2,
         **kwargs,
     ) -> None:
 
@@ -258,6 +261,7 @@ class DeepVARHierarchicalEstimator(DeepVAREstimator):
         self.warmstart_epoch_frac = warmstart_epoch_frac
         self.sample_LH = sample_LH
         self.seq_axis = seq_axis
+        self.reconciliation_tol = reconciliation_tol
 
     def create_training_network(self) -> DeepVARHierarchicalTrainingNetwork:
         return DeepVARHierarchicalTrainingNetwork(
@@ -297,6 +301,7 @@ class DeepVARHierarchicalEstimator(DeepVAREstimator):
             A=self.A,
             assert_reconciliation=self.assert_reconciliation,
             coherent_pred_samples=self.coherent_pred_samples,
+            reconciliation_tol=self.reconciliation_tol,
             target_dim=self.target_dim,
             num_parallel_samples=self.num_parallel_samples,
             num_layers=self.num_layers,

--- a/src/gluonts/model/deepvar_hierarchical/_network.py
+++ b/src/gluonts/model/deepvar_hierarchical/_network.py
@@ -295,7 +295,7 @@ class DeepVARHierarchicalNetwork(DeepVARNetwork):
             if self.assert_reconciliation:
                 assert (
                     reconciliation_error(self.A, samples=coherent_samples)
-                    < 1e-2
+                    < self.reconciliation_tol
                 )
 
             return coherent_samples
@@ -355,8 +355,10 @@ class DeepVARHierarchicalPredictionNetwork(
         num_parallel_samples: int,
         assert_reconciliation: bool,
         coherent_pred_samples: bool,
+        reconciliation_tol: float,
         **kwargs,
     ) -> None:
         super().__init__(num_parallel_samples=num_parallel_samples, **kwargs)
         self.coherent_pred_samples = coherent_pred_samples
         self.assert_reconciliation = assert_reconciliation
+        self.reconciliation_tol = reconciliation_tol

--- a/test/model/deepvar_hierarchical/test_reconcile_samples.py
+++ b/test/model/deepvar_hierarchical/test_reconcile_samples.py
@@ -59,5 +59,5 @@ def test_reconciliation_error(samples):
         reconciliation_mat=mx.nd.array(reconciliation_mat),
         samples=mx.nd.array(samples),
     )
-    print(reconciliation_error(mx.nd.array(A), coherent_samples))
+
     assert reconciliation_error(mx.nd.array(A), coherent_samples) < TOL

--- a/test/model/deepvar_hierarchical/test_reconciliation_error.py
+++ b/test/model/deepvar_hierarchical/test_reconciliation_error.py
@@ -1,0 +1,56 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import mxnet as mx
+import numpy as np
+import pytest
+
+from gluonts.model.deepvar_hierarchical import (
+    constraint_mat,
+    reconciliation_error,
+)
+
+TOL = 1e-4
+
+S = np.array(
+    [
+        [1, 1, 1, 1],
+        [1, 1, 0, 0],
+        [0, 0, 1, 1],
+        [1, 0, 0, 0],
+        [0, 1, 0, 0],
+        [0, 0, 1, 0],
+        [0, 0, 0, 1],
+    ],
+)
+
+num_bottom_ts = S.shape[1]
+A = constraint_mat(S)
+
+
+@pytest.mark.parametrize(
+    "bottom_ts",
+    [
+        np.random.randint(low=0, high=100, size=num_bottom_ts),  # integer data
+        np.random.randint(low=1000, high=100000, size=num_bottom_ts),  # large integer data
+        np.random.poisson(lam=1, size=num_bottom_ts),
+        np.random.negative_binomial(n=1000, p=0.5, size=num_bottom_ts),
+        -np.random.negative_binomial(n=1000, p=0.5, size=num_bottom_ts),  # negative data
+        np.random.standard_normal(size=num_bottom_ts),
+    ]
+)
+def test_reconciliation_error(bottom_ts):
+    all_ts = S @ bottom_ts
+
+    assert reconciliation_error(mx.nd.array(A), mx.nd.array(all_ts)) < TOL
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

A couple of enhancements/refactoring on the reconciliation part:

* Compute the reconciliation error on relative scale. Move it out of the network as it is independent.
* Move `reconcile_samples` out of the network as we no longer need to cache big projection matrix.
* Tests for checking projection/reconciliation works correctly and the reconciliation error is computed as expected.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup