### PR TITLE
Documentation: fix and speed up tutorials

### DIFF
--- a/docs/tutorials/forecasting/extended_tutorial.md
+++ b/docs/tutorials/forecasting/extended_tutorial.md
@@ -46,11 +46,11 @@ from gluonts.dataset.util import to_pandas
 print(f"Available datasets: {list(dataset_recipes.keys())}")
 ```
 
-To download one of the built-in datasets, simply call `get_dataset` with one of the above names. GluonTS can re-use the saved dataset so that it does not need to be downloaded again: simply set `regenerate=False`.
+To download one of the built-in datasets, simply call `get_dataset` with one of the above names. GluonTS can re-use the saved dataset so that it does not need to be downloaded again the next time around.
 
 
 ```python
-dataset = get_dataset("m4_hourly", regenerate=True)
+dataset = get_dataset("m4_hourly")
 ```
 
 ### What is in a dataset?

--- a/docs/tutorials/forecasting/quick_start_tutorial.md
+++ b/docs/tutorials/forecasting/quick_start_tutorial.md
@@ -40,11 +40,11 @@ from gluonts.dataset.util import to_pandas
 print(f"Available datasets: {list(dataset_recipes.keys())}")
 ```
 
-To download one of the built-in datasets, simply call get_dataset with one of the above names. GluonTS can re-use the saved dataset so that it does not need to be downloaded again: simply set `regenerate=False`.
+To download one of the built-in datasets, simply call get_dataset with one of the above names. GluonTS can re-use the saved dataset so that it does not need to be downloaded again the next time around.
 
 
 ```python
-dataset = get_dataset("m4_hourly", regenerate=True)
+dataset = get_dataset("m4_hourly")
 ```
 
 In general, the datasets provided by GluonTS are objects that consists of three main members:

--- a/docs/tutorials/mxnet_models/trainer_callbacks.md
+++ b/docs/tutorials/mxnet_models/trainer_callbacks.md
@@ -7,8 +7,7 @@ You can use predefined GluonTS callbacks like `TrainingHistory`, `ModelAveraging
 ```python
 from gluonts.dataset.repository.datasets import get_dataset
 
-dataset = "m4_hourly"
-dataset = get_dataset(dataset)
+dataset = get_dataset("m4_hourly")
 prediction_length = dataset.metadata.prediction_length
 freq = dataset.metadata.freq
 ```


### PR DESCRIPTION
* Speed up tutorials by disabling regeneration of the datasets, and using `m4_hourly` everywhere so that it's downloaded once
* Fix sentences where needed


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup