### PR TITLE
Add file path argument to m5 dataset generation

### DIFF
--- a/src/gluonts/dataset/repository/_m5.py
+++ b/src/gluonts/dataset/repository/_m5.py
@@ -23,16 +23,19 @@ from gluonts.dataset.repository._util import metadata, save_to_file
 
 
 def generate_m5_dataset(
-    dataset_path: Path, pandas_freq: str, prediction_length: int
+    dataset_path: Path,
+    pandas_freq: str,
+    prediction_length: int,
+    m5_file_path: Path,
 ):
-    cal_path = f"{dataset_path}/calendar.csv"
-    sales_path = f"{dataset_path}/sales_train_validation.csv"
+    cal_path = f"{m5_file_path}/calendar.csv"
+    sales_path = f"{m5_file_path}/sales_train_validation.csv"
 
     if not os.path.exists(cal_path) or not os.path.exists(sales_path):
         raise RuntimeError(
             f"M5 data is available on Kaggle (https://www.kaggle.com/c/m5-forecasting-accuracy/data). "
             f"You first need to agree to the terms of the competition before being able to download the data. "
-            f"After you have done that, please supply the files at {dataset_path}."
+            f"After you have done that, please supply the files at {m5_file_path}."
         )
 
     # Read M5 data from dataset_path

--- a/src/gluonts/dataset/repository/_m5.py
+++ b/src/gluonts/dataset/repository/_m5.py
@@ -38,6 +38,9 @@ def generate_m5_dataset(
             f"After you have done that, please supply the files at {m5_file_path}."
         )
 
+    # Prepare directory
+    dataset_path.mkdir(exist_ok=True)
+
     # Read M5 data from dataset_path
     calendar = pd.read_csv(cal_path)
     sales_train_validation = pd.read_csv(sales_path)

--- a/src/gluonts/dataset/repository/datasets.py
+++ b/src/gluonts/dataset/repository/datasets.py
@@ -204,7 +204,10 @@ dataset_recipes = OrderedDict(
             prediction_length=6,
         ),
         "m5": partial(
-            generate_m5_dataset, pandas_freq="D", prediction_length=28
+            generate_m5_dataset,
+            pandas_freq="D",
+            prediction_length=28,
+            m5_file_path=get_download_path() / "m5",
         ),
     }
 )


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Currently, the M5 dataset cannot be generated. On `materialize_dataset`, the `<default_dir>/m5` is deleted when `regenerate` is set to `True`, but it has to contain the `.csv` files obtained from Kaggle. When not setting `regenerate=True`, the dataset is never generated because the `.csv` files are located in `<default_dir>/m5`.

This PR adds another parameter to the dataset recipe such that the M5 data can be sourced from another directory (which makes more sense anyway, imo).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup