### PR TITLE
Fix SmoothSeasonality Sine Wave Generation.

### DIFF
--- a/src/gluonts/dataset/artificial/recipe.py
+++ b/src/gluonts/dataset/artificial/recipe.py
@@ -803,7 +803,7 @@ class SmoothSeasonality(Lifted):
         period = resolve(self.period, x, length, *args, **kwargs)
         phase = resolve(self.phase, x, length, *args, **kwargs)
         return (
-            np.sin(2.0 / period * np.pi * (np.arange(length) + phase)) + 1
+            np.sin(2.0 * np.pi * (1 / period) * np.arange(length) + phase) + 1
         ) / 2.0
 
 


### PR DESCRIPTION
*Issue #, if available:*
No associated issue.

*Description of changes:*
There was a small error in the code for generating synthetic seasonal data using `rcp.SmoothSeasonality`. In short, the phase parameter was being using incorrectly, not following the standard formula for a sine curve (see [here](https://en.wikipedia.org/wiki/Sine_wave)). The code has been updated to match the correct formula.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.