### PR TITLE
Fixed data leakage bug in implementation of dynamic real and categorical features

### DIFF
--- a/src/gluonts/model/rotbaum/_preprocess.py
+++ b/src/gluonts/model/rotbaum/_preprocess.py
@@ -404,7 +404,17 @@ class PreprocessOnlyLagFeatures(PreprocessGeneric):
             feat_static_cat = []
 
         feat_dynamic_real = (
-            [elem for ent in time_series["feat_dynamic_real"] for elem in ent]
+            list(
+                chain(
+                    *[
+                        list(ent[0]) + list(ent[1].values())
+                        for ent in [
+                            self._pre_transform(ts[starting_index:end_index])
+                            for ts in time_series["feat_dynamic_real"]
+                        ]
+                    ]
+                )
+            )
             if self.use_feat_dynamic_real
             else []
         )

--- a/src/gluonts/model/rotbaum/_preprocess.py
+++ b/src/gluonts/model/rotbaum/_preprocess.py
@@ -419,7 +419,11 @@ class PreprocessOnlyLagFeatures(PreprocessGeneric):
             else []
         )
         feat_dynamic_cat = (
-            [elem for ent in time_series["feat_dynamic_cat"] for elem in ent]
+            [
+                elem
+                for ent in time_series["feat_dynamic_cat"]
+                for elem in ent[starting_index:end_index]
+            ]
             if self.use_feat_dynamic_cat
             else []
         )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The way that the dynamic real and categorical features had been implemented in this code had incorrect logic: it leaked data from the future by taking the entirety of those features (raw, without any adjustments) across all timesteps in each context window. This fixes this problem.

Looking at the rest of the code, I highly suspect that there are still unresolved issues with one hot encoding and whether the notion of cardinality integrates well in this code, but I did not resolve those issues due to time constraints. In particular, the current implementation requires 'feat_static_cat' to be a key in the dataset (even if empty), is this desired behavior?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup