### PR TITLE
Fix `aggregate_valid` function to ignore non-numeric columns

### DIFF
--- a/src/gluonts/evaluation/_base.py
+++ b/src/gluonts/evaluation/_base.py
@@ -23,10 +23,10 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    Mapping,
     Optional,
     Tuple,
     Union,
-    Mapping,
     cast,
 )
 
@@ -91,10 +91,12 @@ def aggregate_valid(
     """
     Filter all `nan` & `inf` values from `metric_per_ts`.
 
-    If all metrics in a column of `metric_per_ts` are `nan` or `inf` the result
-    will be `np.ma.masked` for that column.
+    If all metrics in a column of `metric_per_ts` are `nan` or `+/-inf` the result
+    will be masked for that column.
     """
-    metric_per_ts = metric_per_ts.apply(np.ma.masked_invalid)
+    metric_per_ts = metric_per_ts[
+        ~metric_per_ts.isin([np.nan, np.inf, -np.inf]).any(1)
+    ]
     return {
         key: metric_per_ts[key].agg(agg, skipna=True)
         for key, agg in agg_funs.items()

--- a/src/gluonts/evaluation/_base.py
+++ b/src/gluonts/evaluation/_base.py
@@ -91,8 +91,8 @@ def aggregate_valid(
     """
     Filter all `nan` & `inf` values from `metric_per_ts`.
 
-    If all metrics in a column of `metric_per_ts` are `nan` or `+/-inf` the result
-    will be masked for that column.
+    If all metrics in a column of `metric_per_ts` are `nan` or `+/-inf`
+    the result will be masked for that column.
     """
     metric_per_ts = metric_per_ts[
         ~metric_per_ts.isin([np.nan, np.inf, -np.inf]).any(1)

--- a/src/gluonts/evaluation/_base.py
+++ b/src/gluonts/evaluation/_base.py
@@ -95,7 +95,7 @@ def aggregate_valid(
     the result will be masked for that column.
     """
     metric_per_ts = metric_per_ts[
-        ~metric_per_ts.isin([np.nan, np.inf, -np.inf]).any(1)
+        ~metric_per_ts.isin([np.nan, np.inf, -np.inf]).any(axis=1)
     ]
     return {
         key: metric_per_ts[key].agg(agg, skipna=True)


### PR DESCRIPTION
`metric_per_ts.apply(np.ma.masked_invalid)` fails when `item_id` column of the dataframe has strings in it. 

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup