### PR TITLE
Change negative binomial parametrization to failure count and log-odds

### DIFF
--- a/test/mx/distribution/test_distribution_methods.py
+++ b/test/mx/distribution/test_distribution_methods.py
@@ -76,7 +76,7 @@ test_cases = [
     ),
     (
         NegativeBinomial,
-        {"mu": mx.nd.array([1000.0, 1.0]), "alpha": mx.nd.array([1.0, 2.0])},
+        {"count": mx.nd.array([1.0, 0.5]), "logit": mx.nd.array([6.9077554, 0.6931472])},
     ),
     (
         Uniform,

--- a/test/mx/distribution/test_distribution_sampling.py
+++ b/test/mx/distribution/test_distribution_sampling.py
@@ -71,7 +71,7 @@ test_cases = [
     ),
     (
         NegativeBinomial,
-        {"mu": mx.nd.array([1000.0, 1.0]), "alpha": mx.nd.array([1.0, 2.0])},
+        {"count": mx.nd.array([1.0, 0.5]), "logit": mx.nd.array([6.9077554, 0.6931472])},
     ),
     (
         Uniform,

--- a/test/mx/distribution/test_distribution_shapes.py
+++ b/test/mx/distribution/test_distribution_shapes.py
@@ -101,8 +101,8 @@ from gluonts.mx.util import make_nd_diag
         ),
         (
             NegativeBinomial(
-                mu=mx.nd.zeros(shape=(3, 4, 5)),
-                alpha=mx.nd.ones(shape=(3, 4, 5)),
+                count=mx.nd.ones(shape=(3, 4, 5)),
+                logit=mx.nd.zeros(shape=(3, 4, 5)),
             ),
             (3, 4, 5),
             (),

--- a/test/mx/distribution/test_distribution_slice.py
+++ b/test/mx/distribution/test_distribution_slice.py
@@ -123,8 +123,8 @@ DISTRIBUTIONS_WITH_QUANTILE_FUNCTION = (Gaussian, Uniform, Laplace, Binned)
             mu=mx.nd.zeros(shape=BATCH_SHAPE), b=mx.nd.ones(shape=BATCH_SHAPE)
         ),
         NegativeBinomial(
-            mu=mx.nd.zeros(shape=BATCH_SHAPE),
-            alpha=mx.nd.ones(shape=BATCH_SHAPE),
+            count=mx.nd.ones(shape=BATCH_SHAPE),
+            logit=mx.nd.zeros(shape=BATCH_SHAPE),
         ),
         Poisson(rate=mx.nd.ones(shape=BATCH_SHAPE)),
         Uniform(

--- a/test/mx/distribution/test_issue_287.py
+++ b/test/mx/distribution/test_issue_287.py
@@ -15,15 +15,11 @@ import mxnet as mx
 import numpy as np
 import pytest
 
-from gluonts.mx.distribution import DistributionOutput
 from gluonts.mx.distribution.beta import BetaOutput
 from gluonts.mx.distribution.gamma import GammaOutput
-from gluonts.mx.distribution.neg_binomial import NegativeBinomialOutput
-
-test_cases = [NegativeBinomialOutput, GammaOutput, BetaOutput]
 
 
-@pytest.mark.parametrize("distr_out_class", test_cases)
+@pytest.mark.parametrize("distr_out_class", [GammaOutput, BetaOutput])
 def test_issue_287(distr_out_class):
     network_output = mx.nd.ones(shape=(10,))
     distr_output = distr_out_class()


### PR DESCRIPTION
*Issue #, if available:* Should fix #833 and #1796 

*Description of changes:* Changing the negative binomial parametrization from "mean and dispersion" to "number of failures and log-odds". Adapting tests. Examples of the improvement to-be-posted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup