### PR TITLE
Breaking: reorg torch package, shorten import paths

### DIFF
--- a/docs/tutorials/forecasting/howto_pytorch_lightning.md
+++ b/docs/tutorials/forecasting/howto_pytorch_lightning.md
@@ -56,7 +56,7 @@ import torch.nn as nn
 
 ```python
 from gluonts.torch.model.predictor import PyTorchPredictor
-from gluonts.torch.distribution.distribution_output import StudentTOutput
+from gluonts.torch.distributions import StudentTOutput
 from gluonts.model.forecast_generator import DistributionForecastGenerator
 ```
 

--- a/docs/tutorials/forecasting/howto_pytorch_lightning.md
+++ b/docs/tutorials/forecasting/howto_pytorch_lightning.md
@@ -56,7 +56,7 @@ import torch.nn as nn
 
 ```python
 from gluonts.torch.model.predictor import PyTorchPredictor
-from gluonts.torch.modules.distribution_output import StudentTOutput
+from gluonts.torch.distribution.distribution_output import StudentTOutput
 from gluonts.model.forecast_generator import DistributionForecastGenerator
 ```
 

--- a/examples/example_binned_pareto.py
+++ b/examples/example_binned_pareto.py
@@ -7,7 +7,7 @@ from gluonts.dataset.repository.datasets import get_dataset
 from gluonts.evaluation import Evaluator
 
 from gluonts.torch.model.deepar import DeepAREstimator
-from gluonts.torch.distributions.spliced_binned_pareto import (
+from gluonts.torch.distributions import (
     SplicedBinnedPareto,
     SplicedBinnedParetoOutput,
 )

--- a/src/gluonts/torch/distributions/__init__.py
+++ b/src/gluonts/torch/distributions/__init__.py
@@ -11,24 +11,43 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from .isqf import ISQF, ISQFOutput
-from .piecewise_linear import PiecewiseLinear, PiecewiseLinearOutput
-from .generalized_pareto import GeneralizedPareto, GeneralizedParetoOutput
 from .binned_uniforms import BinnedUniforms, BinnedUniformsOutput
+from .distribution_output import (
+    BetaOutput,
+    DistributionOutput,
+    GammaOutput,
+    NegativeBinomialOutput,
+    NormalOutput,
+    PoissonOutput,
+    StudentTOutput,
+)
+from .generalized_pareto import GeneralizedPareto, GeneralizedParetoOutput
+from .isqf import ISQF, ISQFOutput
+from .mqf2 import MQF2Distribution, MQF2DistributionOutput
+from .piecewise_linear import PiecewiseLinear, PiecewiseLinearOutput
 from .spliced_binned_pareto import (
     SplicedBinnedPareto,
     SplicedBinnedParetoOutput,
 )
 
 __all__ = [
-    "ISQF",
-    "ISQFOutput",
-    "PiecewiseLinear",
-    "PiecewiseLinearOutput",
-    "GeneralizedPareto",
-    "GeneralizedParetoOutput",
+    "BetaOutput",
     "BinnedUniforms",
     "BinnedUniformsOutput",
+    "DistributionOutput",
+    "GammaOutput",
+    "GeneralizedPareto",
+    "GeneralizedParetoOutput",
+    "ISQF",
+    "ISQFOutput",
+    "MQF2Distribution",
+    "MQF2DistributionOutput",
+    "NegativeBinomialOutput",
+    "NormalOutput",
+    "PiecewiseLinear",
+    "PiecewiseLinearOutput",
+    "PoissonOutput",
     "SplicedBinnedPareto",
     "SplicedBinnedParetoOutput",
+    "StudentTOutput",
 ]

--- a/src/gluonts/torch/distributions/binned_uniforms.py
+++ b/src/gluonts/torch/distributions/binned_uniforms.py
@@ -11,14 +11,15 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-import torch
-from typing import Optional, cast, Dict, Tuple
-import torch.nn.functional as F
+from typing import Dict, Optional, Tuple, cast
 
+import torch
+import torch.nn.functional as F
 from torch.distributions import Distribution, constraints
 
 from gluonts.core.component import validated
-from gluonts.torch.distributions import DistributionOutput
+
+from .distribution_output import DistributionOutput
 
 
 class BinnedUniforms(Distribution):

--- a/src/gluonts/torch/distributions/binned_uniforms.py
+++ b/src/gluonts/torch/distributions/binned_uniforms.py
@@ -18,7 +18,7 @@ import torch.nn.functional as F
 from torch.distributions import Distribution, constraints
 
 from gluonts.core.component import validated
-from gluonts.torch.distributions.distribution_output import DistributionOutput
+from gluonts.torch.distributions import DistributionOutput
 
 
 class BinnedUniforms(Distribution):

--- a/src/gluonts/torch/distributions/binned_uniforms.py
+++ b/src/gluonts/torch/distributions/binned_uniforms.py
@@ -18,7 +18,7 @@ import torch.nn.functional as F
 from torch.distributions import Distribution, constraints
 
 from gluonts.core.component import validated
-from gluonts.torch.modules.distribution_output import DistributionOutput
+from gluonts.torch.distributions.distribution_output import DistributionOutput
 
 
 class BinnedUniforms(Distribution):

--- a/src/gluonts/torch/distributions/distribution_output.py
+++ b/src/gluonts/torch/distributions/distribution_output.py
@@ -30,8 +30,7 @@ from torch.distributions import (
 )
 
 from gluonts.core.component import validated
-
-from .lambda_layer import LambdaLayer
+from gluonts.torch.modules.lambda_layer import LambdaLayer
 
 
 class PtArgProj(nn.Module):

--- a/src/gluonts/torch/distributions/generalized_pareto.py
+++ b/src/gluonts/torch/distributions/generalized_pareto.py
@@ -23,7 +23,7 @@ from torch.distributions import Distribution, constraints
 from typing import Optional, cast, Dict, Tuple
 
 from gluonts.core.component import validated
-from gluonts.torch.distributions.distribution_output import DistributionOutput
+from gluonts.torch.distributions import DistributionOutput
 
 
 class GeneralizedPareto(Distribution):

--- a/src/gluonts/torch/distributions/generalized_pareto.py
+++ b/src/gluonts/torch/distributions/generalized_pareto.py
@@ -23,7 +23,7 @@ from torch.distributions import Distribution, constraints
 from typing import Optional, cast, Dict, Tuple
 
 from gluonts.core.component import validated
-from gluonts.torch.modules.distribution_output import DistributionOutput
+from gluonts.torch.distributions.distribution_output import DistributionOutput
 
 
 class GeneralizedPareto(Distribution):

--- a/src/gluonts/torch/distributions/generalized_pareto.py
+++ b/src/gluonts/torch/distributions/generalized_pareto.py
@@ -11,19 +11,17 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from torch.distributions.utils import broadcast_all
-
 from numbers import Number
+from typing import Dict, Optional, Tuple, cast
 
 import numpy as np
-
 import torch
 from torch.distributions import Distribution, constraints
-
-from typing import Optional, cast, Dict, Tuple
+from torch.distributions.utils import broadcast_all
 
 from gluonts.core.component import validated
-from gluonts.torch.distributions import DistributionOutput
+
+from .distribution_output import DistributionOutput
 
 
 class GeneralizedPareto(Distribution):

--- a/src/gluonts/torch/distributions/isqf.py
+++ b/src/gluonts/torch/distributions/isqf.py
@@ -17,7 +17,7 @@ import torch
 import torch.nn.functional as F
 
 from gluonts.core.component import validated
-from gluonts.torch.modules.distribution_output import (
+from gluonts.torch.distributions.distribution_output import (
     Distribution,
     DistributionOutput,
 )

--- a/src/gluonts/torch/distributions/isqf.py
+++ b/src/gluonts/torch/distributions/isqf.py
@@ -17,10 +17,7 @@ import torch
 import torch.nn.functional as F
 
 from gluonts.core.component import validated
-from gluonts.torch.distributions.distribution_output import (
-    Distribution,
-    DistributionOutput,
-)
+from gluonts.torch.distributions import DistributionOutput
 
 from torch.distributions import (
     AffineTransform,
@@ -28,7 +25,7 @@ from torch.distributions import (
 )
 
 
-class ISQF(Distribution):
+class ISQF(torch.distributions.Distribution):
     r"""
     Distribution class for the Incremental (Spline) Quantile Function in the
     paper ``Learning Quantile Functions without Quantile Crossing for

--- a/src/gluonts/torch/distributions/isqf.py
+++ b/src/gluonts/torch/distributions/isqf.py
@@ -11,18 +11,15 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from typing import Dict, Optional, Tuple, List
+from typing import Dict, List, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
+from torch.distributions import AffineTransform, TransformedDistribution
 
 from gluonts.core.component import validated
-from gluonts.torch.distributions import DistributionOutput
 
-from torch.distributions import (
-    AffineTransform,
-    TransformedDistribution,
-)
+from .distribution_output import DistributionOutput
 
 
 class ISQF(torch.distributions.Distribution):

--- a/src/gluonts/torch/distributions/mqf2.py
+++ b/src/gluonts/torch/distributions/mqf2.py
@@ -23,13 +23,10 @@ from torch.distributions import (
 from torch.distributions.normal import Normal
 
 from gluonts.core.component import validated
-from gluonts.torch.distributions.distribution_output import (
-    Distribution,
-    DistributionOutput,
-)
+from gluonts.torch.distributions import DistributionOutput
 
 
-class MQF2Distribution(Distribution):
+class MQF2Distribution(torch.distributions.Distribution):
     r"""
     Distribution class for the model MQF2 proposed in the paper
     ``Multivariate Quantile Function Forecaster``

--- a/src/gluonts/torch/distributions/mqf2.py
+++ b/src/gluonts/torch/distributions/mqf2.py
@@ -23,7 +23,7 @@ from torch.distributions import (
 from torch.distributions.normal import Normal
 
 from gluonts.core.component import validated
-from gluonts.torch.modules.distribution_output import (
+from gluonts.torch.distributions.distribution_output import (
     Distribution,
     DistributionOutput,
 )

--- a/src/gluonts/torch/distributions/mqf2.py
+++ b/src/gluonts/torch/distributions/mqf2.py
@@ -11,19 +11,15 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from typing import Dict, Optional, Tuple, List, cast
+from typing import Dict, List, Optional, Tuple, cast
 
 import torch
-
-from torch.distributions import (
-    AffineTransform,
-    TransformedDistribution,
-)
-
+from torch.distributions import AffineTransform, TransformedDistribution
 from torch.distributions.normal import Normal
 
 from gluonts.core.component import validated
-from gluonts.torch.distributions import DistributionOutput
+
+from .distribution_output import DistributionOutput
 
 
 class MQF2Distribution(torch.distributions.Distribution):

--- a/src/gluonts/torch/distributions/piecewise_linear.py
+++ b/src/gluonts/torch/distributions/piecewise_linear.py
@@ -17,7 +17,7 @@ import torch
 import torch.nn.functional as F
 
 from gluonts.core.component import validated
-from gluonts.torch.modules.distribution_output import (
+from gluonts.torch.distributions.distribution_output import (
     Distribution,
     DistributionOutput,
 )

--- a/src/gluonts/torch/distributions/piecewise_linear.py
+++ b/src/gluonts/torch/distributions/piecewise_linear.py
@@ -17,10 +17,7 @@ import torch
 import torch.nn.functional as F
 
 from gluonts.core.component import validated
-from gluonts.torch.distributions.distribution_output import (
-    Distribution,
-    DistributionOutput,
-)
+from gluonts.torch.distributions import DistributionOutput
 
 from torch.distributions import (
     AffineTransform,
@@ -28,7 +25,7 @@ from torch.distributions import (
 )
 
 
-class PiecewiseLinear(Distribution):
+class PiecewiseLinear(torch.distributions.Distribution):
     def __init__(
         self,
         gamma: torch.Tensor,

--- a/src/gluonts/torch/distributions/piecewise_linear.py
+++ b/src/gluonts/torch/distributions/piecewise_linear.py
@@ -11,18 +11,15 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from typing import Dict, Optional, Tuple, List, cast
+from typing import Dict, List, Optional, Tuple, cast
 
 import torch
 import torch.nn.functional as F
+from torch.distributions import AffineTransform, TransformedDistribution
 
 from gluonts.core.component import validated
-from gluonts.torch.distributions import DistributionOutput
 
-from torch.distributions import (
-    AffineTransform,
-    TransformedDistribution,
-)
+from .distribution_output import DistributionOutput
 
 
 class PiecewiseLinear(torch.distributions.Distribution):

--- a/src/gluonts/torch/distributions/spliced_binned_pareto.py
+++ b/src/gluonts/torch/distributions/spliced_binned_pareto.py
@@ -16,11 +16,12 @@ from typing import Optional, cast, Dict, Tuple
 import torch
 from torch.distributions import constraints
 
-from gluonts.torch.distributions.binned_uniforms import BinnedUniforms
-from gluonts.torch.distributions.generalized_pareto import GeneralizedPareto
-
 from gluonts.core.component import validated
-from gluonts.torch.distributions.distribution_output import DistributionOutput
+from gluonts.torch.distributions import (
+    BinnedUniforms,
+    GeneralizedPareto
+)
+from gluonts.torch.distributions import DistributionOutput
 
 
 class SplicedBinnedPareto(BinnedUniforms):

--- a/src/gluonts/torch/distributions/spliced_binned_pareto.py
+++ b/src/gluonts/torch/distributions/spliced_binned_pareto.py
@@ -20,7 +20,7 @@ from gluonts.torch.distributions.binned_uniforms import BinnedUniforms
 from gluonts.torch.distributions.generalized_pareto import GeneralizedPareto
 
 from gluonts.core.component import validated
-from gluonts.torch.modules.distribution_output import DistributionOutput
+from gluonts.torch.distributions.distribution_output import DistributionOutput
 
 
 class SplicedBinnedPareto(BinnedUniforms):

--- a/src/gluonts/torch/distributions/spliced_binned_pareto.py
+++ b/src/gluonts/torch/distributions/spliced_binned_pareto.py
@@ -17,10 +17,7 @@ import torch
 from torch.distributions import constraints
 
 from gluonts.core.component import validated
-from gluonts.torch.distributions import (
-    BinnedUniforms,
-    GeneralizedPareto
-)
+from gluonts.torch.distributions import BinnedUniforms, GeneralizedPareto
 from gluonts.torch.distributions import DistributionOutput
 
 

--- a/src/gluonts/torch/distributions/spliced_binned_pareto.py
+++ b/src/gluonts/torch/distributions/spliced_binned_pareto.py
@@ -11,14 +11,15 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from typing import Optional, cast, Dict, Tuple
+from typing import Dict, Optional, Tuple, cast
 
 import torch
 from torch.distributions import constraints
 
 from gluonts.core.component import validated
 from gluonts.torch.distributions import BinnedUniforms, GeneralizedPareto
-from gluonts.torch.distributions import DistributionOutput
+
+from .distribution_output import DistributionOutput
 
 
 class SplicedBinnedPareto(BinnedUniforms):

--- a/src/gluonts/torch/model/deepar/estimator.py
+++ b/src/gluonts/torch/model/deepar/estimator.py
@@ -46,7 +46,7 @@ from gluonts.torch.util import (
 )
 from gluonts.torch.model.estimator import PyTorchLightningEstimator
 from gluonts.torch.model.predictor import PyTorchPredictor
-from gluonts.torch.modules.distribution_output import (
+from gluonts.torch.distributions.distribution_output import (
     DistributionOutput,
     StudentTOutput,
 )

--- a/src/gluonts/torch/model/deepar/estimator.py
+++ b/src/gluonts/torch/model/deepar/estimator.py
@@ -46,7 +46,7 @@ from gluonts.torch.util import (
 )
 from gluonts.torch.model.estimator import PyTorchLightningEstimator
 from gluonts.torch.model.predictor import PyTorchPredictor
-from gluonts.torch.distributions.distribution_output import (
+from gluonts.torch.distributions import (
     DistributionOutput,
     StudentTOutput,
 )

--- a/src/gluonts/torch/model/deepar/module.py
+++ b/src/gluonts/torch/model/deepar/module.py
@@ -18,7 +18,7 @@ import torch.nn as nn
 
 from gluonts.core.component import validated
 from gluonts.time_feature import get_lags_for_frequency
-from gluonts.torch.modules.distribution_output import (
+from gluonts.torch.distributions.distribution_output import (
     DistributionOutput,
     StudentTOutput,
 )

--- a/src/gluonts/torch/model/deepar/module.py
+++ b/src/gluonts/torch/model/deepar/module.py
@@ -18,7 +18,7 @@ import torch.nn as nn
 
 from gluonts.core.component import validated
 from gluonts.time_feature import get_lags_for_frequency
-from gluonts.torch.distributions.distribution_output import (
+from gluonts.torch.distributions import (
     DistributionOutput,
     StudentTOutput,
 )

--- a/src/gluonts/torch/model/mqf2/estimator.py
+++ b/src/gluonts/torch/model/mqf2/estimator.py
@@ -15,7 +15,7 @@ from typing import List, Optional, Dict, Any
 
 from gluonts.torch.model.deepar.estimator import DeepAREstimator
 from gluonts.torch.modules.loss import NegativeLogLikelihood, EnergyScore
-from gluonts.torch.distributions.mqf2 import MQF2DistributionOutput
+from gluonts.torch.distributions import MQF2DistributionOutput
 
 from . import MQF2MultiHorizonLightningModule, MQF2MultiHorizonModel
 

--- a/src/gluonts/torch/model/mqf2/module.py
+++ b/src/gluonts/torch/model/mqf2/module.py
@@ -17,7 +17,7 @@ import torch
 
 from gluonts.core.component import validated
 from gluonts.torch.model.deepar.module import DeepARModel
-from gluonts.torch.modules.distribution_output import DistributionOutput
+from gluonts.torch.distributions.distribution_output import DistributionOutput
 
 from cpflows.flows import ActNorm
 from cpflows.icnn import PICNN

--- a/src/gluonts/torch/model/mqf2/module.py
+++ b/src/gluonts/torch/model/mqf2/module.py
@@ -17,7 +17,7 @@ import torch
 
 from gluonts.core.component import validated
 from gluonts.torch.model.deepar.module import DeepARModel
-from gluonts.torch.distributions.distribution_output import DistributionOutput
+from gluonts.torch.distributions import DistributionOutput
 
 from cpflows.flows import ActNorm
 from cpflows.icnn import PICNN

--- a/src/gluonts/torch/model/simple_feedforward/estimator.py
+++ b/src/gluonts/torch/model/simple_feedforward/estimator.py
@@ -38,7 +38,7 @@ from gluonts.torch.util import (
 )
 from gluonts.torch.model.estimator import PyTorchLightningEstimator
 from gluonts.torch.model.predictor import PyTorchPredictor
-from gluonts.torch.modules.distribution_output import (
+from gluonts.torch.distributions.distribution_output import (
     DistributionOutput,
     StudentTOutput,
 )

--- a/src/gluonts/torch/model/simple_feedforward/estimator.py
+++ b/src/gluonts/torch/model/simple_feedforward/estimator.py
@@ -38,7 +38,7 @@ from gluonts.torch.util import (
 )
 from gluonts.torch.model.estimator import PyTorchLightningEstimator
 from gluonts.torch.model.predictor import PyTorchPredictor
-from gluonts.torch.distributions.distribution_output import (
+from gluonts.torch.distributions import (
     DistributionOutput,
     StudentTOutput,
 )

--- a/src/gluonts/torch/model/simple_feedforward/module.py
+++ b/src/gluonts/torch/model/simple_feedforward/module.py
@@ -17,7 +17,7 @@ import torch
 from torch import nn
 
 from gluonts.core.component import validated
-from gluonts.torch.distributions.distribution_output import StudentTOutput
+from gluonts.torch.distributions import StudentTOutput
 
 
 def mean_abs_scaling(seq, min_scale=1e-5):

--- a/src/gluonts/torch/model/simple_feedforward/module.py
+++ b/src/gluonts/torch/model/simple_feedforward/module.py
@@ -17,7 +17,7 @@ import torch
 from torch import nn
 
 from gluonts.core.component import validated
-from gluonts.torch.modules.distribution_output import StudentTOutput
+from gluonts.torch.distributions.distribution_output import StudentTOutput
 
 
 def mean_abs_scaling(seq, min_scale=1e-5):

--- a/test/torch/distribution/test_torch_piecewise_linear.py
+++ b/test/torch/distribution/test_torch_piecewise_linear.py
@@ -17,7 +17,7 @@ import pytest
 import torch
 import numpy as np
 
-from gluonts.torch.distributions.piecewise_linear import (
+from gluonts.torch.distributions import (
     PiecewiseLinear,
     PiecewiseLinearOutput,
 )

--- a/test/torch/model/test_mqf2_modules.py
+++ b/test/torch/model/test_mqf2_modules.py
@@ -19,7 +19,7 @@ from gluonts.torch.model.mqf2 import (
     MQF2MultiHorizonModel,
     MQF2MultiHorizonLightningModule,
 )
-from gluonts.torch.distributions.mqf2 import MQF2DistributionOutput
+from gluonts.torch.distributions import MQF2DistributionOutput
 
 
 @pytest.mark.parametrize(

--- a/test/torch/modules/test_torch_distribution_inference.py
+++ b/test/torch/modules/test_torch_distribution_inference.py
@@ -45,12 +45,11 @@ from gluonts.torch.distributions import (
     StudentTOutput,
 )
 
-from gluonts.torch.distributions.spliced_binned_pareto import (
+from gluonts.torch.distributions import (
     SplicedBinnedPareto,
     SplicedBinnedParetoOutput,
 )
 
-from scipy import stats
 from scipy.special import softmax
 
 NUM_SAMPLES = 3_000

--- a/test/torch/modules/test_torch_distribution_inference.py
+++ b/test/torch/modules/test_torch_distribution_inference.py
@@ -35,7 +35,7 @@ from torch.optim import SGD
 from torch.utils.data import DataLoader, TensorDataset
 
 from gluonts.model.common import NPArrayLike
-from gluonts.torch.distributions.distribution_output import (
+from gluonts.torch.distributions import (
     BetaOutput,
     DistributionOutput,
     GammaOutput,

--- a/test/torch/modules/test_torch_distribution_inference.py
+++ b/test/torch/modules/test_torch_distribution_inference.py
@@ -35,7 +35,7 @@ from torch.optim import SGD
 from torch.utils.data import DataLoader, TensorDataset
 
 from gluonts.model.common import NPArrayLike
-from gluonts.torch.modules.distribution_output import (
+from gluonts.torch.distributions.distribution_output import (
     BetaOutput,
     DistributionOutput,
     GammaOutput,


### PR DESCRIPTION
*Description of changes:* This puts distribution and output layer definitions closer together, to avoid issues like the circular dependencies that #1962 ran into. Also: shortening distribution-related import paths.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup