### PR TITLE
Fix `MQCNN` ignoring zero-seed. (#2378)

### DIFF
--- a/src/gluonts/mx/model/seq2seq/_mq_dnn_estimator.py
+++ b/src/gluonts/mx/model/seq2seq/_mq_dnn_estimator.py
@@ -87,7 +87,7 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
         It makes sense to disable this, if you don't have ``feat_dynamic_real``
         for the prediction range.
     seed
-        Will set the specified int seed for numpy anc MXNet if specified.
+        Will set the specified int seed for numpy and MXNet if specified.
         (default: None)
     decoder_mlp_dim_seq
         The dimensionalities of the Multi Layer Perceptron layers of the
@@ -217,7 +217,7 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
             f"{len(self.dilation_seq)} vs. {len(self.kernel_size_seq)}"
         )
 
-        if seed:
+        if seed is not None:
             np.random.seed(seed)
             mx.random.seed(seed, trainer.ctx)
 


### PR DESCRIPTION
Fixes: https://github.com/awslabs/gluonts/issues/2378

*Description of changes:*
- Fix to how we check whether a seed has been given as input so integer 0 is also used. 
- Small typo fix.

Seeded with 0 output is now:
```
0th run:

100%|██████████████████████████████████| 50/50 [00:12<00:00,  4.00it/s, epoch=1/2, avg_epoch_loss=0.484]
100%|████████████████████████████████████| 50/50 [00:12<00:00,  4.00it/s, epoch=2/2, avg_epoch_loss=0.3]

1th run:

100%|██████████████████████████████████| 50/50 [00:12<00:00,  4.01it/s, epoch=1/2, avg_epoch_loss=0.484]
100%|████████████████████████████████████| 50/50 [00:12<00:00,  4.04it/s, epoch=2/2, avg_epoch_loss=0.3]
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** bug fix