### PR TITLE
Consistent use of term "prediction interval"

### DIFF
--- a/docs/getting_started/background.md
+++ b/docs/getting_started/background.md
@@ -104,7 +104,7 @@ that there is probably a demand of say 50 dishes, but unlikely more than 60.
 ```{figure} ../_static/forecast-distributions.png
 ---
 ---
-Predicting 24 hours, showing `p50`, `p90`, `p95`, `p98` confidence intervals.
+Predicting 24 hours, showing `p50`, `p90`, `p95`, `p98` prediction intervals.
 ```
 
 ```{note}

--- a/src/gluonts/evaluation/_base.py
+++ b/src/gluonts/evaluation/_base.py
@@ -117,7 +117,7 @@ class Evaluator:
         for the given series frequency as returned by `get_seasonality`
     alpha
         Parameter of the MSIS metric from the M4 competition that
-        defines the confidence interval.
+        defines the prediction interval.
         For alpha=0.05 (default) the 95% considered is considered in the
         metric, see
         https://www.m4.unic.ac.cy/wp-content/uploads/2018/03/M4-Competitors-Guide.pdf

--- a/src/gluonts/model/forecast.py
+++ b/src/gluonts/model/forecast.py
@@ -341,14 +341,14 @@ class Forecast:
         **kwargs,
     ):
         """
-        Plots the median of the forecast as well as confidence bounds.
+        Plots the median of the forecast as well as prediction interval bounds
         (requires matplotlib and pandas).
 
         Parameters
         ----------
         prediction_intervals : float or list of floats in [0, 100]
-            Confidence interval size(s). If a list, it will stack the error
-            plots for each confidence interval. Only relevant for error styles
+            Prediction interval size(s). If a list, it will stack the error
+            plots for each prediction interval. Only relevant for error styles
             with "ci" in the name.
         show_mean : boolean
             Whether to also show the mean of the forecast.

--- a/src/gluonts/model/naive_2/_predictor.py
+++ b/src/gluonts/model/naive_2/_predictor.py
@@ -34,7 +34,7 @@ def seasonality_test(past_ts_data: np.array, season_length: int) -> bool:
     Code based on:
     https://github.com/Mcompetitions/M4-methods/blob/master/Benchmarks%20and%20Evaluation.R
     """
-    critical_z_score = 1.645  # corresponds to 90% confidence interval
+    critical_z_score = 1.645  # corresponds to 90% prediction interval
     if len(past_ts_data) < 3 * season_length:
         return False
     else:


### PR DESCRIPTION
*Description of changes:*
The term "confidence interval" is sometimes used when "prediction interval" is meant, as was mentioned in #2372. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.