### PR TITLE
[pytorch] allow train to resume from checkpoint

### DIFF
--- a/src/gluonts/torch/model/estimator.py
+++ b/src/gluonts/torch/model/estimator.py
@@ -109,6 +109,7 @@ class PyTorchLightningEstimator(Estimator):
         num_workers: int = 0,
         shuffle_buffer_length: Optional[int] = None,
         cache_data: bool = False,
+        ckpt_path: Optional[str] = None,
         **kwargs,
     ) -> TrainOutput:
         transformation = self.create_transformation()
@@ -156,6 +157,7 @@ class PyTorchLightningEstimator(Estimator):
             model=training_network,
             train_dataloaders=training_data_loader,
             val_dataloaders=validation_data_loader,
+            ckpt_path=ckpt_path,
         )
 
         logger.info(f"Loading best model from {checkpoint.best_model_path}")
@@ -181,6 +183,7 @@ class PyTorchLightningEstimator(Estimator):
         num_workers: int = 0,
         shuffle_buffer_length: Optional[int] = None,
         cache_data: bool = False,
+        ckpt_path: Optional[str] = None,
         **kwargs,
     ) -> PyTorchPredictor:
         return self.train_model(
@@ -189,5 +192,6 @@ class PyTorchLightningEstimator(Estimator):
             num_workers=num_workers,
             shuffle_buffer_length=shuffle_buffer_length,
             cache_data=cache_data,
+            ckpt_path=ckpt_path,
             **kwargs,
         ).predictor

--- a/src/gluonts/torch/model/estimator.py
+++ b/src/gluonts/torch/model/estimator.py
@@ -141,6 +141,7 @@ class PyTorchLightningEstimator(Estimator):
                 if not cache_data
                 else Cached(transformed_validation_data),
                 training_network,
+                num_workers=num_workers,
             )
 
         monitor = "train_loss" if validation_data is None else "val_loss"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Allows the fit method to resume from a checkpointed file and allow validation dataloader to use multiple workers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup