### PR TITLE
Fix dtype bug in piecewise_linear and add a test

### DIFF
--- a/src/gluonts/mx/distribution/piecewise_linear.py
+++ b/src/gluonts/mx/distribution/piecewise_linear.py
@@ -181,7 +181,9 @@ class PiecewiseLinear(Distribution):
             a_tilde.expand_dims(axis=-1), knot_positions
         )
 
-        knots_cubed = F.broadcast_power(self.knot_positions, F.ones(1) * 3.0)
+        knots_cubed = F.power(
+            knot_positions, F.ones_like(knot_positions) * 3.0
+        )
 
         coeff = (
             (1.0 - knots_cubed) / 3.0

--- a/test/mx/model/deepar/test_deepar_smoke.py
+++ b/test/mx/model/deepar/test_deepar_smoke.py
@@ -17,6 +17,7 @@ import numpy as np
 import pytest
 
 from gluonts.mx import DeepAREstimator
+from gluonts.mx.distribution import PiecewiseLinearOutput, StudentTOutput
 from gluonts.mx.trainer import Trainer
 
 from gluonts.testutil.dummy_datasets import make_dummy_datasets_with_features
@@ -106,11 +107,18 @@ common_estimator_hps = dict(
         ),
     ],
 )
+@pytest.mark.parametrize(
+    "distr_output", [StudentTOutput(), PiecewiseLinearOutput(num_pieces=5)]
+)
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 @pytest.mark.parametrize("impute_missing_values", [False, True])
-def test_deepar_smoke(estimator, datasets, dtype, impute_missing_values):
+def test_deepar_smoke(
+    distr_output, estimator, datasets, dtype, impute_missing_values
+):
     estimator = estimator(
-        dtype=dtype, impute_missing_values=impute_missing_values
+        distr_output=distr_output,
+        dtype=dtype,
+        impute_missing_values=impute_missing_values,
     )
     dataset_train, dataset_test = datasets
     predictor = estimator.train(dataset_train)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The `ones` array is hard-coded in `piecewise_linear.py` without regard to the `dtype`.  
So, the `deepar` model training with `PiecewiseLinearOutput` as output distribution and `dytpe=np.float64` currently fails. 

The smoke test for `deepar` didn't currently check `PiecewiseLinearOutput` and it might be one reason this issue was not detected in tests. Adding this test as well. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup