### PR TITLE
Fix `make_evaluation_predictions` to use `DatetimeIndex`

### DIFF
--- a/src/gluonts/evaluation/_base.py
+++ b/src/gluonts/evaluation/_base.py
@@ -277,17 +277,17 @@ class Evaluator:
         np.ndarray
             time series cut in the Forecast object dates
         """
-        assert forecast.index.intersection(time_series.index).equals(
-            forecast.index
+        assert forecast.datetime_index.intersection(time_series.index).equals(
+            forecast.datetime_index
         ), (
             "Cannot extract prediction target since the index of forecast is"
             " outside the index of target\nIndex of forecast:"
-            f" {forecast.index}\n Index of target: {time_series.index}"
+            f" {forecast.datetime_index}\n Index of target: {time_series.index}"
         )
 
         # cut the time series using the dates of the forecast object
         return np.atleast_1d(
-            np.squeeze(time_series.loc[forecast.index].transpose())
+            np.squeeze(time_series.loc[forecast.datetime_index].transpose())
         )
 
     # This method is needed for the owa calculation. It extracts the training
@@ -308,19 +308,10 @@ class Evaluator:
         np.ndarray
             time series without the forecast dates
         """
-
-        assert forecast.index.intersection(time_series.index).equals(
-            forecast.index
-        ), (
-            "Index of forecast is outside the index of target\nIndex of"
-            f" forecast: {forecast.index}\n Index of target:"
-            f" {time_series.index}"
-        )
-
         # Remove the prediction range
         # If the prediction range is not in the end of the time series,
         # everything after the prediction range is truncated
-        date_before_forecast = forecast.index[0] - forecast.freq
+        date_before_forecast = (forecast.index[0] - forecast.freq).to_timestamp()
         return np.atleast_1d(
             np.squeeze(time_series.loc[:date_before_forecast].transpose())
         )

--- a/src/gluonts/evaluation/backtest.py
+++ b/src/gluonts/evaluation/backtest.py
@@ -19,7 +19,7 @@ import pandas as pd
 
 import gluonts  # noqa
 from gluonts.core.serde import load_code
-from gluonts.dataset.common import DataEntry, Dataset
+from gluonts.dataset.common import Dataset
 from gluonts.dataset.field_names import FieldName
 from gluonts.dataset.stat import (
     DatasetStatistics,

--- a/src/gluonts/model/forecast.py
+++ b/src/gluonts/model/forecast.py
@@ -416,9 +416,7 @@ class Forecast:
             )
             # Hack to create labels for the error intervals. Doesn't actually
             # plot anything, because we only pass a single data point
-            pd.Series(
-                data=p50_data[:1], index=self.datetime_index[:1]
-            ).plot(
+            pd.Series(data=p50_data[:1], index=self.datetime_index[:1]).plot(
                 color=color,
                 alpha=alpha,
                 linewidth=10,

--- a/src/gluonts/model/forecast.py
+++ b/src/gluonts/model/forecast.py
@@ -302,6 +302,7 @@ class Forecast:
     prediction_length: int
     mean: np.ndarray
     _index = None
+    _datetime_index = None
 
     def quantile(self, q: Union[float, str]) -> np.ndarray:
         """
@@ -387,12 +388,12 @@ class Forecast:
         i_p50 = len(percentiles_sorted) // 2
 
         p50_data = ps_data[i_p50]
-        p50_series = pd.Series(data=p50_data, index=self.index.to_timestamp())
+        p50_series = pd.Series(data=p50_data, index=self.datetime_index)
         p50_series.plot(color=color, ls="-", label=f"{label_prefix}median")
 
         if show_mean:
             mean_data = np.mean(self._sorted_samples, axis=0)
-            pd.Series(data=mean_data, index=self.index.to_timestamp()).plot(
+            pd.Series(data=mean_data, index=self.datetime_index).plot(
                 color=color,
                 ls=":",
                 label=f"{label_prefix}mean",
@@ -404,7 +405,7 @@ class Forecast:
             ptile = percentiles_sorted[i]
             alpha = alpha_for_percentile(ptile)
             plt.fill_between(
-                self.index.to_timestamp(),
+                self.datetime_index,
                 ps_data[i],
                 ps_data[-i - 1],
                 facecolor=color,
@@ -416,7 +417,7 @@ class Forecast:
             # Hack to create labels for the error intervals. Doesn't actually
             # plot anything, because we only pass a single data point
             pd.Series(
-                data=p50_data[:1], index=self.index.to_timestamp()[:1]
+                data=p50_data[:1], index=self.datetime_index[:1]
             ).plot(
                 color=color,
                 alpha=alpha,
@@ -437,6 +438,12 @@ class Forecast:
                 freq=self.start_date.freq,
             )
         return self._index
+
+    @property
+    def datetime_index(self) -> pd.DatetimeIndex:
+        if self._datetime_index is None:
+            self._datetime_index = self.index.to_timestamp()
+        return self._datetime_index
 
     def dim(self) -> int:
         """


### PR DESCRIPTION
*Issue #, if available:* Fixes #2205

*Description of changes:*
* Call `DataFrame.to_timestamp` in `make_evaluation_predictions`, since having a `PeriodIndex` appears to be messing up with plotting (see discussion in #2205), and since `make_evaluation_predictions` is currently the main driver of back-test plots.
* Clean up code jungle in `make_evaluation_predictions`
* Some cosmetic changes to `Forecast` and `Evaluator` as a side effect


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup