### PR TITLE
Set __getnewargs_ex__ on the Class Instance rather than the Class itself

### DIFF
--- a/src/gluonts/core/component.py
+++ b/src/gluonts/core/component.py
@@ -17,6 +17,7 @@ import logging
 from collections import OrderedDict
 from functools import singledispatch
 from typing import Any, Type, TypeVar
+from types import MethodType
 
 import numpy as np
 from pydantic import BaseConfig, BaseModel, ValidationError, create_model
@@ -339,8 +340,11 @@ def validated(base_model=None):
                         if not skip_encoding(arg)
                     }
                 )
-                self.__class__.__getnewargs_ex__ = validated_getnewargs_ex
                 self.__class__.__repr__ = validated_repr
+
+                # bind validated_getnewargs_ex to the object such that the
+                # __getnewargs_ex__ method is captured during serialization
+                self.__getnewargs_ex__ = MethodType(validated_getnewargs_ex, self)
 
             return init(self, **all_args)
 


### PR DESCRIPTION
## Issue and Reproducible Case
I currently use `gluon-ts` to train a `DeepAREstimator` and predict on new data across different processes. This involves the following workflow:
- In one Python process, create an untrained `DeepAREstimator` and serialize it to the file system
- In a second Python process (possibly on a different machine), `deser` the untrained estimator, train the estimator, and then serialize it to the file system. 
- Finally, in a third Python process, `deser` the trained `Predictor` and predict on new data.

Assume these steps execute sequentially and all the files required for `deser` are copied to the respective machine (if needed). Unfortunately, the attempt to serialize the trained `DeepAREstimator` (a `Predictor`) fails during the execution of the second step. The execution stops when it attempts to serialize `gluonts.time_feature._base.MinuteOfHour` because there is no attribute `__getnewargs_ex__` on the object. 

### Reproducible Case (best reproduced via Jupyter Notebook):
In one Python process, execute:
```py
import dill
from gluonts.mx.trainer import Trainer
from gluonts.model.deepar import DeepAREstimator
dar_estimator = DeepAREstimator(
    prediction_length=10,
    freq='15min',
    trainer=Trainer(epochs=1)
)
with open("model.dill", "wb") as f:
    f.write(dill.dumps(dar_estimator))
```

In a new Python process in the same location, execute:
```py
import dill
with open("nested/model.dill", 'rb') as f:
    dar_estimator = dill.loads(f.read())

trained_estimator = dar_estimator.train(<sample-data>)
with open("trained_model.dill", "wb") as f:
    f.write(dill.dumps(trained_estimator))
```

You should get the following `RuntimeError`:
```
RuntimeError: Cannot serialize type gluonts.time_feature._base.MinuteOfHour. See the documentation of the `encode` and
`validate` functions at

    http://gluon-ts.mxnet.io/api/gluonts/gluonts.html

and the Python documentation of the `__getnewargs_ex__` magic method at

    https://docs.python.org/3/library/pickle.html#object.__getnewargs_ex__

for more information how to make this type serializable.
```

Also, executing 
```py
from gluonts.core.serde._base import encode
encode(trained_estimator)
```
results in the same `RuntimeError`. The same goes if we tried to execute `encode(dar_estimator)` on the untrained estimator. Interestingly, if we execute `dill.dumps(dar_estimator)` in the new process, it properly serializes the estimator (while `encode` does not). 

## Technical Explanation of Issue
This issue stems from the fact that for classes like `MinuteOfHour`, there is no explicit definition of `__getnewargs_ex__` (whether that be on the class itself or through its super classes). Instead, the attribute `__getnewargs_ex__` is added _retroactively_ to `obj.__class__` during the execution of the `@validated` decorator. In `component.py`, we do the following:

https://github.com/awslabs/gluon-ts/blob/94247a9c0d4768aeb4a17a8bb44252706c519a6a/src/gluonts/core/component.py#L342

Because `__getnewargs_ex__` is not explicitly defined and is instead set on the class dynamically, `dill` will fail to capture this member method during serialization and will not be able to load it back on deserialization. In fact, the following happens:

```py
import dill
with open("nested/model.dill", 'rb') as f:
    dar_estimator = dill.loads(f.read())

# the MinuteOfHour object
dar_estimator.time_features[0].__getnewargs_ex__()
>>> AttributeError: 'MinuteOfHour' object has no attribute '__getnewargs_ex__'

# the same goes for all gluon-ts objects
dar_estimator.__getnewargs_ex__()
>>> AttributeError: 'DeepAREstimator' object has no attribute '__getnewargs_ex__'
```

This issue prevents us from being able to fully serialize/deserialize estimators and predictors in different Python processes. The only way around this without changing the source code is to trigger the `@validated` decorator via calling the constructor. For example, the following code block will _not_ raise an error:
```py
import dill
from gluonts.time_feature._base import MinuteOfHour
with open("nested/model.dill", 'rb') as f:
    dar_estimator = dill.loads(f.read())

# the MinuteOfHour object
MinuteOfHour()
dar_estimator.time_features[0].__getnewargs_ex__()
```

## The Solution
To reiterate, the issue is that `dill` is not capturing `__getnewargs_ex__` on objects where this attribute was set retroactively on `obj.__class__`. The solution given in this PR is to instead set `__getnewargs_ex__` on the object itself and bind it as a member method. This way, `dill` will capture this member method on serialization and will load it back during deserialization. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.