### PR TITLE
Speedup data reader

### DIFF
--- a/src/gluonts/dataset/arrow/dec.py
+++ b/src/gluonts/dataset/arrow/dec.py
@@ -60,8 +60,7 @@ class ArrowDecoder:
             row = {}
             for column_name in self.columns:
                 value = raw_row[column_name]
-                shape_col_name = f"{column_name}._np_shape"
-                shape = raw_row.get(shape_col_name)
+                shape = raw_row.get(f"{column_name}._np_shape")
 
                 if shape is not None:
                     value = np.stack(value).reshape(shape)

--- a/src/gluonts/dataset/arrow/dec.py
+++ b/src/gluonts/dataset/arrow/dec.py
@@ -48,13 +48,8 @@ class ArrowDecoder:
 
     @classmethod
     def from_schema(cls, schema):
-        columns = []
+        return cls([column.name for column in schema if not column.name.endswith("._np_shape")])
 
-        for column in schema:
-            if not column.name.endswith("._np_shape"):
-                columns.append(column.name)
-
-        return cls(columns)
 
     def decode(self, batch, row_number):
         for row in self.decode_batch(batch.slice(row_number, row_number + 1)):

--- a/src/gluonts/dataset/arrow/dec.py
+++ b/src/gluonts/dataset/arrow/dec.py
@@ -41,15 +41,19 @@ def _arrow_to_py_list_scalar(scalar: pa.ListScalar):
     return arr
 
 
-
 @dataclass
 class ArrowDecoder:
     columns: Dict[str, int]
 
     @classmethod
     def from_schema(cls, schema):
-        return cls([column.name for column in schema if not column.name.endswith("._np_shape")])
-
+        return cls(
+            [
+                column.name
+                for column in schema
+                if not column.name.endswith("._np_shape")
+            ]
+        )
 
     def decode(self, batch, row_number):
         for row in self.decode_batch(batch.slice(row_number, row_number + 1)):
@@ -64,11 +68,12 @@ class ArrowDecoder:
 
                 if shape is not None:
                     value = np.stack(value).reshape(shape)
-                if isinstance(value, np.ndarray) and isinstance(value[0], np.ndarray) and len(value.shape) == 1:
+                if (
+                    isinstance(value, np.ndarray)
+                    and isinstance(value[0], np.ndarray)
+                    and len(value.shape) == 1
+                ):
                     value = np.stack(value)
                 row[column_name] = value
 
             yield row
-
-
-

--- a/src/gluonts/dataset/arrow/dec.py
+++ b/src/gluonts/dataset/arrow/dec.py
@@ -12,68 +12,37 @@
 # permissions and limitations under the License.
 
 from dataclasses import dataclass
-from functools import singledispatch
-from typing import Dict
+from typing import List, Tuple
 
 import numpy as np
-import pyarrow as pa
-
-
-@singledispatch
-def _arrow_to_py(scalar):
-    """Convert arrow scalar value to python value."""
-
-    raise NotImplementedError(scalar, scalar.__class__)
-
-
-@_arrow_to_py.register(pa.Scalar)
-def _arrow_to_py_scalar(scalar: pa.Scalar):
-    return scalar.as_py()
-
-
-@_arrow_to_py.register(pa.ListScalar)
-def _arrow_to_py_list_scalar(scalar: pa.ListScalar):
-    arr = scalar.values.to_numpy(zero_copy_only=False)
-
-    if arr.dtype == object:
-        arr = np.array(list(arr))
-
-    return arr
 
 
 @dataclass
 class ArrowDecoder:
-    columns: Dict[str, int]
+    reshape_columns: List[Tuple[str, str]]
 
     @classmethod
     def from_schema(cls, schema):
         return cls(
             [
-                column.name
+                (column.name[: -len("._np_shape")], column.name)
                 for column in schema
-                if not column.name.endswith("._np_shape")
+                if column.name.endswith("._np_shape")
             ]
         )
 
-    def decode(self, batch, row_number):
-        for row in self.decode_batch(batch.slice(row_number, row_number + 1)):
-            return row
+    def decode(self, batch, row_number: int):
+        yield from self.decode_batch(batch.slice(row_number, row_number + 1))
 
     def decode_batch(self, batch):
-        for raw_row in batch.to_pandas().to_dict("records"):
-            row = {}
-            for column_name in self.columns:
-                value = raw_row[column_name]
-                shape = raw_row.get(f"{column_name}._np_shape")
+        for row in batch.to_pandas().to_dict("records"):
+            for column_name, shape_column in self.reshape_columns:
+                row[column_name] = row[column_name].reshape(
+                    row.pop(shape_column)
+                )
 
-                if shape is not None:
-                    value = np.stack(value).reshape(shape)
-                if (
-                    isinstance(value, np.ndarray)
-                    and isinstance(value[0], np.ndarray)
-                    and len(value.shape) == 1
-                ):
-                    value = np.stack(value)
-                row[column_name] = value
+            for name, value in row.items():
+                if type(value) == np.ndarray and value.dtype == object:
+                    row[name] = np.stack(value)
 
             yield row

--- a/test/dataset/test_arrow.py
+++ b/test/dataset/test_arrow.py
@@ -64,6 +64,7 @@ def make_data(n: int):
 @pytest.mark.parametrize("flatten_arrays", [True, False])
 def test_arrow(writer, flatten_arrays):
     data = make_data(5)
+    writer.flatten_arrays = flatten_arrays
 
     with tempfile.TemporaryDirectory() as path:
         path = Path(path, "data.arrow")


### PR DESCRIPTION
*Issue #2195, if available:*

*Description of changes:* @emptymalei @julian-sieber and I have implemented a significant speedup of the data reader. @jaheba Please have a look. We significantly simplified the from_schema method in the decoder by using dictionaries directly instead of the need to infer the idx of the ndarray columns (maybe you have further ideas to simplify the code? we did not do this yet in order not to break anything). For the moment, the implementation is only for data frames the rows of which contain 1D- or 2D-arrays. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Please tag this pr with at least one of these labels to make our release process faster:** other change