### PR TITLE
Fix: use broadcast_lesser in place of comparisons in ISQF

### DIFF
--- a/src/gluonts/mx/distribution/isqf.py
+++ b/src/gluonts/mx/distribution/isqf.py
@@ -384,7 +384,9 @@ class ISQF(Distribution):
         return quantile
 
     def quantile_spline(
-        self, alpha: Tensor, axis: Optional[int] = None,
+        self,
+        alpha: Tensor,
+        axis: Optional[int] = None,
     ) -> Tensor:
         r"""
         Evaluates the spline functions at the
@@ -618,8 +620,8 @@ class ISQF(Distribution):
                 self.qk_x_l,
                 self.qk_y_l,
             )
-            term1 = (z - tail_b) * (qk_x ** 2 - 2 * qk_x + 2 * alpha_tilde)
-            term2 = qk_x ** 2 * tail_a * (-F.log(qk_x) + 0.5)
+            term1 = (z - tail_b) * (qk_x**2 - 2 * qk_x + 2 * alpha_tilde)
+            term2 = qk_x**2 * tail_a * (-F.log(qk_x) + 0.5)
             term2 = term2 + 2 * F.where(
                 z < qk_y,
                 qk_x * tail_a * (F.log(qk_x) - 1)
@@ -633,10 +635,10 @@ class ISQF(Distribution):
                 self.qk_x_r,
                 self.qk_y_r,
             )
-            term1 = (z - tail_b) * (-1 - qk_x ** 2 + 2 * alpha_tilde)
+            term1 = (z - tail_b) * (-1 - qk_x**2 + 2 * alpha_tilde)
             term2 = tail_a * (
                 -0.5 * (qk_x + 1) ** 2
-                + (qk_x ** 2 - 1) * F.log(1 - qk_x)
+                + (qk_x**2 - 1) * F.log(1 - qk_x)
                 + 2 * alpha_tilde
             )
             term2 = term2 + 2 * F.where(
@@ -678,23 +680,23 @@ class ISQF(Distribution):
         )
 
         coeff1 = (
-            -2 / 3 * sk_x_plus ** 3
-            + sk_x * sk_x_plus ** 2
-            + sk_x_plus ** 2
-            - (1 / 3) * sk_x ** 3
+            -2 / 3 * sk_x_plus**3
+            + sk_x * sk_x_plus**2
+            + sk_x_plus**2
+            - (1 / 3) * sk_x**3
             - 2 * sk_x * sk_x_plus
-            - r ** 2
+            - r**2
             + 2 * sk_x * r
         )
 
         coeff2 = F.broadcast_add(
             -2 * F.broadcast_maximum(alpha_tilde_expand, sk_x_plus)
-            + sk_x_plus ** 2,
-            2 * qk_x_plus_expand - qk_x_plus_expand ** 2,
+            + sk_x_plus**2,
+            2 * qk_x_plus_expand - qk_x_plus_expand**2,
         )
 
         result = (
-            (qk_x_plus ** 2 - qk_x ** 2) * F.broadcast_sub(z_expand, qk_y)
+            (qk_x_plus**2 - qk_x**2) * F.broadcast_sub(z_expand, qk_y)
             + 2
             * F.broadcast_sub(qk_x_plus, alpha_tilde)
             * F.broadcast_sub(qk_y, z_expand)
@@ -869,7 +871,10 @@ class ISQFOutput(DistributionOutput):
 
     @classmethod
     def domain_map(
-        cls, F, *args: Tensor, tol: float = 1e-4,
+        cls,
+        F,
+        *args: Tensor,
+        tol: float = 1e-4,
     ) -> Tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
         """
         Domain map function

--- a/src/gluonts/mx/distribution/isqf.py
+++ b/src/gluonts/mx/distribution/isqf.py
@@ -384,9 +384,7 @@ class ISQF(Distribution):
         return quantile
 
     def quantile_spline(
-        self,
-        alpha: Tensor,
-        axis: Optional[int] = None,
+        self, alpha: Tensor, axis: Optional[int] = None,
     ) -> Tensor:
         r"""
         Evaluates the spline functions at the
@@ -478,8 +476,9 @@ class ISQF(Distribution):
             alpha = 1 - alpha
 
         if axis is not None:
-            tail_a, tail_b = F.expand_dims(tail_a, axis=axis), F.expand_dims(
-                tail_b, axis=axis
+            tail_a, tail_b = (
+                F.expand_dims(tail_a, axis=axis),
+                F.expand_dims(tail_b, axis=axis),
             )
 
         return F.broadcast_add(F.broadcast_mul(tail_a, F.log(alpha)), tail_b)
@@ -619,8 +618,8 @@ class ISQF(Distribution):
                 self.qk_x_l,
                 self.qk_y_l,
             )
-            term1 = (z - tail_b) * (qk_x**2 - 2 * qk_x + 2 * alpha_tilde)
-            term2 = qk_x**2 * tail_a * (-F.log(qk_x) + 0.5)
+            term1 = (z - tail_b) * (qk_x ** 2 - 2 * qk_x + 2 * alpha_tilde)
+            term2 = qk_x ** 2 * tail_a * (-F.log(qk_x) + 0.5)
             term2 = term2 + 2 * F.where(
                 z < qk_y,
                 qk_x * tail_a * (F.log(qk_x) - 1)
@@ -634,10 +633,10 @@ class ISQF(Distribution):
                 self.qk_x_r,
                 self.qk_y_r,
             )
-            term1 = (z - tail_b) * (-1 - qk_x**2 + 2 * alpha_tilde)
+            term1 = (z - tail_b) * (-1 - qk_x ** 2 + 2 * alpha_tilde)
             term2 = tail_a * (
                 -0.5 * (qk_x + 1) ** 2
-                + (qk_x**2 - 1) * F.log(1 - qk_x)
+                + (qk_x ** 2 - 1) * F.log(1 - qk_x)
                 + 2 * alpha_tilde
             )
             term2 = term2 + 2 * F.where(
@@ -666,8 +665,9 @@ class ISQF(Distribution):
         sk_x, sk_x_plus = self.sk_x, self.sk_x_plus
         delta_sk_x, delta_sk_y = self.delta_sk_x, self.delta_sk_y
 
-        z_expand, qk_x_plus_expand = F.expand_dims(z, axis=-1), F.expand_dims(
-            qk_x_plus, axis=-1
+        z_expand, qk_x_plus_expand = (
+            F.expand_dims(z, axis=-1),
+            F.expand_dims(qk_x_plus, axis=-1),
         )
 
         alpha_tilde = self.cdf_spline(z)
@@ -678,23 +678,23 @@ class ISQF(Distribution):
         )
 
         coeff1 = (
-            -2 / 3 * sk_x_plus**3
-            + sk_x * sk_x_plus**2
-            + sk_x_plus**2
-            - (1 / 3) * sk_x**3
+            -2 / 3 * sk_x_plus ** 3
+            + sk_x * sk_x_plus ** 2
+            + sk_x_plus ** 2
+            - (1 / 3) * sk_x ** 3
             - 2 * sk_x * sk_x_plus
-            - r**2
+            - r ** 2
             + 2 * sk_x * r
         )
 
         coeff2 = F.broadcast_add(
             -2 * F.broadcast_maximum(alpha_tilde_expand, sk_x_plus)
-            + sk_x_plus**2,
-            2 * qk_x_plus_expand - qk_x_plus_expand**2,
+            + sk_x_plus ** 2,
+            2 * qk_x_plus_expand - qk_x_plus_expand ** 2,
         )
 
         result = (
-            (qk_x_plus**2 - qk_x**2) * F.broadcast_sub(z_expand, qk_y)
+            (qk_x_plus ** 2 - qk_x ** 2) * F.broadcast_sub(z_expand, qk_y)
             + 2
             * F.broadcast_sub(qk_x_plus, alpha_tilde)
             * F.broadcast_sub(qk_y, z_expand)
@@ -869,10 +869,7 @@ class ISQFOutput(DistributionOutput):
 
     @classmethod
     def domain_map(
-        cls,
-        F,
-        *args: Tensor,
-        tol: float = 1e-4,
+        cls, F, *args: Tensor, tol: float = 1e-4,
     ) -> Tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
         """
         Domain map function

--- a/src/gluonts/mx/distribution/isqf.py
+++ b/src/gluonts/mx/distribution/isqf.py
@@ -346,7 +346,7 @@ class ISQF(Distribution):
             qk_x_plus = F.expand_dims(qk_x_plus, axis=axis)
 
         quantile = F.where(
-            alpha < qk_x_l,
+            alpha < F.broadcast_like(qk_x_l, alpha),
             self.quantile_tail(alpha, axis=axis, left_tail=True),
             self.quantile_tail(alpha, axis=axis, left_tail=False),
         )
@@ -356,14 +356,19 @@ class ISQF(Distribution):
         for spline_idx in range(self.num_qk - 1):
 
             is_in_between = F.broadcast_logical_and(
-                F.slice_axis(
-                    qk_x, axis=-1, begin=spline_idx, end=spline_idx + 1
-                ).squeeze(-1)
-                <= alpha,
+                F.broadcast_like(
+                    F.slice_axis(
+                        qk_x, axis=-1, begin=spline_idx, end=spline_idx + 1
+                    ).squeeze(-1),
+                    alpha
+                ) <= alpha,
                 alpha
-                < F.slice_axis(
-                    qk_x_plus, axis=-1, begin=spline_idx, end=spline_idx + 1
-                ).squeeze(-1),
+                < F.broadcast_like(
+                    F.slice_axis(
+                        qk_x_plus, axis=-1, begin=spline_idx, end=spline_idx + 1
+                    ).squeeze(-1),
+                    alpha
+                )
             )
 
             quantile = F.where(

--- a/src/gluonts/mx/distribution/isqf.py
+++ b/src/gluonts/mx/distribution/isqf.py
@@ -346,7 +346,7 @@ class ISQF(Distribution):
             qk_x_plus = F.expand_dims(qk_x_plus, axis=axis)
 
         quantile = F.where(
-            alpha < F.broadcast_like(qk_x_l, alpha),
+            F.broadcast_lesser(alpha, qk_x_l),
             self.quantile_tail(alpha, axis=axis, left_tail=True),
             self.quantile_tail(alpha, axis=axis, left_tail=False),
         )
@@ -356,19 +356,21 @@ class ISQF(Distribution):
         for spline_idx in range(self.num_qk - 1):
 
             is_in_between = F.broadcast_logical_and(
-                F.broadcast_like(
+                F.broadcast_lesser_equal(
                     F.slice_axis(
                         qk_x, axis=-1, begin=spline_idx, end=spline_idx + 1
                     ).squeeze(-1),
-                    alpha
-                ) <= alpha,
-                alpha
-                < F.broadcast_like(
+                    alpha,
+                ),
+                F.broadcast_lesser(
+                    alpha,
                     F.slice_axis(
-                        qk_x_plus, axis=-1, begin=spline_idx, end=spline_idx + 1
+                        qk_x_plus,
+                        axis=-1,
+                        begin=spline_idx,
+                        end=spline_idx + 1,
                     ).squeeze(-1),
-                    alpha
-                )
+                ),
             )
 
             quantile = F.where(


### PR DESCRIPTION
*Issue #, if available:*

When running in hybridized form, I'm running into shape inference errors where those comparisons are done.

*Description of changes:*

I added explicit `broadcast_like` in those comparisons to resolve this issue.

* There are other comparisons that may need fixing.
* This might be better fixed upstream as part of mxnet.