### PR TITLE
Add support for nan values in Rotbaum

### DIFF
--- a/src/gluonts/model/rotbaum/_predictor.py
+++ b/src/gluonts/model/rotbaum/_predictor.py
@@ -117,6 +117,8 @@ class TreePredictor(RepresentablePredictor):
         max_workers: Optional[int] = None,
         method: str = "QRX",
         quantiles=None,  # Used only for "QuantileRegression" method.
+        subtract_mean: bool = True,
+        count_nans: bool = False,
         model=None,
         seed=None,
     ) -> None:
@@ -142,6 +144,8 @@ class TreePredictor(RepresentablePredictor):
             use_feat_dynamic_cat=use_feat_dynamic_cat,
             cardinality=cardinality,
             one_hot_encode=one_hot_encode,
+            subtract_mean=subtract_mean,
+            count_nans=count_nans,
             seed=seed,
         )
 

--- a/src/gluonts/model/rotbaum/_preprocess.py
+++ b/src/gluonts/model/rotbaum/_preprocess.py
@@ -346,14 +346,14 @@ class PreprocessOnlyLagFeatures(PreprocessGeneric):
             count_nans)
         """
         mean_value = np.nanmean(time_series_window)
-        featurized_data = (
+        featurized_data = [
             time_series_window,
             {
                 "mean": mean_value,
                 "std": np.nanstd(time_series_window),
                 "n_lag_features": len(time_series_window),
             },
-        )
+        ]
         if subtract_mean:
             featurized_data[0] = featurized_data[0] - mean_value
         if count_nans:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I added support for nan values. Since in the featurization process Rotbaum removes the mean, having nan values make all of the coordinates into nans. I have done the following:
1. Change all "mean"s and "std"s in the featurization to np.nanmean and np.nanstd.
2. Allow for a feature that counts number of nans in the context windows. You can turn it on by setting count_nans=True.
3. Allow for not removing the mean value in the featurization process. You can do this by setting subtract_mean=False.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup