### PR TITLE
Use xdist (n=2) in tests.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,7 @@ jobs:
         pip install -r requirements/requirements-test.txt
         pip install -r requirements/requirements-rotbaum.txt
         pip install -r requirements/requirements-extras-m-competitions.txt
+        pip install pytest-xdist
     - name: Test with pytest
       run: |
-        pytest -m 'not (gpu or serial)' --cov src/gluonts --cov-report=term --cov-report xml --ignore test/nursery test
+        pytest -n2 -m 'not (gpu or serial)' --cov src/gluonts --cov-report=term --cov-report xml --ignore test/nursery test

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,7 +6,7 @@ markers =
     integration: mark an integration test
     skip_master: mark a test that is temporarily skipped for mxnet master validation.
 
-timeout = 30
+timeout = 60
 
 addopts =
     --ignore src/gluonts/block.py
@@ -16,4 +16,3 @@ addopts =
     --ignore src/gluonts/trainer.py
 
 doctest_optionflags = NORMALIZE_WHITESPACE
-


### PR DESCRIPTION
Github Action uses workers with 2 CPUs by default. Thus, parallelising tests should make the runs considerably faster.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup