### PR TITLE
changed metadata creation function

### DIFF
--- a/src/gluonts/dataset/repository/_util.py
+++ b/src/gluonts/dataset/repository/_util.py
@@ -59,11 +59,15 @@ def save_to_file(path: Path, data: List[Dict]):
 def metadata(
     cardinality: Union[int, List[int]], freq: str, prediction_length: int
 ):
+    if isinstance(cardinality) != list:
+        cardinality = [cardinality]
+
     return {
         "freq": freq,
         "prediction_length": prediction_length,
         "feat_static_cat": [
-            {"name": "feat_static_cat", "cardinality": str(cardinality)}
+            {"name": f"feat_static_cat_{i}", "cardinality": str(card)}
+            for i, card in enumerate(cardinality)
         ],
     }
 

--- a/src/gluonts/dataset/repository/_util.py
+++ b/src/gluonts/dataset/repository/_util.py
@@ -59,7 +59,7 @@ def save_to_file(path: Path, data: List[Dict]):
 def metadata(
     cardinality: Union[int, List[int]], freq: str, prediction_length: int
 ):
-    if isinstance(cardinality) != list:
+    if not isinstance(cardinality, list):
         cardinality = [cardinality]
 
     return {

--- a/test/dataset/repository/__init__.py
+++ b/test/dataset/repository/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.

--- a/test/dataset/repository/test_util.py
+++ b/test/dataset/repository/test_util.py
@@ -15,8 +15,9 @@ from gluonts.dataset.repository import _util
 
 
 def test_metadata_1():
-    inp = [[10, 3], "1H", 20]
-    exp = {
+    assert _util.metadata(
+        freq="1H", prediction_length=20, cardinality=[10, 3]
+    ) == {
         "freq": "1H",
         "prediction_length": 20,
         "feat_static_cat": [
@@ -24,16 +25,13 @@ def test_metadata_1():
             {"name": "feat_static_cat_1", "cardinality": "3"},
         ],
     }
-    assert _util.metadata(*inp) == exp
 
 
 def test_metadata_2():
-    inp = [10, "1H", 2]
-    exp = {
+    assert _util.metadata(freq="1H", prediction_length=2, cardinality=10) == {
         "freq": "1H",
         "prediction_length": 2,
         "feat_static_cat": [
-            {"name": "feat_static_cat_0", "cardinality": "10"},
+            {"name": "feat_static_cat_0", "cardinality": "10"}
         ],
     }
-    assert _util.metadata(*inp) == exp

--- a/test/dataset/repository/test_util.py
+++ b/test/dataset/repository/test_util.py
@@ -1,0 +1,39 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from gluonts.dataset.repository import _util
+
+
+def test_metadata_1():
+    inp = [[10, 3], "1H", 20]
+    exp = {
+        "freq": "1H",
+        "prediction_length": 20,
+        "feat_static_cat": [
+            {"name": "feat_static_cat_0", "cardinality": "10"},
+            {"name": "feat_static_cat_1", "cardinality": "3"},
+        ],
+    }
+    assert _util.metadata(*inp) == exp
+
+
+def test_metadata_2():
+    inp = [10, "1H", 2]
+    exp = {
+        "freq": "1H",
+        "prediction_length": 2,
+        "feat_static_cat": [
+            {"name": "feat_static_cat_0", "cardinality": "10"},
+        ],
+    }
+    assert _util.metadata(*inp) == exp


### PR DESCRIPTION
Change to `cardinality` output in the metadata.

According to Gluonts template `feat_static_cat`-entry of metadata.json is a list of `CategoricalFeatureInfo` ``[(feature_name, cardinality),...]``:

https://github.com/awslabs/gluon-ts/blob/d7679a5f239cbfd9e885dfdfe5312eb292353f73/src/gluonts/dataset/common.py#L74-L86

Currently this list only contains one element with cardinalies of all features as a list. This PR changes the structure of `feat_static_cat`-entry to contain information on each categorical feature separately (see example below).

Example: For two cat-features the change would output the metadata

```json
{
  "freq": "1M",
  "prediction_length": 18,
  "feat_static_cat": [
    {
      "name": "feat_static_cat_1",
      "cardinality": "1428"
    },
    {
      "name": "feat_static_cat_2",
      "cardinality": "6"
    }
  ]
}
```

instead of

```json
{
  "freq": "1M",
  "prediction_length": 18,
  "feat_static_cat": [
    {
      "name": "feat_static_cat",
      "cardinality": "[1428, 6]"
    }
  ]
}
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
