### PR TITLE
Fix  to support Periods as index.

### DIFF
--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -101,9 +101,12 @@ class PandasDataset(Dataset):
         for i, (item_id, df) in enumerate(self._dataframes):
             if self.timestamp:
                 df = df.set_index(keys=self.timestamp)
-            df.index = pd.to_datetime(df.index)
 
-            df = df.to_period(freq=self.freq).sort_index()
+            if not isinstance(df.index, pd.PeriodIndex):
+                df.index = pd.to_datetime(df.index)
+                df = df.to_period(freq=self.freq)
+
+            df.sort_index(inplace=True)
 
             assert is_uniform(df.index), (
                 "Dataframe index is not uniformly spaced. "

--- a/test/dataset/test_pandas.py
+++ b/test/dataset/test_pandas.py
@@ -20,9 +20,10 @@ import pytest
 from gluonts.dataset import pandas
 
 
-@pytest.fixture()
-def my_series():
-    idx = pd.date_range("2021-01-01", freq="1D", periods=3)
+@pytest.fixture(params=[pd.date_range, pd.period_range])
+def my_series(request):
+
+    idx = request.param("2021-01-01", freq="1D", periods=3)
     series = pd.Series(np.random.normal(size=3), index=idx)
     return series
 


### PR DESCRIPTION
Without the changes, this fails with?

```
TypeError: Passing PeriodDtype data is invalid. Use `data.to_timestamp()` instead
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup