### PR TITLE
Fix `item_id` values in `ConstantValuePredictor`

### DIFF
--- a/src/gluonts/model/trivial/constant.py
+++ b/src/gluonts/model/trivial/constant.py
@@ -76,5 +76,5 @@ class ConstantValuePredictor(RepresentablePredictor, FallbackPredictor):
         return SampleForecast(
             samples=samples,
             start_date=forecast_start(item),
-            item_id=item.get("id"),
+            item_id=item.get("item_id"),
         )


### PR DESCRIPTION
*Description of changes:*
This fixes issue #2173 by using the correct key to get the item_id.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup