### PR TITLE
Add info cli.

### DIFF
--- a/src/gluonts/info.py
+++ b/src/gluonts/info.py
@@ -1,0 +1,30 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import click
+
+import gluonts
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command()
+def version():
+    click.echo(gluonts.__version__)
+
+
+if __name__ == "__main__":
+    cli()

--- a/src/gluonts/info.py
+++ b/src/gluonts/info.py
@@ -11,7 +11,13 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-import click
+try:
+    import click
+except ImportError:
+    import sys
+
+    print("`gluonts.info` requires `click` to be installed.", file=sys.stderr)
+    sys.exit(1)
 
 import gluonts
 


### PR DESCRIPTION
*Issue #, if available:*

Simple CLI tool to get infos about gluonts installation:

```sh
$ python -m gluonts.info version
0.dev0+g027df66f
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup