### PR TITLE
Fix: Hard threshold positive distribution parameters

### DIFF
--- a/src/gluonts/mx/distribution/beta.py
+++ b/src/gluonts/mx/distribution/beta.py
@@ -137,10 +137,8 @@ class BetaOutput(DistributionOutput):
             Two squeezed tensors, of shape `(*batch_shape)`: both have entries
             mapped to the positive orthant.
         """
-        epsilon = np.finfo(cls._dtype).eps  # machine epsilon
-
-        alpha = softplus(F, alpha) + epsilon
-        beta = softplus(F, beta) + epsilon
+        alpha = F.maximum(softplus(F, alpha), cls.eps())
+        beta = F.maximum(softplus(F, beta), cls.eps())
         return alpha.squeeze(axis=-1), beta.squeeze(axis=-1)
 
     @property

--- a/src/gluonts/mx/distribution/distribution_output.py
+++ b/src/gluonts/mx/distribution/distribution_output.py
@@ -84,6 +84,10 @@ class Output:
     def dtype(self):
         return self._dtype
 
+    @classmethod
+    def eps(cls):
+        return np.finfo(cls.dtype).eps
+
     @dtype.setter
     def dtype(self, dtype: Type):
         self._dtype = dtype

--- a/src/gluonts/mx/distribution/distribution_output.py
+++ b/src/gluonts/mx/distribution/distribution_output.py
@@ -84,13 +84,13 @@ class Output:
     def dtype(self):
         return self._dtype
 
-    @classmethod
-    def eps(cls):
-        return np.finfo(cls._dtype).eps
-
     @dtype.setter
     def dtype(self, dtype: Type):
         self._dtype = dtype
+
+    @classmethod
+    def eps(cls):
+        return np.finfo(cls._dtype).eps
 
     def get_args_proj(self, prefix: Optional[str] = None) -> gluon.HybridBlock:
         return ArgProj(

--- a/src/gluonts/mx/distribution/distribution_output.py
+++ b/src/gluonts/mx/distribution/distribution_output.py
@@ -86,7 +86,7 @@ class Output:
 
     @classmethod
     def eps(cls):
-        return np.finfo(cls.dtype).eps
+        return np.finfo(cls._dtype).eps
 
     @dtype.setter
     def dtype(self, dtype: Type):

--- a/src/gluonts/mx/distribution/gamma.py
+++ b/src/gluonts/mx/distribution/gamma.py
@@ -143,10 +143,8 @@ class GammaOutput(DistributionOutput):
             Two squeezed tensors, of shape `(*batch_shape)`: both have entries
             mapped to the positive orthant.
         """
-        epsilon = np.finfo(cls._dtype).eps  # machine epsilon
-
-        alpha = softplus(F, alpha) + epsilon
-        beta = softplus(F, beta) + epsilon
+        alpha = F.maximum(softplus(F, alpha), cls.eps())
+        beta = F.maximum(softplus(F, beta), cls.eps())
         return alpha.squeeze(axis=-1), beta.squeeze(axis=-1)
 
     @property

--- a/src/gluonts/mx/distribution/gaussian.py
+++ b/src/gluonts/mx/distribution/gaussian.py
@@ -152,7 +152,7 @@ class GaussianOutput(DistributionOutput):
             same entries as `mu` and the second has entries mapped to the
             positive orthant.
         """
-        sigma = softplus(F, sigma)
+        sigma = F.maximum(softplus(F, sigma), cls.eps())
         return mu.squeeze(axis=-1), sigma.squeeze(axis=-1)
 
     @property

--- a/src/gluonts/mx/distribution/genpareto.py
+++ b/src/gluonts/mx/distribution/genpareto.py
@@ -192,9 +192,8 @@ class GenParetoOutput(DistributionOutput):
             Two squeezed tensors, of shape `(*batch_shape)`: both have entries
             mapped to the positive orthant.
         """
-        epsilon = np.finfo(cls._dtype).eps
-        xi = softplus(F, xi) + epsilon
-        beta = softplus(F, beta) + epsilon
+        xi = F.maximum(softplus(F, xi), cls.eps())
+        beta = F.maximum(softplus(F, beta), cls.eps())
         return xi.squeeze(axis=-1), beta.squeeze(axis=-1)
 
     @property

--- a/src/gluonts/mx/distribution/inflated_beta.py
+++ b/src/gluonts/mx/distribution/inflated_beta.py
@@ -193,10 +193,8 @@ class ZeroAndOneInflatedBetaOutput(DistributionOutput):
             entries mapped to the positive orthant, zero_probability is mapped
             to (0, 1), one_probability is mapped to (0, 1-zero_probability)
         """
-        epsilon = np.finfo(cls._dtype).eps  # machine epsilon
-
-        alpha = softplus(F, alpha) + epsilon
-        beta = softplus(F, beta) + epsilon
+        alpha = F.maximum(softplus(F, alpha), cls.eps())
+        beta = F.maximum(softplus(F, beta), cls.eps())
         zero_probability = F.sigmoid(zero_probability)
         one_probability = (1 - zero_probability) * F.sigmoid(one_probability)
         return (
@@ -241,10 +239,8 @@ class ZeroInflatedBetaOutput(ZeroAndOneInflatedBetaOutput):
             Three squeezed tensors, of shape `(*batch_shape)`: First two have
             entries mapped to the positive orthant, last is mapped to (0,1)
         """
-        epsilon = np.finfo(cls._dtype).eps  # machine epsilon
-
-        alpha = softplus(F, alpha) + epsilon
-        beta = softplus(F, beta) + epsilon
+        alpha = F.maximum(softplus(F, alpha), cls.eps())
+        beta = F.maximum(softplus(F, beta), cls.eps())
         zero_probability = F.sigmoid(zero_probability)
         return (
             alpha.squeeze(axis=-1),

--- a/src/gluonts/mx/distribution/inflated_beta.py
+++ b/src/gluonts/mx/distribution/inflated_beta.py
@@ -13,8 +13,6 @@
 
 from typing import Dict, Tuple
 
-import numpy as np
-
 from gluonts.core.component import validated
 from gluonts.mx import Tensor
 

--- a/src/gluonts/mx/distribution/laplace.py
+++ b/src/gluonts/mx/distribution/laplace.py
@@ -112,7 +112,7 @@ class LaplaceOutput(DistributionOutput):
 
     @classmethod
     def domain_map(cls, F, mu, b):
-        b = softplus(F, b)
+        b = F.maximum(softplus(F, b), cls.eps())
         return mu.squeeze(axis=-1), b.squeeze(axis=-1)
 
     @property

--- a/src/gluonts/mx/distribution/logit_normal.py
+++ b/src/gluonts/mx/distribution/logit_normal.py
@@ -108,7 +108,7 @@ class LogitNormalOutput(DistributionOutput):
 
     @classmethod
     def domain_map(cls, F, mu, sigma):
-        sigma = softplus(F, sigma)
+        sigma = F.maximum(softplus(F, sigma), cls.eps())
         return mu.squeeze(axis=-1), sigma.squeeze(axis=-1)
 
     @property

--- a/src/gluonts/mx/distribution/neg_binomial.py
+++ b/src/gluonts/mx/distribution/neg_binomial.py
@@ -107,9 +107,8 @@ class NegativeBinomialOutput(DistributionOutput):
 
     @classmethod
     def domain_map(cls, F, mu, alpha):
-        epsilon = np.finfo(cls._dtype).eps  # machine epsilon
-        mu = F.maximum(softplus(F, mu), epsilon)
-        alpha = F.maximum(softplus(F, alpha), epsilon)
+        mu = F.maximum(softplus(F, mu), cls.eps())
+        alpha = F.maximum(softplus(F, alpha), cls.eps())
         return mu.squeeze(axis=-1), alpha.squeeze(axis=-1)
 
     # Overwrites the parent class method. We cannot scale using the affine

--- a/src/gluonts/mx/distribution/poisson.py
+++ b/src/gluonts/mx/distribution/poisson.py
@@ -90,7 +90,7 @@ class PoissonOutput(DistributionOutput):
 
     @classmethod
     def domain_map(cls, F, rate):
-        rate = softplus(F, rate) + 1e-8
+        rate = F.maximum(softplus(F, rate), cls.eps())
         return rate.squeeze(axis=-1)
 
     # Overwrites the parent class method. We cannot scale using the affine

--- a/src/gluonts/mx/distribution/student_t.py
+++ b/src/gluonts/mx/distribution/student_t.py
@@ -128,8 +128,8 @@ class StudentTOutput(DistributionOutput):
 
     @classmethod
     def domain_map(cls, F, mu, sigma, nu):
-        sigma = softplus(F, sigma)
-        nu = 2.0 + softplus(F, nu)
+        sigma = F.maximum(softplus(F, sigma), cls.eps())
+        nu = 2.0 + F.maximum(softplus(F, nu), cls.eps())
         return mu.squeeze(axis=-1), sigma.squeeze(axis=-1), nu.squeeze(axis=-1)
 
     @property


### PR DESCRIPTION
*Description of changes:* The output of `softplus` can easily be zero or negative on CPU (see also #1894), so enforcing positive outputs by adding a small constant is fragile and can potentially give nans in the loss computation (when log or reciprocal is taken). In the case of student-t for example, no safety margin was even added (see code). This fix ensures that distribution parameters which are required to be positive are in fact positive (>= machine epsilon, for the floating point type being used).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup