### PR TITLE
Optimize `TimeSeriesSlice` performance

### DIFF
--- a/src/gluonts/dataset/split.py
+++ b/src/gluonts/dataset/split.py
@@ -198,13 +198,13 @@ class AbstractBaseSplitter(ABC):
     """
 
     @abstractmethod
-    def training_entry(self, item: TimeSeriesSlice) -> TimeSeriesSlice:
+    def training_entry(self, entry: DataEntry) -> DataEntry:
         pass
 
     @abstractmethod
     def test_pair(
-        self, item: TimeSeriesSlice, prediction_length: int, offset: int = 0
-    ) -> Tuple[TimeSeriesSlice, TimeSeriesSlice]:
+        self, entry: DataEntry, prediction_length: int, offset: int = 0
+    ) -> Tuple[DataEntry, DataEntry]:
         pass
 
     def split(

--- a/src/gluonts/dataset/split.py
+++ b/src/gluonts/dataset/split.py
@@ -114,7 +114,8 @@ def to_integer_slice(slice_: slice, start: pd.Period) -> slice:
         start_offset = slice_.start
     else:
         raise ValueError(
-            f"Can only use None, int, or pd.Period for slicing, got type {type(slice_.start)}"
+            "Can only use None, int, or pd.Period for slicing, got type "
+            f"{type(slice_.start)}"
         )
 
     if isinstance(slice_.stop, pd.Period):
@@ -124,7 +125,8 @@ def to_integer_slice(slice_: slice, start: pd.Period) -> slice:
         stop_offset = slice_.stop
     else:
         raise ValueError(
-            f"Can only use None, int, or pd.Period for slicing, got type {type(slice_.stop)}"
+            "Can only use None, int, or pd.Period for slicing, got type "
+            f"{type(slice_.stop)}"
         )
 
     return slice(start_offset, stop_offset)

--- a/src/gluonts/dataset/split.py
+++ b/src/gluonts/dataset/split.py
@@ -123,7 +123,7 @@ def slice_data_entry(
 ) -> DataEntry:
     slc = to_positive_slice(
         to_integer_slice(slc, entry[FieldName.START]),
-        len(entry[FieldName.TARGET])
+        len(entry[FieldName.TARGET]),
     )
     if slc.stop is not None:
         slc_extended = slice(slc.start, slc.stop + prediction_length, slc.step)

--- a/src/gluonts/dataset/split.py
+++ b/src/gluonts/dataset/split.py
@@ -73,11 +73,9 @@ argument.
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import cast, Generator, List, Optional, Tuple
+from typing import Generator, Optional, Tuple
 
-import numpy as np
 import pandas as pd
-import pydantic
 
 from gluonts.dataset import Dataset, DataEntry
 from gluonts.dataset.field_names import FieldName

--- a/src/gluonts/dataset/split.py
+++ b/src/gluonts/dataset/split.py
@@ -113,7 +113,9 @@ def to_integer_slice(slice_: slice, start: pd.Period) -> slice:
     elif start_is_int:
         start_offset = slice_.start
     else:
-        raise ValueError(f"Can only use None, int, or pd.Period for slicing, got type {type(slice_.start)}")
+        raise ValueError(
+            f"Can only use None, int, or pd.Period for slicing, got type {type(slice_.start)}"
+        )
 
     if isinstance(slice_.stop, pd.Period):
         stop_offset = (slice_.stop - start).n + 1
@@ -121,7 +123,9 @@ def to_integer_slice(slice_: slice, start: pd.Period) -> slice:
     elif stop_is_int:
         stop_offset = slice_.stop
     else:
-        raise ValueError(f"Can only use None, int, or pd.Period for slicing, got type {type(slice_.stop)}")
+        raise ValueError(
+            f"Can only use None, int, or pd.Period for slicing, got type {type(slice_.stop)}"
+        )
 
     return slice(start_offset, stop_offset)
 
@@ -135,7 +139,9 @@ def slice_data_entry(
     )
 
     if slice_.stop is not None:
-        slice_extended = slice(slice_.start, slice_.stop + prediction_length, slice_.step)
+        slice_extended = slice(
+            slice_.start, slice_.stop + prediction_length, slice_.step
+        )
     else:
         slice_extended = slice_
 

--- a/test/dataset/test_split.py
+++ b/test/dataset/test_split.py
@@ -200,7 +200,3 @@ def test_split(date, offset, windows, distance, max_history):
                 offset=offset,
             )
             k += 1
-
-
-if __name__ == "__main__":
-    test_split(pd.Period("2021-06-17", freq="D"), None, 1, None, None)

--- a/test/dataset/test_split.py
+++ b/test/dataset/test_split.py
@@ -36,63 +36,26 @@ def test_time_series_slice():
 
     tss = TimeSeriesSlice(entry)
 
-    entry_slice = tss[10:20].to_data_entry()
+    entry_slice = tss[10:20]
     assert entry_slice["start"] == pd.Period("2021-02-03", "D") + 10
     assert (entry_slice["target"] == np.arange(10, 20)).all()
     assert (
         entry_slice["feat_dynamic_real"] == np.array([np.arange(10, 20)])
     ).all()
 
-    entry_slice = tss[:-20].to_data_entry()
+    entry_slice = tss[:-20]
     assert entry_slice["start"] == pd.Period("2021-02-03", "D")
     assert (entry_slice["target"] == np.arange(80)).all()
     assert (
         entry_slice["feat_dynamic_real"] == np.array([np.arange(80)])
     ).all()
 
-    entry_slice = tss[-20:].to_data_entry()
+    entry_slice = tss[-20:]
     assert entry_slice["start"] == pd.Period("2021-02-03", "D") + 80
     assert (entry_slice["target"] == np.arange(80, 100)).all()
     assert (
         entry_slice["feat_dynamic_real"] == np.array([np.arange(80, 100)])
     ).all()
-
-
-def check_training_validation(
-    original_entry,
-    train_entry,
-    valid_pair,
-    prediction_length: int,
-    max_history,
-    date,
-    offset,
-) -> None:
-    assert original_entry[FieldName.ITEM_ID] == train_entry[FieldName.ITEM_ID]
-    assert train_entry[FieldName.ITEM_ID] == valid_pair[0][FieldName.ITEM_ID]
-    if max_history is not None:
-        assert len(valid_pair[0][FieldName.TARGET]) == max_history
-    assert len(valid_pair[1][FieldName.TARGET]) == prediction_length
-    train_end = (
-        train_entry[FieldName.START]
-        + len(train_entry[FieldName.TARGET])
-        * train_entry[FieldName.START].freq
-    )
-    if date is not None:
-        assert train_end == date + train_entry[FieldName.START].freq
-    if offset is not None:
-        if offset > 0:
-            assert len(train_entry[FieldName.TARGET]) == offset
-        else:
-            assert len(train_entry[FieldName.TARGET]) - offset == len(
-                original_entry[FieldName.TARGET]
-            )
-    assert train_end <= valid_pair[1][FieldName.START]
-    valid_end = (
-        valid_pair[0][FieldName.START]
-        + len(valid_pair[0][FieldName.TARGET])
-        * valid_pair[0][FieldName.START].freq
-    )
-    assert valid_end == valid_pair[1][FieldName.START]
 
 
 def test_split_mult_freq():
@@ -146,6 +109,48 @@ def test_negative_offset_splitter():
     ]
 
 
+def check_training_validation(
+    original_entry,
+    train_entry,
+    valid_pair,
+    prediction_length: int,
+    max_history,
+    date,
+    offset,
+) -> None:
+    assert original_entry[FieldName.ITEM_ID] == train_entry[FieldName.ITEM_ID]
+    assert train_entry[FieldName.ITEM_ID] == valid_pair[0][FieldName.ITEM_ID]
+    if max_history is not None:
+        assert valid_pair[0][FieldName.TARGET].shape[0] == max_history
+    assert valid_pair[1][FieldName.TARGET].shape[0] == prediction_length
+    train_end = (
+        train_entry[FieldName.START]
+        + train_entry[FieldName.TARGET].shape[0]
+        * train_entry[FieldName.START].freq
+    )
+    if date is not None:
+        assert train_end == date + train_entry[FieldName.START].freq
+    if offset is not None:
+        if offset > 0:
+            assert train_entry[FieldName.TARGET].shape[0] == offset
+        else:
+            assert train_entry[FieldName.TARGET].shape[0] - offset == len(
+                original_entry[FieldName.TARGET]
+            )
+    assert train_end <= valid_pair[1][FieldName.START]
+    valid_end = (
+        valid_pair[0][FieldName.START]
+        + valid_pair[0][FieldName.TARGET].shape[0]
+        * valid_pair[0][FieldName.START].freq
+    )
+    assert valid_end == valid_pair[1][FieldName.START]
+    if FieldName.FEAT_DYNAMIC_REAL in valid_pair[0]:
+        assert (
+            valid_pair[0][FieldName.FEAT_DYNAMIC_REAL].shape[-1]
+            == valid_pair[0][FieldName.TARGET].shape[0] + prediction_length
+        )
+
+
 @pytest.mark.parametrize(
     "date, offset, windows, distance, max_history",
     [
@@ -163,8 +168,18 @@ def test_split(date, offset, windows, distance, max_history):
 
     dataset = ListDataset(
         [
-            {"item_id": 0, "start": "2021-03-04", "target": [1.0] * 365},
-            {"item_id": 1, "start": "2021-03-04", "target": [2.0] * 265},
+            {
+                "item_id": 0,
+                "start": "2021-03-04",
+                "target": [1.0] * 365,
+                "feat_dynamic_real": [[2.0] * 365],
+            },
+            {
+                "item_id": 1,
+                "start": "2021-03-04",
+                "target": [2.0] * 265,
+                "feat_dynamic_real": [[3.0] * 265],
+            },
         ],
         freq="D",
     )


### PR DESCRIPTION
*Description of changes:* the `TimeSeriesSlice` class used in `gluonts.dataset.split` tools adds a lot of overhead due to pandas conversions. This PR gets rid of most of the overhead by operating directly on `numpy` arrays.

To test the improvement one can use the following snippet, iterating `N` times over the `m4_hourly` dataset and splits obtained from it:

```python
import time
from contextlib import AbstractContextManager

from gluonts.dataset.repository.datasets import get_dataset
from gluonts.dataset.split import split

dataset = get_dataset("m4_hourly").train
# dataset = list(get_dataset("m4_hourly").train)

class Timer(AbstractContextManager):
    def __init__(self, name: str):
        self.name = name

    def __enter__(self):
        self.start = time.time()

    def __exit__(self, *args):
        end = time.time()
        print(f"{self.name}: {end - self.start} seconds")

N = 100

with Timer("dataset    "):
    for k in range(N):
        for entry in dataset:
            pass

training_data, test_template = split(dataset, offset=-100)

with Timer("training   "):
    for k in range(N):
        for entry in training_data:
            pass

test_pairs = test_template.generate_instances(prediction_length=24)

with Timer("test pairs "):
    for k in range(N):
        for entry in test_pairs:
            pass
```

Before the fix:

```
dataset    : 3.6620118618011475 seconds
training   : 13.0590181350708 seconds
test pairs : 22.129828214645386 seconds
```

After the fix:

```
dataset    : 3.6478400230407715 seconds
training   : 3.8759350776672363 seconds
test pairs : 4.291091203689575 seconds
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup