### PR TITLE
Fix `QuantileForecast.plot()` to use `DateTimeIndex`

### DIFF
--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -7,3 +7,4 @@ ujson
 orjson
 requests
 holidays~=0.9
+matplotlib

--- a/src/gluonts/model/forecast.py
+++ b/src/gluonts/model/forecast.py
@@ -779,14 +779,11 @@ class QuantileForecast(Forecast):
             keys = self.forecast_keys
 
         for k, v in zip(keys, self.forecast_array):
-            plt.plot(
-                self.index,
-                v,
+            pd.Series(data=v, index=self.index.to_timestamp()).plot(
                 label=f"{label_prefix}q{k}",
                 *args,
                 **kwargs,
             )
-            plt.legend()
         if output_file:
             plt.savefig(output_file)
 

--- a/test/model/test_forecast.py
+++ b/test/model/test_forecast.py
@@ -60,6 +60,8 @@ def test_Forecast(name):
     assert len(forecast.index) == pred_length
     assert forecast.index[0] == START_DATE
 
+    forecast.plot()
+
 
 @pytest.mark.parametrize(
     "forecast, exp_index",


### PR DESCRIPTION
*Issue #, if available:* #2268

*Description of changes:* Changed plotting function from `plt.plot()` to `Series.plot()` to be consistent with the superclass and index to `DateTimeIndex`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup