### PR TITLE
Docs: Simplify wide `DataFrame` example

### DIFF
--- a/docs/tutorials/data_manipulation/pandasdataframes.md.template
+++ b/docs/tutorials/data_manipulation/pandasdataframes.md.template
@@ -93,10 +93,8 @@ predictions = predictor.predict(ds)
 
 ## Use case 2 - Loading data from a `wide` dataframe
 
-Here, instead of a `long` dataset, we are given data in the `wide` format,
-where time series are stacked side-by-side. To convert the dataset
-to `PandasDataset` we first convert it to the `long` format and then use the
-`PandasDataset.from_long_dataframe` constructor.
+Here, we are given data in the `wide` format, where time series are stacked side-by-side in a `DataFrame`.
+We can simply turn this into a dictionary of `Series` objects with `dict`, and construct a `PandasDataset` with it:
 
 ```python
 import pandas as pd
@@ -110,17 +108,11 @@ print(df_wide.head())
 ```
 
 ```python
-df_long = pd.melt(df_wide.reset_index(), id_vars="index", value_vars=df_wide.columns)
-print(df_long.head())
-```
-
-```python
 from gluonts.dataset.pandas import PandasDataset
 
-ds = PandasDataset.from_long_dataframe(
-    df_long, item_id="variable", target="value", timestamp="index"
-)
+ds = PandasDataset(dict(df_wide))
 ```
+
 As shown in `Use case 1` we can now use `ds` to train an estimator.
 
 

--- a/docs/tutorials/data_manipulation/pandasdataframes.md.template
+++ b/docs/tutorials/data_manipulation/pandasdataframes.md.template
@@ -91,32 +91,7 @@ predictions = predictor.predict(ds)
 ```
 
 
-## Use case 2 - Loading data from a `wide` dataframe
-
-Here, we are given data in the `wide` format, where time series are stacked side-by-side in a `DataFrame`.
-We can simply turn this into a dictionary of `Series` objects with `dict`, and construct a `PandasDataset` with it:
-
-```python
-import pandas as pd
-
-url_wide = (
-    "https://gist.githubusercontent.com/rsnirwan/c8c8654a98350fadd229b00167174ec4"
-    "/raw/a42101c7786d4bc7695228a0f2c8cea41340e18f/ts_wide.csv"
-)
-df_wide = pd.read_csv(url_wide, index_col=0, parse_dates=True)
-print(df_wide.head())
-```
-
-```python
-from gluonts.dataset.pandas import PandasDataset
-
-ds = PandasDataset(dict(df_wide))
-```
-
-As shown in `Use case 1` we can now use `ds` to train an estimator.
-
-
-## Use case 3 - Loading data with missing values
+## Use case 2 - Loading data with missing values
 
 In case the `timestamp` column is not evenly spaced and monotonically increasing
 we get an error when using `PandasDataset`. Here we show how to fill in the gaps
@@ -154,6 +129,31 @@ for item_id, gdf in df.groupby("item_id"):
 
 ds = PandasDataset(dfs_dict, target="target")
 ```
+
+
+## Use case 3 - Loading data from a `wide` dataframe
+
+Here, we are given data in the `wide` format, where time series are stacked side-by-side in a `DataFrame`.
+We can simply turn this into a dictionary of `Series` objects with `dict`, and construct a `PandasDataset` with it:
+
+```python
+import pandas as pd
+
+url_wide = (
+    "https://gist.githubusercontent.com/rsnirwan/c8c8654a98350fadd229b00167174ec4"
+    "/raw/a42101c7786d4bc7695228a0f2c8cea41340e18f/ts_wide.csv"
+)
+df_wide = pd.read_csv(url_wide, index_col=0, parse_dates=True)
+print(df_wide.head())
+```
+
+```python
+from gluonts.dataset.pandas import PandasDataset
+
+ds = PandasDataset(dict(df_wide))
+```
+
+As shown in `Use case 1` we can now use `ds` to train an estimator.
 
 
 ## General use cases


### PR DESCRIPTION
*Description of changes:* Just using `dict` on the wide `DataFrame` appears to be faster then `melt` + `from_long_dataframe`.

```python
from timeit import default_timer
import pandas as pd
from gluonts.dataset.pandas import PandasDataset

class Timer:
    def __init__(self, verbose=True):
        self.verbose = verbose
        self.timer = default_timer
        
    def __enter__(self):
        self.start = self.timer()
        return self
        
    def __exit__(self, *args):
        end = self.timer()
        self.elapsed_secs = end - self.start
        self.elapsed = self.elapsed_secs * 1000  # millisecs
        if self.verbose:
            print(f'elapsed time: {self.elapsed} ms')

df = pd.DataFrame(
    {
        k: [1.0] * 5000
        for k in range(200)
    },
    index=pd.period_range("2005-01-01", periods=5000, freq="2H")
)

with Timer():
    ds1 = PandasDataset(dict(df))

with Timer():
    df_long = pd.melt(df.reset_index(), id_vars="index", value_vars=df.columns)
    ds2 = PandasDataset.from_long_dataframe(
        df_long, item_id="variable", target="value", timestamp="index"
    )

for entry1, entry2 in zip(ds1, ds2):
    assert entry1["start"] == entry2["start"]
    assert (entry1["target"] == entry2["target"]).all()
    assert entry1['item_id'] == entry2['item_id']
```

gives

```
elapsed time: 81.61166999999992 ms
elapsed time: 3277.0063850000006 ms
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup