### PR TITLE
Initial TorchServe support for PyTorch-based models.

### DIFF
--- a/src/gluonts/torch/serve/README.md
+++ b/src/gluonts/torch/serve/README.md
@@ -1,0 +1,26 @@
+# GluonTS TorchServe Handlers
+
+GluonTS PyTorch models can be served using TorchServe.
+
+## Packaging Models
+In order to prepare a model for serving with TorchServe, first serialize the predictor with `predictor.serialize(file_name, use_torchscript=True)`.
+
+You can then package the resulting serialzed predictor using the `torch-model-archiver`, e.g.:
+
+    torch-model-archiver --model-name test -v 1 \
+    --serialized-file test_model/prediction_net.pt \
+    --handler /path/to/gluonts/src/gluonts/torch/serve/handler.py \
+    --extra-files test_model/input_transform.json,test_model/parameters.json,test_model/type.txt,test_model/version.json
+
+The resulting test.mar file can then be copied into the TorchServe model store.
+
+You can then make inference requests to the API, e.g.
+
+    curl -X POST \
+    -H "Content-Type: application/json"  \
+    http://localhost:8080/predictions/test \
+    -d '{"target": [1, 2, 3], "start": "2020-01-01"}'
+
+## Customization
+
+You can customize the model output format by subclassing the GluonTSHandler and overriding the `postprocess()` method.

--- a/src/gluonts/torch/serve/handler.py
+++ b/src/gluonts/torch/serve/handler.py
@@ -1,0 +1,56 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from pathlib import Path
+import torch
+from ts.torch_handler.base_handler import BaseHandler
+from gluonts.dataset.common import ListDataset
+from gluonts.torch.model.predictor import PyTorchPredictor
+
+
+class GluonTSHandler(BaseHandler):
+    def initialize(self, context):
+        # Partially copied from BaseHandler::initialize
+        properties = context.system_properties
+        self.map_location = (
+            "cuda"
+            if torch.cuda.is_available()
+            and properties.get("gpu_id") is not None
+            else "cpu"
+        )
+        self.device = torch.device(
+            self.map_location + ":" + str(properties.get("gpu_id"))
+            if torch.cuda.is_available()
+            and properties.get("gpu_id") is not None
+            else self.map_location
+        )
+        self.manifest = context.manifest
+
+        model_dir = properties.get("model_dir")
+        self.predictor = PyTorchPredictor.deserialize(Path(model_dir))
+        self.model = self.predictor.prediction_net
+        self.model.to(self.device)
+        self.model.eval()
+        self.initialized = True
+
+    def inference(self, data, *args, **kwargs):
+        # FIXME: Get freq from model
+        list_dataset = ListDataset(data, freq="1H")
+        return list(self.predictor.predict(list_dataset))
+
+    def preprocess(self, data):
+        return data
+
+    def postprocess(self, data):
+        # FIXME: Return a more complete/configurable response
+        return [dict(mean=fcst.mean.tolist()) for fcst in data]


### PR DESCRIPTION
*Description of changes:*

Add support for exporting `PyTorchPredictor`s into TorchScript and enable serving such models using TorchServe. 

This is rudimentary at this point, and we may want to move the handler directory to the nursery for the time being.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.