### PR TITLE
Improve `TestData` class in `gluonts.dataset.split`

### DIFF
--- a/src/gluonts/dataset/split.py
+++ b/src/gluonts/dataset/split.py
@@ -408,7 +408,7 @@ class LabelDataset:
         return len(self.test_data)
 
     def __iter__(self):
-        for input_, label in self.test_data:
+        for _input, label in self.test_data:
             yield label
 
 

--- a/src/gluonts/dataset/split.py
+++ b/src/gluonts/dataset/split.py
@@ -253,11 +253,9 @@ class AbstractBaseSplitter(ABC):
                 )
 
                 if max_history is not None:
-                    input = TimeSeriesSlice(test[0])[-max_history:]
+                    yield TimeSeriesSlice(test[0])[-max_history:], test[1]
                 else:
-                    input = test[0]
-
-                yield input, test[1]
+                    yield test[0], test[1]
 
 
 @dataclass
@@ -398,8 +396,8 @@ class InputDataset:
         return len(self.test_data)
 
     def __iter__(self):
-        for input, _ in self.test_data:
-            yield input
+        for input_, label in self.test_data:
+            yield input_
 
 
 @dataclass
@@ -410,7 +408,7 @@ class LabelDataset:
         return len(self.test_data)
 
     def __iter__(self):
-        for _, label in self.test_data:
+        for input_, label in self.test_data:
             yield label
 
 

--- a/src/gluonts/dataset/split.py
+++ b/src/gluonts/dataset/split.py
@@ -334,11 +334,11 @@ class DateSplitter(AbstractBaseSplitter):
 
 
 @dataclass
-class TestDataset:
+class TestData:
     """
     An iterable type used for wrapping test data.
 
-    Elements of a ``TestDataset`` are pairs ``(input, label)``, where
+    Elements of a ``TestData`` object are pairs ``(input, label)``, where
     ``input`` is input data for models, while ``label`` is the future
     ground truth that models are supposed to predict.
 
@@ -378,20 +378,39 @@ class TestDataset:
             max_history=self.max_history,
         )
 
-    @property
-    def input(self) -> Generator[DataEntry, None, None]:
-        """
-        Iterable over the ``input`` portion of the test data.
-        """
-        for input, _ in self:
-            yield input
+    def __len__(self):
+        return len(self.dataset) * self.windows
 
     @property
-    def label(self) -> Generator[DataEntry, None, None]:
-        """
-        Iterable over the ``label`` portion of the test data.
-        """
-        for _, label in self:
+    def input(self) -> "InputDataset":
+        return InputDataset(self)
+
+    @property
+    def label(self) -> "LabelDataset":
+        return LabelDataset(self)
+
+
+@dataclass
+class InputDataset:
+    test_data: TestData
+
+    def __len__(self):
+        return len(self.test_data)
+
+    def __iter__(self):
+        for input, _ in self.test_data:
+            yield input
+
+
+@dataclass
+class LabelDataset:
+    test_data: TestData
+
+    def __len__(self):
+        return len(self.test_data)
+
+    def __iter__(self):
+        for _, label in self.test_data:
             yield label
 
 
@@ -412,14 +431,39 @@ class TestTemplate:
     dataset: Dataset
     splitter: AbstractBaseSplitter
 
-    def generate_instances(self, **kwargs) -> TestDataset:
+    def generate_instances(
+        self,
+        prediction_length: int,
+        windows: int = 1,
+        distance: Optional[int] = None,
+        max_history: Optional[int] = None,
+    ) -> TestData:
         """
         Generate an iterator of test dataset, which includes input part and
         label part.
 
-        Keyword arguments are the same as for :class:`TestDataset`.
+        Parameters
+        ----------
+        prediction_length
+            Length of the prediction interval in test data.
+        windows
+            Indicates how many test windows to generate for each original
+            dataset entry.
+        distance
+            This is rather the difference between the start of each test
+            window generated, for each of the original dataset entries.
+        max_history
+            If given, all entries in the *test*-set have a max-length of
+            `max_history`. This can be used to produce smaller file-sizes.
         """
-        return TestDataset(self.dataset, self.splitter, **kwargs)
+        return TestData(
+            self.dataset,
+            self.splitter,
+            prediction_length,
+            windows,
+            distance,
+            max_history,
+        )
 
 
 @dataclass

--- a/src/gluonts/dataset/split.py
+++ b/src/gluonts/dataset/split.py
@@ -396,8 +396,8 @@ class InputDataset:
         return len(self.test_data)
 
     def __iter__(self):
-        for input_, label in self.test_data:
-            yield input_
+        for input, _label in self.test_data:
+            yield input
 
 
 @dataclass


### PR DESCRIPTION
*Description of changes:* This makes the `TestData` (formerly `TestDataset`) output proper iterable objects (effectively, `Dataset`) when asked for the `input` and `label` portions of the test data.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup