### PR TITLE
Fix mypy checks

### DIFF
--- a/.devtools/githooks/pre-commit
+++ b/.devtools/githooks/pre-commit
@@ -9,7 +9,11 @@ from subprocess import CalledProcessError, check_output
 
 
 def type_check() -> int:
-    mypy_opts = ['--follow-imports=silent', '--ignore-missing-imports']
+    mypy_opts = [
+        '--allow-redefinition',
+        '--follow-imports=silent',
+        '--ignore-missing-imports'
+    ]
     mypy_args = [
         str(p.parent.resolve())
         for p in Path(__file__).parents[2].glob('**/.typesafe')

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ class TypeCheckCommand(distutils.cmd.Command):
             "--ignore-missing-imports",
         ]
 
-        folders = [str(p.parent.resolve()) for p in SRC.glob("**/.typesafe")]
+        folders = [str(p.parent.resolve()) for p in ROOT.glob("**/.typesafe")]
 
         print(
             "The following folders contain a `.typesafe` marker file "

--- a/test/dataset/artificial/test_recipe.py
+++ b/test/dataset/artificial/test_recipe.py
@@ -11,6 +11,8 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+from typing import Any, Dict
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -80,7 +82,7 @@ BASE_RECIPE = [("foo", ConstantVec(1.0)), ("cat", RandomCat([10]))]
     ],
 )
 def test_call_and_repr(func) -> None:
-    global_state = {}
+    global_state: Dict[Any, Any] = {}
     x = evaluate(BASE_RECIPE, length=10, global_state=global_state)
     kwargs = dict(foo=42, bar=23)
     np.random.seed(0)
@@ -150,6 +152,7 @@ def test_recipe_dataset(recipe) -> None:
 
     generated = data.generate()
     generated_train = list(generated.train)
+    assert generated.test is not None
     generated_test = list(generated.test)
     train_lengths = np.array([len(x["target"]) for x in generated_train])
     test_lengths = np.array([len(x["target"]) for x in generated_test])


### PR DESCRIPTION
*Description of changes:* The type checking setup diverted a bit between `setup.py` and the local `precommit` hook. The former was only looking in `src`, while the latter missed some option. This PR aligns them and fixes a couple of typing issues in the `test` folder.

(Arguably the best fix here would be to have `precommit` hook just invoke `setup.py`)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup