### PR TITLE
Fix `r_forecast` wrapper to shift start date when truncating time series

### DIFF
--- a/src/gluonts/model/r_forecast/_predictor.py
+++ b/src/gluonts/model/r_forecast/_predictor.py
@@ -249,6 +249,9 @@ class RForecastPredictor(RepresentablePredictor):
 
         for data in dataset:
             if self.trunc_length:
+                data["start"] = data["start"] + (
+                    data["target"].shape[-1] - self.trunc_length
+                )
                 data["target"] = data["target"][-self.trunc_length :]
 
             params = self.params.copy()

--- a/src/gluonts/model/r_forecast/_predictor.py
+++ b/src/gluonts/model/r_forecast/_predictor.py
@@ -249,9 +249,8 @@ class RForecastPredictor(RepresentablePredictor):
 
         for data in dataset:
             if self.trunc_length:
-                data["start"] = data["start"] + (
-                    data["target"].shape[-1] - self.trunc_length
-                )
+                shift_by = max(data["target"].shape[0] - self.trunc_length, 0)
+                data["start"] = data["start"] + shift_by
                 data["target"] = data["target"][-self.trunc_length :]
 
             params = self.params.copy()

--- a/test/model/r_forecast/test_r_predictor.py
+++ b/test/model/r_forecast/test_r_predictor.py
@@ -15,7 +15,7 @@ import pytest
 
 from gluonts.core import serde
 from gluonts.dataset.repository import datasets
-from gluonts.dataset.util import forecast_start
+from gluonts.dataset.util import forecast_start, to_pandas
 from gluonts.evaluation import Evaluator, backtest_metrics
 from gluonts.model.forecast import SampleForecast, QuantileForecast
 from gluonts.model.r_forecast import (
@@ -97,6 +97,16 @@ def test_forecasts(method_name):
     assert agg_metrics["mean_wQuantileLoss"] < TOLERANCE
     assert agg_metrics["NRMSE"] < TOLERANCE
     assert agg_metrics["RMSE"] < TOLERANCE
+
+    trunc_length = prediction_length
+
+    predictor = RForecastPredictor(**params, trunc_length=trunc_length)
+    predictions = list(predictor.predict(train_dataset))
+
+    assert all(
+        prediction.start_date == to_pandas(data).index[-1] + 1
+        for data, prediction in zip(train_dataset, predictions)
+    )
 
 
 def test_r_predictor_serialization():


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixed the r_forecast wrapper to shift the start date of the time series accordingly when truncating the time series. Currently, it uses the the original start date even for the truncated time series which results in an incorrect forecast start date.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup