### PR TITLE
Fix: add missing link to splitting tutorial

### DIFF
--- a/docs/tutorials/data_manipulation/index.md
+++ b/docs/tutorials/data_manipulation/index.md
@@ -3,5 +3,6 @@
 ```{toctree}
 :maxdepth: 1
 pandasdataframes
+dataset_splitting_example
 synthetic_data_generation
 ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup