### PR TITLE
Revert "Fix `aggregate_valid` function to ignore non-numeric columns"

### DIFF
--- a/src/gluonts/evaluation/_base.py
+++ b/src/gluonts/evaluation/_base.py
@@ -23,10 +23,10 @@ from typing import (
     Iterable,
     Iterator,
     List,
-    Mapping,
     Optional,
     Tuple,
     Union,
+    Mapping,
     cast,
 )
 
@@ -91,12 +91,10 @@ def aggregate_valid(
     """
     Filter all `nan` & `inf` values from `metric_per_ts`.
 
-    If all metrics in a column of `metric_per_ts` are `nan` or `+/-inf`
-    the result will be masked for that column.
+    If all metrics in a column of `metric_per_ts` are `nan` or `inf` the result
+    will be `np.ma.masked` for that column.
     """
-    metric_per_ts = metric_per_ts[
-        ~metric_per_ts.isin([np.nan, np.inf, -np.inf]).any(axis=1)
-    ]
+    metric_per_ts = metric_per_ts.apply(np.ma.masked_invalid)
     return {
         key: metric_per_ts[key].agg(agg, skipna=True)
         for key, agg in agg_funs.items()


### PR DESCRIPTION
This reverts awslabs/gluon-ts#2204 since it was pointed out by @kashif that it creates further issues.