### PR TITLE
Fix numerical bug in `BinnedUniforms`

### DIFF
--- a/src/gluonts/torch/distributions/binned_uniforms.py
+++ b/src/gluonts/torch/distributions/binned_uniforms.py
@@ -268,7 +268,8 @@ class BinnedUniforms(Distribution):
         # including the bin (upper)
         incomplete_cdf_upper = bins_prob.cumsum(dim=-1)
         # incomplete_cdf_upper.shape: (*batch_shape, numb_bins)
-        incomplete_cdf_lower = bins_prob.cumsum(dim=-1) - bins_prob
+        incomplete_cdf_lower = torch.zeros_like(incomplete_cdf_upper)
+        incomplete_cdf_lower[..., 1:] = incomplete_cdf_upper[..., :-1]
         # incomplete_cdf_lower.shape: (*batch_shape, numb_bins)
 
         one_hot_bin_indicator = (incomplete_cdf_lower <= quantiles) * (


### PR DESCRIPTION
Computing prob.cumsum() - prob is a numerically unsafe way to shift prob.cumsum() to the right. The numerical error will create small gaps or overlaps in the windows defined by the lower and upper tensors. If a quantile falls in one of these overlap or gap the one hot bin indicator will have 0 or 2 hot bins and generate a shape mismatch error. 

*Issue #, if available:*

*Description of changes:*

The fix consists of doing a shift by copy.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup

#bug fix