### PR TITLE
Add `Evaluator.evaluate`.

### DIFF
--- a/src/gluonts/evaluation/_base.py
+++ b/src/gluonts/evaluation/_base.py
@@ -179,6 +179,20 @@ class Evaluator:
         self.aggregation_strategy = aggregation_strategy
         self.ignore_invalid_values = ignore_invalid_values
 
+    def evaluate(
+        self, predictor, test_dataset, **kwargs
+    ) -> Tuple[Dict[str, float], pd.DataFrame]:
+        from .backtest import make_evaluation_predictions
+
+        fcst_iterator, ts_iterator = make_evaluation_predictions(
+            dataset=test_dataset, predictor=predictor, **kwargs
+        )
+
+        fcst_iterator = list(fcst_iterator)
+        ts_iterator = list(ts_iterator)
+
+        return self(ts_iterator, fcst_iterator, len(fcst_iterator))
+
     def __call__(
         self,
         ts_iterator: Iterable[Union[pd.DataFrame, pd.Series]],


### PR DESCRIPTION
This should make `make_evaluation_predictions` obsolete in most cases.

```py
from gluonts.evaluation import Evaluator
from gluonts.dataset.repository.datasets import get_dataset
from gluonts.model.npts import NPTSPredictor

npts = NPTSPredictor(prediction_length=12, freq="H")
ev = Evaluator()

metrics = ev.evaluate(npts, get_dataset("electricity").test)
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

