### PR TITLE
Convert batchify list to np array

### DIFF
--- a/src/gluonts/torch/batchify.py
+++ b/src/gluonts/torch/batchify.py
@@ -21,7 +21,7 @@ from gluonts.dataset.common import DataBatch
 
 def stack(data, device: Optional[torch.device] = None):
     if isinstance(data[0], np.ndarray):
-        data = torch.tensor(data, device=device)
+        data = torch.tensor(np.array(data), device=device)
     elif isinstance(data[0], (list, tuple)):
         return list(stack(t, device=device) for t in zip(*data))
     return data


### PR DESCRIPTION
Convert list of numpy array to a single ndarray before converting to torch.Tensor since creating a tensor from a list of numpy.ndarrays is extremely slow.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup