### PR TITLE
Fix recursive case for `gluonts.mx.batchify.stack`

### DIFF
--- a/src/gluonts/mx/batchify.py
+++ b/src/gluonts/mx/batchify.py
@@ -80,7 +80,16 @@ def stack(
     if isinstance(data[0], np.ndarray):
         data = mx.nd.array(data, dtype=dtype, ctx=ctx)
     elif isinstance(data[0], (list, tuple)):
-        return list(stack(t, ctx=ctx) for t in zip(*data))
+        return list(
+            stack(
+                t,
+                ctx=ctx,
+                dtype=dtype,
+                variable_length=variable_length,
+                is_right_pad=is_right_pad,
+            )
+            for t in zip(*data)
+        )
     return data
 
 


### PR DESCRIPTION
*Description of changes:* Recursive call to `stack` was not passing on all the options. Related to #2171.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup