### PR TITLE
Add optional parameter `time_axis` to `forecast_start`.

### DIFF
--- a/src/gluonts/dataset/util.py
+++ b/src/gluonts/dataset/util.py
@@ -12,13 +12,16 @@
 # permissions and limitations under the License.
 from typing import Optional
 
+import numpy as np
 import pandas as pd
 
 from .field_names import FieldName
 
 
-def forecast_start(entry):
-    return entry[FieldName.START] + len(entry[FieldName.TARGET])
+def forecast_start(entry, time_axis: int = -1):
+    return (
+        entry[FieldName.START] + np.shape(entry[FieldName.TARGET])[time_axis]
+    )
 
 
 def to_pandas(instance: dict, freq: Optional[str] = None) -> pd.Series:

--- a/src/gluonts/dataset/util.py
+++ b/src/gluonts/dataset/util.py
@@ -12,16 +12,13 @@
 # permissions and limitations under the License.
 from typing import Optional
 
-import numpy as np
 import pandas as pd
 
 from .field_names import FieldName
 
 
 def forecast_start(entry, time_axis: int = -1):
-    return (
-        entry[FieldName.START] + np.shape(entry[FieldName.TARGET])[time_axis]
-    )
+    return entry[FieldName.START] + entry[FieldName.TARGET].shape[time_axis]
 
 
 def to_pandas(instance: dict, freq: Optional[str] = None) -> pd.Series:


### PR DESCRIPTION
We add the optional parameter `time_axis` to `forecast_start`. This is particularly useful for hierarchical time series, where we have multivariate data. The default value of the optional parameter `time_axis` is set to `-1` to make it consistent with the previous case, which assumes that the target is univariate.

This PR is related to the following ongoing PR: 
https://github.com/awslabs/gluon-ts/pull/1685#discussion_r902732323_


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup