### PR TITLE
Fix: torch DeepAR observed indicator in multivariate case

### DIFF
--- a/src/gluonts/torch/model/deepar/lightning_module.py
+++ b/src/gluonts/torch/model/deepar/lightning_module.py
@@ -73,7 +73,7 @@ class DeepARLightningModule(pl.LightningModule):
         if len(self.model.target_shape) == 0:
             loss_weights = observed_values
         else:
-            loss_weights = observed_values.min(dim=-1, keepdim=False)
+            loss_weights, _ = observed_values.min(dim=-1, keepdim=False)
 
         return weighted_average(loss_values, weights=loss_weights)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
pytorch min return min and min_indicies so only use the min

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup