### PR TITLE
Breaking: Split incremental quantile output into separate class

### DIFF
--- a/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
+++ b/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
@@ -240,14 +240,12 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
             prefix="decoder_",
         )
 
-        if self.quantiles:
-            quantile_output = (
-                IncrementalQuantileOutput(self.quantiles)
-                if is_iqf
-                else QuantileOutput(self.quantiles)
-            )
-        else:
+        if not self.quantiles:
             quantile_output = None
+        elif is_iqf:
+            quantile_output = IncrementalQuantileOutput(self.quantiles)
+        else:
+            quantile_output = QuantileOutput(self.quantiles)
 
         super().__init__(
             encoder=encoder,
@@ -401,14 +399,12 @@ class MQRNNEstimator(ForkingSeq2SeqEstimator):
             prefix="decoder_",
         )
 
-        if self.quantiles:
-            quantile_output = (
-                IncrementalQuantileOutput(self.quantiles)
-                if is_iqf
-                else QuantileOutput(self.quantiles)
-            )
-        else:
+        if not self.quantiles:
             quantile_output = None
+        elif is_iqf:
+            quantile_output = IncrementalQuantileOutput(self.quantiles)
+        else:
+            quantile_output = QuantileOutput(self.quantiles)
 
         super().__init__(
             encoder=encoder,

--- a/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
+++ b/src/gluonts/model/seq2seq/_mq_dnn_estimator.py
@@ -26,7 +26,10 @@ from gluonts.mx.block.encoder import (
     HierarchicalCausalConv1DEncoder,
     RNNEncoder,
 )
-from gluonts.mx.block.quantile_output import QuantileOutput
+from gluonts.mx.block.quantile_output import (
+    QuantileOutput,
+    IncrementalQuantileOutput,
+)
 from gluonts.mx.distribution import DistributionOutput
 from gluonts.mx.trainer import Trainer
 
@@ -237,11 +240,14 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
             prefix="decoder_",
         )
 
-        quantile_output = (
-            QuantileOutput(self.quantiles, is_iqf=self.is_iqf)
-            if self.quantiles
-            else None
-        )
+        if self.quantiles:
+            quantile_output = (
+                IncrementalQuantileOutput(self.quantiles)
+                if is_iqf
+                else QuantileOutput(self.quantiles)
+            )
+        else:
+            quantile_output = None
 
         super().__init__(
             encoder=encoder,
@@ -395,11 +401,14 @@ class MQRNNEstimator(ForkingSeq2SeqEstimator):
             prefix="decoder_",
         )
 
-        quantile_output = (
-            QuantileOutput(self.quantiles, is_iqf=self.is_iqf)
-            if self.quantiles
-            else None
-        )
+        if self.quantiles:
+            quantile_output = (
+                IncrementalQuantileOutput(self.quantiles)
+                if is_iqf
+                else QuantileOutput(self.quantiles)
+            )
+        else:
+            quantile_output = None
 
         super().__init__(
             encoder=encoder,

--- a/src/gluonts/mx/block/quantile_output.py
+++ b/src/gluonts/mx/block/quantile_output.py
@@ -33,15 +33,15 @@ def crps_weights_pwl(quantile_levels: List[float]) -> List[float]:
 
     Under the assumption of linear interpolation
 
-        CRPS = sum_{i=0}^{n-1} 0.5 * (q_{i+1} - q_{i}) * (z_{i+1} + z_{i})
+    .. math:: CRPS = sum_{i=0}^{n-1} 0.5 * (q_{i+1} - q_{i}) * (z_{i+1} + z_{i})
 
-    where ``z_i`` is the i-th quantile prediction ``q_i``.
+    where :math:`z_i` is the i-th quantile prediction :math:`q_i`.
     The inner terms cancel due to the telescoping sum property and we obtain
 
-        CRPS = sum_{i=1}^n w_i z_i
+    .. math:: CRPS = sum_{i=1}^n w_i z_i
 
-    with the weights ``w_i = (q_{i+1}-q_{i-1})/2`` for ``i = 1, ..., n-1``,
-    ``w_0 = (q_1-q_0)/2`` and ``w_n = (w_n - w_{n-1})/2``.
+    with the weights :math:`w_i = (q_{i+1}-q_{i-1})/2` for :math:`i = 1, ..., n-1`,
+    :math:`w_0 = (q_1-q_0)/2` and :math:`w_n = (w_n - w_{n-1})/2`.
     """
     num_quantiles = len(quantile_levels)
 

--- a/src/gluonts/mx/block/quantile_output.py
+++ b/src/gluonts/mx/block/quantile_output.py
@@ -39,7 +39,10 @@ def crps_weights_pwl(quantile_levels: List[float]) -> List[float]:
     w_0 = (q_1-q_0)/2 and w_n = (w_n - w_{n-1})/2.
     """
     num_quantiles = len(quantile_levels)
-    assert num_quantiles > 0
+    assert num_quantiles >= 0
+
+    if num_quantiles < 2:
+        return [1.0] * num_quantiles
 
     return (
         [0.5 * (quantile_levels[1] - quantile_levels[0])]

--- a/src/gluonts/mx/block/quantile_output.py
+++ b/src/gluonts/mx/block/quantile_output.py
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 from mxnet.gluon import nn
 from mxnet.gluon.loss import Loss

--- a/src/gluonts/mx/block/quantile_output.py
+++ b/src/gluonts/mx/block/quantile_output.py
@@ -41,23 +41,14 @@ def crps_weights_pwl(quantile_levels: List[float]) -> List[float]:
     num_quantiles = len(quantile_levels)
     assert num_quantiles > 0
 
-    sorted_indices, sorted_quantiles = zip(
-        *sorted(enumerate(quantile_levels), key=lambda p: p[1])
-    )
-    sorted_weights = (
-        [0.5 * (sorted_quantiles[1] - sorted_quantiles[0])]
+    return (
+        [0.5 * (quantile_levels[1] - quantile_levels[0])]
         + [
-            0.5 * (sorted_quantiles[i + 1] - sorted_quantiles[i - 1])
+            0.5 * (quantile_levels[i + 1] - quantile_levels[i - 1])
             for i in range(1, num_quantiles - 1)
         ]
-        + [0.5 * (sorted_quantiles[-1] - sorted_quantiles[-2])]
+        + [0.5 * (quantile_levels[-1] - quantile_levels[-2])]
     )
-
-    weights = sorted_weights.copy()
-    for sidx, idx in enumerate(sorted_indices):
-        weights[idx] = sorted_weights[sidx]
-
-    return weights
 
 
 class QuantileLoss(Loss):

--- a/src/gluonts/mx/block/quantile_output.py
+++ b/src/gluonts/mx/block/quantile_output.py
@@ -77,13 +77,10 @@ class QuantileLoss(Loss):
         ----------
         quantiles
             list of quantiles to compute loss over.
-
         quantile_weights
             weights of the quantiles.
-
         weight
             weighting of the loss.
-
         batch_axis
             indicates axis that represents the batch.
         """

--- a/src/gluonts/mx/block/quantile_output.py
+++ b/src/gluonts/mx/block/quantile_output.py
@@ -20,7 +20,7 @@ from gluonts.core.component import validated
 from gluonts.mx import Tensor
 
 
-def uniform_weights(x):
+def uniform_weights(x: list) -> List[float]:
     return [1.0 / len(x) for _ in x]
 
 
@@ -93,7 +93,10 @@ class QuantileLoss(Loss):
 
         self.quantiles = quantiles
         self.num_quantiles = len(quantiles)
-        self.quantile_weights = quantile_weights
+        self.quantile_weights = (
+            quantile_weights if quantile_weights is not None
+            else uniform_weights(quantiles)
+        )
 
     # noinspection PyMethodOverriding
     def hybrid_forward(

--- a/src/gluonts/mx/block/quantile_output.py
+++ b/src/gluonts/mx/block/quantile_output.py
@@ -20,26 +20,30 @@ from gluonts.core.component import validated
 from gluonts.mx import Tensor
 
 
-def uniform_weights(x: list) -> List[float]:
-    return [1.0 / len(x)] * len(x)
+def uniform_weights(quantile_levels: List[float]) -> List[float]:
+    return [1.0 / len(quantile_levels)] * len(quantile_levels)
 
 
 def crps_weights_pwl(quantile_levels: List[float]) -> List[float]:
     """
-    Computes the quantile loss weights corresponding to CRPS under linear
+    Compute the quantile loss weights corresponding to CRPS under linear
     interpolation assumption.
 
     Quantile levels are assumed to be sorted in increasing order.
 
-    CRPS = sum_{i=0}^{n-1} 0.5 * (q_{i+1} - q_{i}) * (z_{i+1} + z_{i})
-    under the assumption of linear interpolation, where z_i is the
-    ith quantile prediction q_i. The inner terms cancel due to the
-    telescoping sum property and we obtain CRPS = sum_{i=1}^n w_i z_i, with
-    the weights w_i = (q_{i+1}-q_{i-1})/2 for i = 1, ..., n-1,
-    w_0 = (q_1-q_0)/2 and w_n = (w_n - w_{n-1})/2.
+    Under the assumption of linear interpolation
+
+        CRPS = sum_{i=0}^{n-1} 0.5 * (q_{i+1} - q_{i}) * (z_{i+1} + z_{i})
+
+    where ``z_i`` is the i-th quantile prediction ``q_i``.
+    The inner terms cancel due to the telescoping sum property and we obtain
+
+        CRPS = sum_{i=1}^n w_i z_i
+
+    with the weights ``w_i = (q_{i+1}-q_{i-1})/2`` for ``i = 1, ..., n-1``,
+    ``w_0 = (q_1-q_0)/2`` and ``w_n = (w_n - w_{n-1})/2``.
     """
     num_quantiles = len(quantile_levels)
-    assert num_quantiles >= 0
 
     if num_quantiles < 2:
         return [1.0] * num_quantiles

--- a/src/gluonts/mx/block/quantile_output.py
+++ b/src/gluonts/mx/block/quantile_output.py
@@ -21,7 +21,7 @@ from gluonts.mx import Tensor
 
 
 def uniform_weights(x: list) -> List[float]:
-    return [1.0 / len(x) for _ in x]
+    return [1.0 / len(x)] * len(x)
 
 
 def crps_weights_pwl(quantile_levels: List[float]) -> List[float]:

--- a/src/gluonts/mx/block/quantile_output.py
+++ b/src/gluonts/mx/block/quantile_output.py
@@ -94,7 +94,8 @@ class QuantileLoss(Loss):
         self.quantiles = quantiles
         self.num_quantiles = len(quantiles)
         self.quantile_weights = (
-            quantile_weights if quantile_weights is not None
+            quantile_weights
+            if quantile_weights is not None
             else uniform_weights(quantiles)
         )
 

--- a/src/gluonts/mx/block/quantile_output.py
+++ b/src/gluonts/mx/block/quantile_output.py
@@ -20,28 +20,45 @@ from gluonts.core.component import validated
 from gluonts.mx import Tensor
 
 
-def uniform_weights(quantile_levels: List[float]) -> List[float]:
-    return [1.0 / len(quantile_levels)] * len(quantile_levels)
+def uniform_weights(objects: list) -> List[float]:
+    """
+    Return uniform weights for a list of objects.
+
+    >>> uniform_weights(["a", "b", "c", "d"])
+    [0.25, 0.25, 0.25, 0.25]
+
+    Parameters
+    ----------
+    objects
+        Objects that need to be weighted.
+
+    Returns
+    -------
+    List[float]
+        List of weights.
+    """
+    return [1.0 / len(objects)] * len(objects)
 
 
 def crps_weights_pwl(quantile_levels: List[float]) -> List[float]:
     """
-    Compute the quantile loss weights corresponding to CRPS under linear
-    interpolation assumption.
+    Compute the quantile loss weights making mean quantile loss equal to CRPS
+    under linear interpolation assumption.
 
     Quantile levels are assumed to be sorted in increasing order.
 
     Under the assumption of linear interpolation
 
-    .. math:: CRPS = sum_{i=0}^{n-1} 0.5 * (q_{i+1} - q_{i}) * (z_{i+1} + z_{i})
+    .. math:: CRPS = sum_{i=0}^{n-1} 0.5 * (q_{i+1}-q_{i}) * (z_{i+1}+z_{i})
 
     where :math:`z_i` is the i-th quantile prediction :math:`q_i`.
     The inner terms cancel due to the telescoping sum property and we obtain
 
     .. math:: CRPS = sum_{i=1}^n w_i z_i
 
-    with the weights :math:`w_i = (q_{i+1}-q_{i-1})/2` for :math:`i = 1, ..., n-1`,
-    :math:`w_0 = (q_1-q_0)/2` and :math:`w_n = (w_n - w_{n-1})/2`.
+    with the weights :math:`w_i = (q_{i+1}-q_{i-1})/2` for
+    :math:`i = 1, ..., n-1`, :math:`w_0 = (q_1-q_0)/2` and
+    :math:`w_n = (w_n - w_{n-1})/2`.
     """
     num_quantiles = len(quantile_levels)
 
@@ -69,7 +86,7 @@ class QuantileLoss(Loss):
         **kwargs,
     ) -> None:
         """
-        Represents the quantile loss used to fit decoders that learn quantiles.
+        Represent the quantile loss used to fit decoders that learn quantiles.
 
         Parameters
         ----------

--- a/src/gluonts/mx/block/quantile_output.py
+++ b/src/gluonts/mx/block/quantile_output.py
@@ -41,7 +41,9 @@ def crps_weights_pwl(quantile_levels: List[float]) -> List[float]:
     num_quantiles = len(quantile_levels)
     assert num_quantiles > 0
 
-    sorted_indices, sorted_quantiles = zip(*sorted(enumerate(quantile_levels), key=lambda p: p[1]))
+    sorted_indices, sorted_quantiles = zip(
+        *sorted(enumerate(quantile_levels), key=lambda p: p[1])
+    )
     sorted_weights = (
         [0.5 * (sorted_quantiles[1] - sorted_quantiles[0])]
         + [
@@ -125,8 +127,12 @@ class QuantileLoss(Loss):
             y_pred_all = [F.squeeze(y_pred, axis=-1)]
 
         qt_loss = []
-        for level, weight, y_pred_q in zip(self.quantiles, self.quantile_weights, y_pred_all):
-            qt_loss.append(weight * self.compute_quantile_loss(F, y_true, y_pred_q, level))
+        for level, weight, y_pred_q in zip(
+            self.quantiles, self.quantile_weights, y_pred_all
+        ):
+            qt_loss.append(
+                weight * self.compute_quantile_loss(F, y_true, y_pred_q, level)
+            )
         stacked_qt_losses = F.stack(*qt_loss, axis=-1)
         sum_qt_loss = F.mean(
             stacked_qt_losses, axis=-1
@@ -206,9 +212,10 @@ class QuantileOutput:
         return QuantileLoss(
             quantiles=self.quantiles,
             quantile_weights=(
-                self.quantile_weights if self.quantile_weights is not None
+                self.quantile_weights
+                if self.quantile_weights is not None
                 else uniform_weights(self.quantiles)
-            )
+            ),
         )
 
     def get_quantile_proj(self, **kwargs) -> nn.HybridBlock:
@@ -290,9 +297,10 @@ class IncrementalQuantileOutput(QuantileOutput):
         return QuantileLoss(
             quantiles=self.quantiles,
             quantile_weights=(
-                self.quantile_weights if self.quantile_weights is not None
+                self.quantile_weights
+                if self.quantile_weights is not None
                 else crps_weights_pwl(self.quantiles)
-            )
+            ),
         )
 
     def get_quantile_proj(self, **kwargs) -> nn.HybridBlock:

--- a/test/model/seq2seq/test_quantile_loss.py
+++ b/test/model/seq2seq/test_quantile_loss.py
@@ -18,7 +18,7 @@ import numpy as np
 from pandas import Timestamp
 
 # First-party imports
-from gluonts.mx.block.quantile_output import QuantileLoss
+from gluonts.mx.block.quantile_output import QuantileLoss, crps_weights_pwl
 from gluonts.model.forecast import QuantileForecast
 
 
@@ -68,16 +68,14 @@ def test_compute_quantile_loss(quantile_weights, correct_qt_loss) -> None:
         ),
     ],
 )
-def test_compute_quantile_weights(quantiles, true_quantile_weight) -> None:
+def test_crps_pwl_quantile_weights(quantiles, true_quantile_weight) -> None:
     assert len(quantiles) == len(true_quantile_weight), (
         f"length quantiles {quantiles} "
         f"and quantile_weights {true_quantile_weight} "
         f"do not match."
     )
     tol = 1e-5
-    quantile_weights = QuantileLoss(
-        quantiles, is_equal_weights=False
-    ).compute_quantile_weights()
+    quantile_weights = crps_weights_pwl(quantiles)
     assert (
         sum(
             abs(quantile_weights[i] - true_quantile_weight[i])

--- a/test/mx/block/test_quantile_loss.py
+++ b/test/mx/block/test_quantile_loss.py
@@ -1,0 +1,73 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import mxnet as mx
+import numpy as np
+import pytest
+
+from gluonts.mx.block.quantile_output import (
+    crps_weights_pwl,
+    uniform_weights,
+    QuantileLoss,
+)
+
+
+@pytest.mark.parametrize(
+    "levels, weights_fun, actuals, predictions, expected_loss_values",
+    [
+        (
+            [0.1, 0.5, 0.7, 0.95],
+            uniform_weights,
+            [10.0, 20.0, 30.0],
+            [
+                [11.0, 12.0, 13.0, 14.0],
+                [19.0, 19.5, 21.0, 22.0],
+                [27.0, 28.0, 29.0, 29.5],
+            ],
+            [0.375, 0.09375, 0.309375],
+        ),
+        (
+            [0.1, 0.5, 0.7, 0.95],
+            crps_weights_pwl,
+            [10.0, 20.0, 30.0],
+            [
+                [11.0, 12.0, 13.0, 14.0],
+                [19.0, 19.5, 21.0, 22.0],
+                [27.0, 28.0, 29.0, 29.5],
+            ],
+            [0.35375002, 0.08750001, 0.28843752],
+        ),
+    ],
+)
+def test_quantile_loss(
+    levels: list,
+    actuals: list,
+    predictions: list,
+    expected_loss_values: list,
+    weights_fun,
+):
+    loss_function = QuantileLoss(levels, quantile_weights=weights_fun(levels))
+    loss_values = loss_function(
+        mx.nd.array(actuals), mx.nd.array(predictions)
+    ).asnumpy()
+    assert np.allclose(expected_loss_values, loss_values)
+
+    # reverse quantile-level-axis and test again
+    levels_rev = levels[::-1]
+    loss_function_rev = QuantileLoss(
+        levels_rev, quantile_weights=weights_fun(levels_rev)
+    )
+    loss_values_rev = loss_function_rev(
+        mx.nd.array(actuals), mx.nd.array([p[::-1] for p in predictions])
+    ).asnumpy()
+    assert np.allclose(expected_loss_values, loss_values_rev)

--- a/test/mx/block/test_quantile_loss.py
+++ b/test/mx/block/test_quantile_loss.py
@@ -61,13 +61,3 @@ def test_quantile_loss(
         mx.nd.array(actuals), mx.nd.array(predictions)
     ).asnumpy()
     assert np.allclose(expected_loss_values, loss_values)
-
-    # reverse quantile-level-axis and test again
-    levels_rev = levels[::-1]
-    loss_function_rev = QuantileLoss(
-        levels_rev, quantile_weights=weights_fun(levels_rev)
-    )
-    loss_values_rev = loss_function_rev(
-        mx.nd.array(actuals), mx.nd.array([p[::-1] for p in predictions])
-    ).asnumpy()
-    assert np.allclose(expected_loss_values, loss_values_rev)


### PR DESCRIPTION
*Issue #, if available:* Fixes #1944

*Description of changes:* #1693 modified the behavior of `QuantileOutput` causing #1944. This PR recovers the former behavior, and splits the "incremental quantiles" case into a separate `IncrementalQuantileOutput` class (instead of having the `is_iqf` option). Surrounding changes to related classes are also there (projection layers used, MQ-DNN models).

This is a bit of a sensible change, so I'd like to add tests. Opening nevertheless to get early feedback @dcmaddix @youngsuk0723 

I also think that `IncrementalQuantileOutput` should avoid sorting the quantile levels, or at least allow the projection layer to sort them back, which would make the interface clearer: if I construct the class with quantile levels `[0.9, 0.1]`, maybe I expect the projection layer to output the 90% and 10% percentile in this order (principle of least surprise); but maybe we can address this separately, or in this PR after proper discussion. ***Edit:** sorting back the quantile values appears to be non-trivial with mxnet*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup