### PR TITLE
added missing word in readme

### DIFF
--- a/src/gluonts/model/rotbaum/README_LSF.ipynb
+++ b/src/gluonts/model/rotbaum/README_LSF.ipynb
@@ -43,7 +43,7 @@
    "id": "aboriginal-arkansas",
    "metadata": {},
    "source": [
-    "It is possible to provide LSF the exact same dataset that `underlying_model` was trained on, but it is necessary. There is also no assumption that the dataset provided to LSF is the same size as the one provided to `underlying_model`.\n",
+    "It is possible to provide LSF the exact same dataset that `underlying_model` was trained on, but it is not necessary. There is also no assumption that the dataset provided to LSF is the same size as the one provided to `underlying_model`.\n",
     "\n",
     "The hyperparameter `min_bin_size` is by default `100`. While the NeurIPS paper ensures consistency, under certain conditions, with an increasing `min_bin_size` (of order of magnitude `(ln(n))^2`), in practice we have found that keeping this hyperparameter at `100` works in a surprisingly wide variety of datasets.\n",
     "\n",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* added the missing word "not" in the LSF readme.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup