### PR TITLE
Add multiprocessing to validation data loader

### DIFF
--- a/src/gluonts/dataset/loader.py
+++ b/src/gluonts/dataset/loader.py
@@ -77,7 +77,7 @@ def worker_fn(
 DataLoader = Iterable[DataBatch]
 
 
-class MultiProcessIterable(DataLoader):
+class MultiProcessLoader(DataLoader):
     def __init__(
         self,
         dataset: Dataset,
@@ -208,12 +208,13 @@ def TrainDataLoader(
     transformed_dataset = transform.apply(dataset, is_train=True)
 
     if num_workers is not None:
-        return iter(MultiProcessIterable(
+        loader = MultiProcessLoader(
             transformed_dataset,
             decode_fn=decode_fn,
             num_workers=num_workers,
             max_queue_size=num_prefetch,
-        ))
+        )
+        batches = iter(loader)
     else:
         batches = iter(transformed_dataset)
 
@@ -269,7 +270,7 @@ def ValidationDataLoader(
     if num_workers is None:
         return transformed_dataset
 
-    return MultiProcessIterable(
+    return MultiProcessLoader(
         transformed_dataset,
         decode_fn=decode_fn,
         num_workers=num_workers,

--- a/src/gluonts/dataset/loader.py
+++ b/src/gluonts/dataset/loader.py
@@ -117,17 +117,14 @@ class MultiProcessIterator(DataLoader):
 
     def __next__(self):
         while self.num_finished < self.num_workers:
-            data = self._get()
+            # TODO make timeout configurable
+            raw = self.result_queue.get(timeout=120)
+            data = pickle.loads(raw)
             if data is None:
                 self.num_finished += 1
                 continue
-            return data
+            return self.decode_fn(data)
         raise StopIteration
-
-    def _get(self):
-        # TODO make timeout configurable
-        raw = self.result_queue.get(timeout=120)
-        return self.decode_fn(pickle.loads(raw))
 
 
 @dataclass

--- a/src/gluonts/dataset/loader.py
+++ b/src/gluonts/dataset/loader.py
@@ -16,7 +16,6 @@ import logging
 import multiprocessing as mp
 import pickle
 import sys
-from functools import partial
 from multiprocessing.reduction import ForkingPickler
 from typing import Callable, Iterable, Optional
 

--- a/src/gluonts/dataset/loader.py
+++ b/src/gluonts/dataset/loader.py
@@ -108,7 +108,7 @@ class MultiProcessLoader(DataLoader):
                     "num_workers": num_workers,
                     "input_queue": input_queue,
                     "output_queue": self.output_queue,
-                }
+                },
             )
             for worker_id, input_queue in enumerate(self.input_queues)
         ]

--- a/src/gluonts/dataset/loader.py
+++ b/src/gluonts/dataset/loader.py
@@ -95,8 +95,9 @@ class MultiProcessLoader(DataLoader):
 
         self.decode_fn = decode_fn
         self.queue_timeout_seconds = queue_timeout_seconds
-        self.output_queue = mp.Manager().Queue(maxsize=max_queue_size)
-        self.input_queues = [mp.Manager().Queue() for _ in range(num_workers)]
+        self.manager = mp.Manager()
+        self.output_queue = self.manager.Queue(maxsize=max_queue_size)
+        self.input_queues = [self.manager.Queue() for _ in range(num_workers)]
         self.num_workers = num_workers
 
         self.processes = [

--- a/src/gluonts/dataset/loader.py
+++ b/src/gluonts/dataset/loader.py
@@ -69,7 +69,7 @@ def worker_fn(
         try:
             result_queue.put(raw)
         except (EOFError, BrokenPipeError):
-            break
+            return
 
     result_queue.put(_encode(None))
 

--- a/src/gluonts/model/seq2seq/_forking_estimator.py
+++ b/src/gluonts/model/seq2seq/_forking_estimator.py
@@ -476,6 +476,8 @@ class ForkingSeq2SeqEstimator(GluonEstimator):
             transform=instance_splitter + SelectFields(input_names),
             batch_size=self.batch_size,
             stack_fn=partial(batchify, ctx=self.trainer.ctx, dtype=self.dtype),
+            decode_fn=partial(as_in_context, ctx=self.trainer.ctx),
+            **kwargs,
         )
 
     def create_training_network(self) -> ForkingSeq2SeqNetworkBase:

--- a/src/gluonts/mx/model/estimator.py
+++ b/src/gluonts/mx/model/estimator.py
@@ -195,6 +195,8 @@ class GluonEstimator(Estimator):
                 transformed_validation_data
                 if not cache_data
                 else Cached(transformed_validation_data),
+                num_workers=num_workers,
+                num_prefetch=num_prefetch,
             )
 
         training_network = self.create_training_network()

--- a/test/dataset/test_data_loader.py
+++ b/test/dataset/test_data_loader.py
@@ -163,28 +163,30 @@ def test_training_data_loader(dataset_context, num_workers):
         default_file_dataset,
     ],
 )
-def test_validation_data_loader(dataset_context):
+@pytest.mark.parametrize(
+    "num_workers",
+    [None, 1, 2, 5],
+)
+def test_validation_data_loader(dataset_context, num_workers):
     with dataset_context() as dataset:
         dl = ValidationDataLoader(
             dataset=dataset,
             transform=default_transformation(),
             batch_size=4,
             stack_fn=batchify,
+            num_workers=num_workers,
         )
 
-        batches = list(dl)
+        for _ in range(3):
+            batches = list(dl)
 
-        for batch in batches:
-            assert all(batch["is_train"])
+            for batch in batches:
+                assert all(batch["is_train"])
 
-        counter = count_item_ids(batches)
+            counter = count_item_ids(batches)
 
-        for entry in dataset:
-            assert counter[entry[FieldName.ITEM_ID]] == 1
-
-        batches_again = list(dl)
-
-        assert (b1 == b2 for b1, b2 in zip(batches, batches_again))
+            for entry in dataset:
+                assert counter[entry[FieldName.ITEM_ID]] == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Addresses #1928 

Fixes multiprocessing iterator so that it can be iterated over multiple times. This requires a little more synchronization between workers and main process, but it’s pretty simple.

To do:
- [x] Propagate multiprocessing options appropriately in the estimator types
- [x] Run experiment to confirm the speedup


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup