### PR TITLE
Added support of "long" RTS, making short RTS be "past_feat_dynamic_real"

### DIFF
--- a/src/gluonts/model/rotbaum/_predictor.py
+++ b/src/gluonts/model/rotbaum/_predictor.py
@@ -110,7 +110,7 @@ class TreePredictor(RepresentablePredictor):
         min_bin_size: int = 100,  # Used only for "QRX" method.
         context_length: Optional[int] = None,
         use_feat_static_real: bool = False,
-        use_hist_feat_dynamic_real: bool = False,
+        use_past_feat_dynamic_real: bool = False,
         use_feat_dynamic_real: bool = False,
         use_feat_dynamic_cat: bool = False,
         cardinality: Cardinality = "auto",
@@ -139,7 +139,7 @@ class TreePredictor(RepresentablePredictor):
             n_ignore_last=n_ignore_last,
             max_n_datapts=max_n_datapts,
             use_feat_static_real=use_feat_static_real,
-            use_hist_feat_dynamic_real=use_hist_feat_dynamic_real,
+            use_past_feat_dynamic_real=use_past_feat_dynamic_real,
             use_feat_dynamic_real=use_feat_dynamic_real,
             use_feat_dynamic_cat=use_feat_dynamic_cat,
             cardinality=cardinality,
@@ -156,7 +156,7 @@ class TreePredictor(RepresentablePredictor):
         assert (
             prediction_length > 0
             or use_feat_dynamic_cat
-            or use_hist_feat_dynamic_real
+            or use_past_feat_dynamic_real
             or use_feat_dynamic_real
             or use_feat_static_real
             or cardinality != "ignore"

--- a/src/gluonts/model/rotbaum/_predictor.py
+++ b/src/gluonts/model/rotbaum/_predictor.py
@@ -110,6 +110,7 @@ class TreePredictor(RepresentablePredictor):
         min_bin_size: int = 100,  # Used only for "QRX" method.
         context_length: Optional[int] = None,
         use_feat_static_real: bool = False,
+        use_hist_feat_dynamic_real: bool = False,
         use_feat_dynamic_real: bool = False,
         use_feat_dynamic_cat: bool = False,
         cardinality: Cardinality = "auto",
@@ -138,6 +139,7 @@ class TreePredictor(RepresentablePredictor):
             n_ignore_last=n_ignore_last,
             max_n_datapts=max_n_datapts,
             use_feat_static_real=use_feat_static_real,
+            use_hist_feat_dynamic_real=use_hist_feat_dynamic_real,
             use_feat_dynamic_real=use_feat_dynamic_real,
             use_feat_dynamic_cat=use_feat_dynamic_cat,
             cardinality=cardinality,
@@ -154,6 +156,7 @@ class TreePredictor(RepresentablePredictor):
         assert (
             prediction_length > 0
             or use_feat_dynamic_cat
+            or use_hist_feat_dynamic_real
             or use_feat_dynamic_real
             or use_feat_static_real
             or cardinality != "ignore"

--- a/src/gluonts/model/rotbaum/_preprocess.py
+++ b/src/gluonts/model/rotbaum/_preprocess.py
@@ -280,7 +280,7 @@ class PreprocessOnlyLagFeatures(PreprocessGeneric):
         n_ignore_last=0,
         num_samples=-1,
         use_feat_static_real=False,
-        use_hist_feat_dynamic_real=False,
+        use_past_feat_dynamic_real=False,
         use_feat_dynamic_real=False,
         use_feat_dynamic_cat=False,
         cardinality: Cardinality = CardinalityLabel.auto,
@@ -309,7 +309,7 @@ class PreprocessOnlyLagFeatures(PreprocessGeneric):
 
         self.use_feat_static_real = use_feat_static_real
         self.cardinality = cardinality
-        self.use_hist_feat_dynamic_real = use_hist_feat_dynamic_real
+        self.use_past_feat_dynamic_real = use_past_feat_dynamic_real
         self.use_feat_dynamic_real = use_feat_dynamic_real
         self.use_feat_dynamic_cat = use_feat_dynamic_cat
         self.one_hot_encode = one_hot_encode
@@ -408,19 +408,19 @@ class PreprocessOnlyLagFeatures(PreprocessGeneric):
         else:
             feat_static_cat = []
 
-        hist_feat_dynamic_real = (
+        past_feat_dynamic_real = (
             list(
                 chain(
                     *[
                         list(ent[0]) + list(ent[1].values())
                         for ent in [
                             self._pre_transform(ts[starting_index:end_index])
-                            for ts in time_series["hist_feat_dynamic_real"]
+                            for ts in time_series["past_feat_dynamic_real"]
                         ]
                     ]
                 )
             )
-            if self.use_hist_feat_dynamic_real
+            if self.use_past_feat_dynamic_real
             else []
         )
         feat_dynamic_real = (
@@ -465,7 +465,7 @@ class PreprocessOnlyLagFeatures(PreprocessGeneric):
         )
 
         feat_dynamics = (
-            hist_feat_dynamic_real + feat_dynamic_real + feat_dynamic_cat
+            past_feat_dynamic_real + feat_dynamic_real + feat_dynamic_cat
         )
         feat_statics = feat_static_real + feat_static_cat
         only_lag_features = list(only_lag_features)

--- a/src/gluonts/model/rotbaum/_preprocess.py
+++ b/src/gluonts/model/rotbaum/_preprocess.py
@@ -280,6 +280,7 @@ class PreprocessOnlyLagFeatures(PreprocessGeneric):
         n_ignore_last=0,
         num_samples=-1,
         use_feat_static_real=False,
+        use_hist_feat_dynamic_real=False,
         use_feat_dynamic_real=False,
         use_feat_dynamic_cat=False,
         cardinality: Cardinality = CardinalityLabel.auto,
@@ -308,6 +309,7 @@ class PreprocessOnlyLagFeatures(PreprocessGeneric):
 
         self.use_feat_static_real = use_feat_static_real
         self.cardinality = cardinality
+        self.use_hist_feat_dynamic_real = use_hist_feat_dynamic_real
         self.use_feat_dynamic_real = use_feat_dynamic_real
         self.use_feat_dynamic_cat = use_feat_dynamic_cat
         self.one_hot_encode = one_hot_encode
@@ -406,13 +408,33 @@ class PreprocessOnlyLagFeatures(PreprocessGeneric):
         else:
             feat_static_cat = []
 
-        feat_dynamic_real = (
+        hist_feat_dynamic_real = (
             list(
                 chain(
                     *[
                         list(ent[0]) + list(ent[1].values())
                         for ent in [
                             self._pre_transform(ts[starting_index:end_index])
+                            for ts in time_series["hist_feat_dynamic_real"]
+                        ]
+                    ]
+                )
+            )
+            if self.use_hist_feat_dynamic_real
+            else []
+        )
+        feat_dynamic_real = (
+            list(
+                chain(
+                    *[
+                        list(ent[0]) + list(ent[1].values())
+                        for ent in [
+                            self._pre_transform(
+                                ts[
+                                    starting_index : end_index
+                                    + self.forecast_horizon
+                                ]
+                            )
                             for ts in time_series["feat_dynamic_real"]
                         ]
                     ]
@@ -442,7 +464,9 @@ class PreprocessOnlyLagFeatures(PreprocessGeneric):
             np.floor(np_feat_dynamic_cat) == np_feat_dynamic_cat
         )
 
-        feat_dynamics = feat_dynamic_real + feat_dynamic_cat
+        feat_dynamics = (
+            hist_feat_dynamic_real + feat_dynamic_real + feat_dynamic_cat
+        )
         feat_statics = feat_static_real + feat_static_cat
         only_lag_features = list(only_lag_features)
         return (


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I added support for related time series (RTS) that are accessible in the forecast horizon. I changed the syntax so that 'feat_dynamic_real' now means "long" RTS (having info in the forecast horizon), and 'past_feat_dynamic_real' refers to "short" RTS (having no info in the forecast horizon). This is a change of syntax from before in the sense that before there was only support for 'feat_dynamic_real', which was assumed to be short, not long.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup