### PR TITLE
Fix negative binomial parameter map

### DIFF
--- a/src/gluonts/mx/distribution/neg_binomial.py
+++ b/src/gluonts/mx/distribution/neg_binomial.py
@@ -107,9 +107,8 @@ class NegativeBinomialOutput(DistributionOutput):
     @classmethod
     def domain_map(cls, F, mu, alpha):
         epsilon = np.finfo(cls._dtype).eps  # machine epsilon
-
-        mu = softplus(F, mu) + epsilon
-        alpha = softplus(F, alpha) + epsilon
+        mu = F.maximum(softplus(F, mu), epsilon)
+        alpha = F.maximum(softplus(F, alpha), epsilon)
         return mu.squeeze(axis=-1), alpha.squeeze(axis=-1)
 
     # Overwrites the parent class method.


### PR DESCRIPTION
*Issue #, if available:* May fix #833 and #1796

*Description of changes:* This replaces #1890, with a much simpler fix that appears to solve the NaN issue when training DeepAR with a `NegativeBinomialOutput`, at least in the [example](https://github.com/awslabs/gluon-ts/issues/1796#issuecomment-1041392110) I described in #1796.

The issue appears to be with our `softplus`, which may return very small negative values.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup