### PR TITLE
Docs: Fix running tutorials for publishing docs.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,9 +6,6 @@ defaults:
   run:
     shell: bash
 
-env:
-  SKIP_BUILD_NOTEBOOK: ${{!( github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'pr:docs-build-notebook'))}}
-
 jobs:
   docs-build:
     runs-on: ubuntu-latest

--- a/Justfile
+++ b/Justfile
@@ -18,10 +18,7 @@
 ROOTDIR := justfile_directory()
 MD2IPYNB := ROOTDIR + "/docs/md2ipynb.py"
 
-skip_build_notebook := env_var_or_default("SKIP_BUILD_NOTEBOOK", "false")
-
-
-docs: release
+docs: compile_notebooks
   make -C docs html # SPHINXOPTS=-W
 
 clean:

--- a/requirements/requirements-docs.txt
+++ b/requirements/requirements-docs.txt
@@ -11,3 +11,5 @@ optuna~=2.10
 furo==2022.6.4.1
 m2r2
 myst-parser
+click
+orjson


### PR DESCRIPTION
`just docs` was missing a dependency on running the notebooks, leaving notebooks unrendered.

Added dependency on `click`, since `md2ipynb` requires it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup