### PR TITLE
Fix negative binomial sampling

### DIFF
--- a/src/gluonts/mx/distribution/neg_binomial.py
+++ b/src/gluonts/mx/distribution/neg_binomial.py
@@ -87,13 +87,9 @@ class NegativeBinomial(Distribution):
     ) -> Tensor:
         def s(mu: Tensor, alpha: Tensor) -> Tensor:
             F = self.F
-            tol = 1e-5
             r = 1.0 / alpha
             theta = alpha * mu
-            r = F.minimum(F.maximum(tol, r), 1e10)
-            theta = F.minimum(F.maximum(tol, theta), 1e10)
-            x = F.minimum(F.random.gamma(r, theta), 1e6)
-            return F.random.poisson(lam=x, dtype=dtype)
+            return F.random.poisson(lam=F.random.gamma(r, theta), dtype=dtype)
 
         return _sample_multiple(
             s, mu=self.mu, alpha=self.alpha, num_samples=num_samples


### PR DESCRIPTION
*Issue #, if available:* Fixes #1881

*Description of changes:* The `sample` method of `NegativeBinomial` contained some arbitrary parameter clipping that distorts the distribution in extreme cases. This PR removes it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup