### PR TITLE
Add item id to Uber TLC dataset 

### DIFF
--- a/src/gluonts/dataset/repository/_uber_tlc.py
+++ b/src/gluonts/dataset/repository/_uber_tlc.py
@@ -74,6 +74,7 @@ def generate_uber_dataset(
             "start": start_time,
             "target": target,
             "feat_static_cat": feat_static_cat,
+            "item_id": locationID,
         }
         test_data.append(test_format_dict)
 
@@ -81,6 +82,7 @@ def generate_uber_dataset(
             "start": start_time,
             "target": target[:-prediction_length],
             "feat_static_cat": feat_static_cat,
+            "item_id": locationID,
         }
         train_data.append(train_format_dict)
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/gluon-ts/issues/2188

*Description of changes:*
Added an item id field to the uber tlc data loader using the unique locationID. This allows for unique identification of each TS in the dataset.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.