### PR TITLE
Add dataset.schema.translate.

### DIFF
--- a/src/gluonts/dataset/common.py
+++ b/src/gluonts/dataset/common.py
@@ -234,7 +234,7 @@ def ListDataset(
     one_dim_target: bool = True,
     use_timestamp: bool = False,
     translate: Optional[dict] = None,
-) -> Dataset:
+) -> List[DataEntry]:
     """
     Dataset backed directly by a list of dictionaries.
 
@@ -251,12 +251,16 @@ def ListDataset(
         Whether to accept only univariate target time series.
     """
 
-    if translate is not None:
-        data_iter = Map(Translator.parse(translate), data_iter)
+    data = list(data_iter)
 
-    return Map(
-        ProcessDataEntry(to_offset(freq), one_dim_target, use_timestamp),
-        list(data_iter),
+    if translate is not None:
+        data = Map(Translator.parse(translate), data)
+
+    return list(
+        Map(
+            ProcessDataEntry(to_offset(freq), one_dim_target, use_timestamp),
+            data,
+        )
     )
 
 

--- a/src/gluonts/dataset/common.py
+++ b/src/gluonts/dataset/common.py
@@ -210,12 +210,12 @@ def _FileDataset(
     )
 
     if translate is not None:
-        dataset: Dataset = Map(Translator.parse(translate), dataset)
+        dataset = cast(Dataset, Map(Translator.parse(translate), dataset))
 
-    dataset: Dataset = Map(process, dataset)
+    dataset = cast(Dataset, Map(process, dataset))
 
     if cache:
-        dataset: Dataset = Cached(dataset)
+        dataset = cast(Dataset, Cached(dataset))
 
     return dataset
 

--- a/src/gluonts/dataset/common.py
+++ b/src/gluonts/dataset/common.py
@@ -220,7 +220,7 @@ def _FileDataset(
     if translate is not None:
         dataset = Map(Translator.parse(translate), dataset)
 
-    dataset: Dataset = Map(process, dataset)
+    dataset = Map(process, dataset)
 
     if cache:
         dataset = Cached(dataset)
@@ -229,7 +229,7 @@ def _FileDataset(
 
 
 def ListDataset(
-    data_iter: Iterable[DataEntry],
+    data_iter: Dataset,
     freq: str,
     one_dim_target: bool = True,
     use_timestamp: bool = False,
@@ -251,15 +251,13 @@ def ListDataset(
         Whether to accept only univariate target time series.
     """
 
-    data = list(data_iter)
-
     if translate is not None:
-        data = Map(Translator.parse(translate), data)
+        data_iter = Map(Translator.parse(translate), data_iter)
 
     return list(
         Map(
             ProcessDataEntry(to_offset(freq), one_dim_target, use_timestamp),
-            data,
+            data_iter,
         )
     )
 

--- a/src/gluonts/dataset/common.py
+++ b/src/gluonts/dataset/common.py
@@ -210,12 +210,12 @@ def _FileDataset(
     )
 
     if translate is not None:
-        dataset = Map(Translator.parse(translate), dataset)
+        dataset: Dataset = Map(Translator.parse(translate), dataset)
 
-    dataset = Map(process, dataset)
+    dataset: Dataset = Map(process, dataset)
 
     if cache:
-        dataset = Cached(dataset)
+        dataset: Dataset = Cached(dataset)
 
     return dataset
 

--- a/src/gluonts/dataset/common.py
+++ b/src/gluonts/dataset/common.py
@@ -206,7 +206,7 @@ def FileDataset(
 
 
 def _FileDataset(
-    dataset,
+    dataset: Dataset,
     freq: str,
     one_dim_target: bool = True,
     cache: bool = False,

--- a/src/gluonts/dataset/common.py
+++ b/src/gluonts/dataset/common.py
@@ -218,7 +218,7 @@ def _FileDataset(
     )
 
     if translate is not None:
-        dataset = Map(Translator.new(translate), dataset)
+        dataset = Map(Translator.parse(translate), dataset)
 
     dataset: Dataset = Map(process, dataset)
 
@@ -252,7 +252,7 @@ def ListDataset(
     """
 
     if translate is not None:
-        data_iter = Map(Translator.new(translate), data_iter)
+        data_iter = Map(Translator.parse(translate), data_iter)
 
     return Map(
         ProcessDataEntry(to_offset(freq), one_dim_target, use_timestamp),

--- a/src/gluonts/dataset/common.py
+++ b/src/gluonts/dataset/common.py
@@ -16,15 +16,7 @@ import logging
 import shutil
 from pathlib import Path
 from types import ModuleType
-from typing import (
-    Callable,
-    Iterable,
-    List,
-    NamedTuple,
-    Optional,
-    Union,
-    cast,
-)
+from typing import Callable, List, NamedTuple, Optional, Union, cast
 
 import numpy as np
 import pandas as pd

--- a/src/gluonts/dataset/schema/__init__.py
+++ b/src/gluonts/dataset/schema/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+from .translate import Translator

--- a/src/gluonts/dataset/schema/__init__.py
+++ b/src/gluonts/dataset/schema/__init__.py
@@ -11,5 +11,6 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+__all__ = ["Translator"]
 
 from .translate import Translator

--- a/src/gluonts/dataset/schema/translate.py
+++ b/src/gluonts/dataset/schema/translate.py
@@ -150,10 +150,6 @@ def check_type(token, ty, val):
     return False
 
 
-def is_boundary(stream):
-    return not stream or stream.peek("DOT") or stream.peek("PARAN_OPEN")
-
-
 @dataclass
 class Parser:
     stream: TokenStream

--- a/src/gluonts/dataset/schema/translate.py
+++ b/src/gluonts/dataset/schema/translate.py
@@ -186,7 +186,11 @@ class Parser:
             dims.append(self.parse_number())
 
         self.stream.pop("PARAN_CLOSE", "]")
-        return GetItem(obj, tuple(dims))
+
+        if len(dims) == 1:
+            return GetItem(obj, dims[0])
+        else:
+            return GetItem(obj, tuple(dims))
 
     def parse_dot(self, obj):
         self.stream.pop("DOT")

--- a/src/gluonts/dataset/schema/translate.py
+++ b/src/gluonts/dataset/schema/translate.py
@@ -106,7 +106,7 @@ class TokenStream:
     TOKENS: ClassVar[dict] = {
         "DOT": re.escape("."),
         "COMMA": re.escape(","),
-        "PARAN_OPEN": one_of("[("),
+        "PAREN_OPEN": one_of("[("),
         "PARAN_CLOSE": one_of("])"),
         "NUMBER": r"\-?\d+",
         "NAME": r"\w+",
@@ -209,7 +209,7 @@ class Parser:
             raise ValueError(f"Invalid token {self.stream.peak()}")
 
     def parse_getitem(self, obj):
-        self.stream.pop("PARAN_OPEN", "[")
+        self.stream.pop("PAREN_OPEN", "[")
 
         dims = [self.parse_number()]
 
@@ -231,14 +231,14 @@ class Parser:
         return GetAttr(obj, name)
 
     def parse_invoke(self, obj):
-        self.stream.pop("PARAN_OPEN", "(")
+        self.stream.pop("PAREN_OPEN", "(")
         args = self.parse_args()
         self.stream.pop("PARAN_CLOSE", ")")
 
         return Method(obj, args)
 
     def parse_expr(self):
-        if self.stream.peek("PARAN_OPEN", "["):
+        if self.stream.peek("PAREN_OPEN", "["):
             self.stream.pop()
             expr = [self.parse_expr()]
 
@@ -256,10 +256,10 @@ class Parser:
             if self.stream.peek("DOT"):
                 obj = self.parse_dot(obj)
 
-            elif self.stream.peek("PARAN_OPEN", "("):
+            elif self.stream.peek("PAREN_OPEN", "("):
                 obj = self.parse_invoke(obj)
 
-            elif self.stream.peek("PARAN_OPEN", "["):
+            elif self.stream.peek("PAREN_OPEN", "["):
                 obj = self.parse_getitem(obj)
 
             else:

--- a/src/gluonts/dataset/schema/translate.py
+++ b/src/gluonts/dataset/schema/translate.py
@@ -160,11 +160,11 @@ class Parser:
     def parse_args(self):
         self.stream.pop("PARAN_OPEN", "(")
 
+        args = []
+
         # no args: `f()`
         if self.stream.peek("PARAN_CLOSE", ")"):
-            return
-
-        args = []
+            return args
 
         while True:
             args.append(self.parse_number())

--- a/test/dataset/schema/test_translate.py
+++ b/test/dataset/schema/test_translate.py
@@ -21,7 +21,7 @@ from gluonts.dataset.schema import Translator
 def test_translate():
     input_data = {"a": np.arange(100).reshape(20, 5)}
 
-    t = Translator.new(b="a.T[0]")
+    t = Translator.parse(b="a.T[0]")
     b = t(input_data)["b"]
 
     assert np.array_equal(b, np.arange(0, 100, 5))
@@ -41,7 +41,7 @@ def test_dataset_translate():
         translate={
             "target": "sales",
             "feat_dynamic_real": "[price, temperature]",
-            "feat_dynamic_real_T": "[price, temperature].T",
+            "feat_dynamic_real_T": "[price, temperature].transpose()",
         },
     ):
         assert entry["target"].shape == (100,)

--- a/test/dataset/schema/test_translate.py
+++ b/test/dataset/schema/test_translate.py
@@ -14,6 +14,7 @@
 import numpy as np
 
 
+from gluonts.dataset.common import ListDataset
 from gluonts.dataset.schema import Translator
 
 
@@ -24,3 +25,25 @@ def test_translate():
     b = t(input_data)["b"]
 
     assert np.array_equal(b, np.arange(0, 100, 5))
+
+
+def test_dataset_translate():
+    input_data = {
+        "sales": np.random.random(100),
+        "start": "2020",
+        "price": np.full(100, 1.5),
+        "temperature": np.full(100, 23),
+    }
+
+    for entry in ListDataset(
+        [input_data],
+        freq="D",
+        translate={
+            "target": "sales",
+            "feat_dynamic_real": "[price, temperature]",
+            "feat_dynamic_real_T": "[price, temperature].T",
+        },
+    ):
+        assert entry["target"].shape == (100,)
+        assert entry["feat_dynamic_real"].shape == (2, 100)
+        assert entry["feat_dynamic_real_T"].shape == (100, 2)

--- a/test/dataset/schema/test_translate.py
+++ b/test/dataset/schema/test_translate.py
@@ -1,0 +1,26 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import numpy as np
+
+
+from gluonts.dataset.schema import Translator
+
+
+def test_translate():
+    input_data = {"a": np.arange(100).reshape(20, 5)}
+
+    t = Translator.new(b="a.T[0]")
+    b = t(input_data)["b"]
+
+    assert np.array_equal(b, np.arange(0, 100, 5))


### PR DESCRIPTION
This implements a solution for #2239

The idea is to define translation steps as strings, which resemble Python expressions:

```py
tl = Translator.new(target="price")
```

What is currently supported is to use some indexing, attribute access and invocation of methods.

Further, passing a list will stack the values.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup