### PR TITLE
Remove `dct_reduce`.

### DIFF
--- a/src/gluonts/dataset/util.py
+++ b/src/gluonts/dataset/util.py
@@ -139,16 +139,3 @@ def to_pandas(instance: dict, freq: Optional[str] = None) -> pd.Series:
         target,
         index=pd.period_range(start=start, periods=len(target), freq=freq),
     )
-
-
-def dct_reduce(reduce_fn, dcts):
-    """
-    Similar to `reduce`, but applies reduce_fn to fields of dicts with the same
-    name.
-
-    >>> dct_reduce(sum, [{"a": 1}, {"a": 2}])
-    {'a': 3}
-    """
-    keys = dcts[0].keys()
-
-    return {key: reduce_fn([item[key] for item in dcts]) for key in keys}


### PR DESCRIPTION
This function is not used, and there is `itertoolz.merge_with`
which offers the same functionality`.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup