### PR TITLE
Fixed autograd inplace operations error in Transformed Distribution

### DIFF
--- a/src/gluonts/mx/distribution/transformed_distribution.py
+++ b/src/gluonts/mx/distribution/transformed_distribution.py
@@ -155,7 +155,7 @@ class TransformedDistribution(Distribution):
         for t in self.transforms[::-1]:
             x = t.f_inv(y)
             ladj = t.log_abs_det_jac(x, y)
-            lp -= sum_trailing_axes(F, ladj, self.event_dim - t.event_dim)
+            lp = lp - sum_trailing_axes(F, ladj, self.event_dim - t.event_dim)
             y = x
 
         return self.base_distribution.log_prob(x) + lp


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
While using `TransformedDistribution` with series of `AffineTransformation` bijection, I get the following `Autograd` error.

`MXNetError: Check failed: AGInfo: :IsNone(*output): Inplace operations (+=, -=, x[:]=, etc) are not supported when recording with autograd.` 
at
`File "/Users/kapooshu/miniconda3/envs/tsf-uds/lib/python3.7/site packages/gluonts/mx/distribution/transformed_distribution.py", line 158, in log_prob
    lp -= sum_trailing_axes(F, ladj, self.event_dim - t.event_dim)`

In this PR, I removed this Inplace operation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup