### PR TITLE
Fix dummy estimator

### DIFF
--- a/src/gluonts/model/estimator.py
+++ b/src/gluonts/model/estimator.py
@@ -98,6 +98,6 @@ class DummyEstimator(Estimator):
     def train(
         self,
         training_data: Dataset,
-        validation_dataset: Optional[Dataset] = None,
+        validation_data: Optional[Dataset] = None,
     ) -> Predictor:
         return self.predictor

--- a/test/model/npts/test_model.py
+++ b/test/model/npts/test_model.py
@@ -29,3 +29,15 @@ def test_repr(repr_test):
 
 def test_serialize(serialize_test):
     serialize_test(NPTSEstimator, hyperparameters)
+
+
+def test_train_with_validation_data(dsinfo):
+    estimator = NPTSEstimator.from_hyperparameters(
+        freq=dsinfo.freq,
+        prediction_length=dsinfo.prediction_length,
+        **hyperparameters,
+    )
+    predictor = estimator.train(
+        training_data=dsinfo.train_ds,
+        validation_data=dsinfo.train_ds,
+    )

--- a/test/model/npts/test_model.py
+++ b/test/model/npts/test_model.py
@@ -29,15 +29,3 @@ def test_repr(repr_test):
 
 def test_serialize(serialize_test):
     serialize_test(NPTSEstimator, hyperparameters)
-
-
-def test_train_with_validation_data(dsinfo):
-    estimator = NPTSEstimator.from_hyperparameters(
-        freq=dsinfo.freq,
-        prediction_length=dsinfo.prediction_length,
-        **hyperparameters,
-    )
-    predictor = estimator.train(
-        training_data=dsinfo.train_ds,
-        validation_data=dsinfo.train_ds,
-    )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

It appears the `DummyEstimator.train` still expected `validation_dataset` which conflicts with `Estimator` and broke inheriting dummy classes if `validation_data` was passed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup