### PR TITLE
Extend default quantiles for MQ* Estimators to match MSIS quantiles.

### DIFF
--- a/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
+++ b/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
@@ -349,7 +349,7 @@ class MQRNNEstimator(ForkingSeq2SeqEstimator):
         self.quantiles = (
             quantiles
             if (quantiles is not None) or (distr_output is not None)
-            else [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+            else [0.025, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.975]
         )
         self.is_iqf = is_iqf
 

--- a/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
+++ b/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
@@ -95,7 +95,7 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
         The list of quantiles that will be optimized for, and predicted by, the model.
         Optimizing for more quantiles than are of direct interest to you can result
         in improved performance due to a regularizing effect.
-        (default: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
+        (default: [0.025, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.975])
     distr_output
         DistributionOutput to use. Only one between `quantile` and `distr_output`
         can be set. (Default: None)
@@ -183,7 +183,7 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
         self.quantiles = (
             quantiles
             if (quantiles is not None) or (distr_output is not None)
-            else [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+            else [0.025, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.975]
         )
         self.is_iqf = is_iqf
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup