### PR TITLE
add encode for pydantic dataclass

### DIFF
--- a/src/gluonts/core/serde/_base.py
+++ b/src/gluonts/core/serde/_base.py
@@ -220,6 +220,15 @@ def encode(v: Any) -> Any:
             "kwargs": encode(kwargs),
         }
 
+    if hasattr(v, "__pydantic_model__"):
+        member = v.__dict__
+        del member["__initialised__"]
+        return {
+            "__kind__": Kind.Instance,
+            "class": fqname_for(v.__class__),
+            "kwargs": encode(member),
+        }
+
     try:
         # as fallback, we try to just take the path of the value
         fqname = fqname_for(v)

--- a/test/core/test_serde.py
+++ b/test/core/test_serde.py
@@ -19,6 +19,7 @@ from typing import NamedTuple
 import numpy as np
 import pandas as pd
 import pytest
+from pydantic.dataclasses import dataclass
 
 from gluonts.core.component import equals, equals_list
 from gluonts.core import serde
@@ -150,3 +151,20 @@ def test_serde_method():
     m = serde.decode(serde.encode(x.m))
 
     assert m() == 42
+
+
+@dataclass
+class C:
+    value: int
+
+
+@dataclass
+class D:
+    c: C
+    d: int
+
+
+def test_serde_dataclass():
+    d = D(c=C(value=42), d=99)
+
+    assert equals(d, serde.decode(serde.encode(d)))


### PR DESCRIPTION
*Issue #1852, if available:*

*Description of changes:*
Add encode for `pydantic` dataclass. Later we can use `dataclass` to replace `validated`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup