### PR TITLE
Fix ignore hidden files when generating datasets

### DIFF
--- a/src/gluonts/dataset/common.py
+++ b/src/gluonts/dataset/common.py
@@ -156,7 +156,7 @@ def FileDataset(
     use_timestamp: bool = False,
     loader_class=None,
     ignore=False,
-    pattern="[!._]*",
+    pattern="*",
     levels=1,
 ) -> Dataset:
     path = Path(path)

--- a/src/gluonts/dataset/common.py
+++ b/src/gluonts/dataset/common.py
@@ -156,7 +156,7 @@ def FileDataset(
     use_timestamp: bool = False,
     loader_class=None,
     ignore=False,
-    pattern="*",
+    pattern="[!._]*",
     levels=1,
 ) -> Dataset:
     path = Path(path)

--- a/src/gluonts/dataset/repository/_gp_copula_2019.py
+++ b/src/gluonts/dataset/repository/_gp_copula_2019.py
@@ -161,4 +161,4 @@ def get_data(dataset_path: Path, ds_info: GPCopulaDataset):
 
 def clean_up_dataset(dataset_path: Path, ds_info: GPCopulaDataset):
     os.remove(dataset_path.parent / f"{ds_info.name}.tar.gz")
-    shutil.rmtree(dataset_path / "metadata")
+    shutil.rmtree(dataset_path / "metadata", ignore_errors=True)

--- a/src/gluonts/dataset/repository/_gp_copula_2019.py
+++ b/src/gluonts/dataset/repository/_gp_copula_2019.py
@@ -154,7 +154,7 @@ def get_data(dataset_path: Path, ds_info: GPCopulaDataset):
             "item_id": cat,
         }
         for cat, data_entry in enumerate(
-            FileDataset(dataset_path, freq=ds_info.freq)
+            FileDataset(dataset_path, freq=ds_info.freq, pattern="[!._]*")
         )
     ]
 


### PR DESCRIPTION
the data sets contain ._ json mac osx specific hidden files which get read when regenrating datasets e.g. "taxi_30min"

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup