### PR TITLE
Docs: simplify call to evaluator

### DIFF
--- a/docs/tutorials/advanced_topics/howto_pytorch_lightning.md
+++ b/docs/tutorials/advanced_topics/howto_pytorch_lightning.md
@@ -335,6 +335,6 @@ evaluator = Evaluator(quantiles=[0.1, 0.5, 0.9])
 
 
 ```python
-metrics_pytorch, _ = evaluator(iter(tss_pytorch), iter(forecasts_pytorch), num_series=len(dataset.test))
+metrics_pytorch, _ = evaluator(tss_pytorch, forecasts_pytorch)
 pd.DataFrame.from_records(metrics_pytorch, index=["FeedForward"]).transpose()
 ```

--- a/docs/tutorials/advanced_topics/hp_tuning_with_optuna.md
+++ b/docs/tutorials/advanced_topics/hp_tuning_with_optuna.md
@@ -256,7 +256,7 @@ from gluonts.evaluation import Evaluator
 
 ```python
 evaluator = Evaluator(quantiles=[0.1, 0.5, 0.9])
-agg_metrics, item_metrics = evaluator(iter(tss), iter(forecasts), num_series=len(dataset.test))
+agg_metrics, item_metrics = evaluator(tss, forecasts)
 ```
 
 Aggregate metrics aggregate both across time-steps and across time series.

--- a/docs/tutorials/forecasting/extended_tutorial.md
+++ b/docs/tutorials/forecasting/extended_tutorial.md
@@ -740,7 +740,7 @@ from gluonts.evaluation import Evaluator
 
 ```python
 evaluator = Evaluator(quantiles=[0.1, 0.5, 0.9])
-agg_metrics, item_metrics = evaluator(iter(tss), iter(forecasts), num_series=len(test_ds))
+agg_metrics, item_metrics = evaluator(tss, forecasts)
 ```
 
 Aggregate metrics aggregate both across time-steps and across time series.

--- a/docs/tutorials/forecasting/quick_start_tutorial.md
+++ b/docs/tutorials/forecasting/quick_start_tutorial.md
@@ -270,7 +270,7 @@ from gluonts.evaluation import Evaluator
 
 ```python
 evaluator = Evaluator(quantiles=[0.1, 0.5, 0.9])
-agg_metrics, item_metrics = evaluator(iter(tss), iter(forecasts), num_series=len(dataset.test))
+agg_metrics, item_metrics = evaluator(tss, forecasts)
 ```
 
 Aggregate metrics aggregate both across time-steps and across time series.


### PR DESCRIPTION
*Issue #, if available:* Related to discussion in https://github.com/awslabs/gluon-ts/issues/2058#issuecomment-1162796263

*Description of changes:* No need to invoke `iter` on the original container. Also the `num_series` can be avoided for simplicity.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup