### PR TITLE
Make `PandasDataset` faster

### DIFF
--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -305,4 +305,5 @@ def is_uniform(index: pd.PeriodIndex) -> bool:
     >>> is_uniform(pd.DatetimeIndex(ts).to_period("2H"))
     False
     """
-    return (index[1:] - index[:-1] == index.freq).all()
+    other = pd.period_range(index[0], periods=len(index), freq=index.freq)
+    return (other == index).all()


### PR DESCRIPTION
*Issue #, if available:* Fixes #2147

*Description of changes:* This implementation of `is_uniform` is much faster. When timing the call to `is_uniform` in

```python
from gluonts.dataset.pandas import is_uniform
import pandas as pd

index = pd.period_range("2002-01-01 00", periods=10000, freq="2H")

is_uniform(index)
```

I get ~0.48 ms after the change, against ~160 ms before the change. When timing the `PandasDataset` construction in

```python
import pandas as pd
from gluonts.dataset.pandas import PandasDataset

df = pd.DataFrame(
    {
        k: [1.0] * 5000
        for k in range(200)
    },
    index=pd.period_range("2005-01-01", periods=5000, freq="2H")
)

dataset = PandasDataset(dict(df))
```

I get ~70 ms after the change, against ~14 seconds before the change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup