### PR TITLE
Change default behavior for TrainDatasets overwrite

### DIFF
--- a/src/gluonts/dataset/common.py
+++ b/src/gluonts/dataset/common.py
@@ -93,7 +93,7 @@ class TrainDatasets(NamedTuple):
         self,
         path_str: str,
         writer: DatasetWriter,
-        overwrite=True,
+        overwrite=False,
     ) -> None:
         """
         Saves an TrainDatasets object to a JSON Lines file.

--- a/src/gluonts/dataset/repository/_airpassengers.py
+++ b/src/gluonts/dataset/repository/_airpassengers.py
@@ -44,4 +44,4 @@ def generate_airpassengers_dataset(
     meta = MetaData(freq="1M", prediction_length=12)
 
     dataset = TrainDatasets(metadata=meta, train=train, test=test)
-    dataset.save(str(dataset_path), writer=dataset_writer)
+    dataset.save(str(dataset_path), writer=dataset_writer, overwrite=True)

--- a/src/gluonts/dataset/repository/_artificial.py
+++ b/src/gluonts/dataset/repository/_artificial.py
@@ -31,4 +31,6 @@ def generate_artificial_dataset(
         ds.metadata.prediction_length = prediction_length
 
     dataset = TrainDatasets(metadata=ds.metadata, train=ds.train, test=ds.test)
-    dataset.save(path_str=str(dataset_path), writer=dataset_writer)
+    dataset.save(
+        path_str=str(dataset_path), writer=dataset_writer, overwrite=True
+    )

--- a/src/gluonts/dataset/repository/_gp_copula_2019.py
+++ b/src/gluonts/dataset/repository/_gp_copula_2019.py
@@ -130,7 +130,9 @@ def generate_gp_copula_dataset(
     )
 
     dataset = TrainDatasets(metadata=meta, train=train_data, test=test_data)
-    dataset.save(path_str=str(dataset_path), writer=dataset_writer)
+    dataset.save(
+        path_str=str(dataset_path), writer=dataset_writer, overwrite=True
+    )
     clean_up_dataset(dataset_path, ds_info)
 
 

--- a/src/gluonts/dataset/repository/_lstnet.py
+++ b/src/gluonts/dataset/repository/_lstnet.py
@@ -205,4 +205,6 @@ def generate_lstnet_dataset(
     )
 
     dataset = TrainDatasets(metadata=meta, train=train_ts, test=test_ts)
-    dataset.save(path_str=str(dataset_path), writer=dataset_writer)
+    dataset.save(
+        path_str=str(dataset_path), writer=dataset_writer, overwrite=True
+    )

--- a/src/gluonts/dataset/repository/_m3.py
+++ b/src/gluonts/dataset/repository/_m3.py
@@ -190,6 +190,8 @@ def generate_m3_dataset(
     )
 
     dataset = TrainDatasets(metadata=meta, train=train_data, test=test_data)
-    dataset.save(path_str=str(dataset_path), writer=dataset_writer)
+    dataset.save(
+        path_str=str(dataset_path), writer=dataset_writer, overwrite=True
+    )
 
     check_dataset(dataset_path, len(df), subset.sheet_name)

--- a/src/gluonts/dataset/repository/_m4.py
+++ b/src/gluonts/dataset/repository/_m4.py
@@ -89,4 +89,6 @@ def generate_m4_dataset(
     )
 
     dataset = TrainDatasets(metadata=meta, train=train_data, test=test_data)
-    dataset.save(path_str=str(dataset_path), writer=dataset_writer)
+    dataset.save(
+        path_str=str(dataset_path), writer=dataset_writer, overwrite=True
+    )

--- a/src/gluonts/dataset/repository/_m5.py
+++ b/src/gluonts/dataset/repository/_m5.py
@@ -165,4 +165,6 @@ def generate_m5_dataset(
     )
 
     dataset = TrainDatasets(metadata=meta, train=train_ds, test=test_ds)
-    dataset.save(path_str=str(dataset_path), writer=dataset_writer)
+    dataset.save(
+        path_str=str(dataset_path), writer=dataset_writer, overwrite=True
+    )

--- a/src/gluonts/dataset/repository/_tsf_datasets.py
+++ b/src/gluonts/dataset/repository/_tsf_datasets.py
@@ -228,7 +228,9 @@ def generate_forecasting_dataset(
     )
 
     dataset = TrainDatasets(metadata=meta, train=train_data, test=test_data)
-    dataset.save(path_str=str(dataset_path), writer=dataset_writer)
+    dataset.save(
+        path_str=str(dataset_path), writer=dataset_writer, overwrite=True
+    )
 
 
 def default_prediction_length_from_frequency(freq: str) -> int:

--- a/src/gluonts/dataset/repository/_uber_tlc.py
+++ b/src/gluonts/dataset/repository/_uber_tlc.py
@@ -93,4 +93,6 @@ def generate_uber_dataset(
     )
 
     dataset = TrainDatasets(metadata=meta, train=train_data, test=test_data)
-    dataset.save(path_str=str(dataset_path), writer=dataset_writer)
+    dataset.save(
+        path_str=str(dataset_path), writer=dataset_writer, overwrite=True
+    )


### PR DESCRIPTION
Fixes #2120 

*Description of changes:*
Default behaviour for TrainDatasets is no longer to overwrite, as this can delete the entire folder.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.