### PR TITLE
Exposing the choice of train_sampler and validation_sampler for MQCNN and MQRNN 

### DIFF
--- a/src/gluonts/mx/model/seq2seq/_mq_dnn_estimator.py
+++ b/src/gluonts/mx/model/seq2seq/_mq_dnn_estimator.py
@@ -142,7 +142,8 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
         The size of the batches to be used training and prediction.
     train_sampler
         Controls the sampling of windows during training.
-
+    validation_sampler
+        Controls the sampling of windows during validation.
     """
 
     @validated()
@@ -176,6 +177,7 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
         is_iqf: bool = True,
         batch_size: int = 32,
         train_sampler: Optional[InstanceSampler] = None,
+        validation_sampler: Optional[InstanceSampler] = None,
     ) -> None:
 
         assert (distr_output is None) or (quantiles is None)
@@ -279,6 +281,7 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
             num_forking=num_forking,
             max_ts_len=max_ts_len,
             train_sampler=train_sampler,
+            validation_sampler=validation_sampler,
             batch_size=batch_size,
         )
 
@@ -373,6 +376,7 @@ class MQRNNEstimator(ForkingSeq2SeqEstimator):
         is_iqf: bool = True,
         batch_size: int = 32,
         train_sampler: Optional[InstanceSampler] = None,
+        validation_sampler: Optional[InstanceSampler] = None,
     ) -> None:
 
         assert (
@@ -434,5 +438,6 @@ class MQRNNEstimator(ForkingSeq2SeqEstimator):
             scaling_decoder_dynamic_feature=scaling_decoder_dynamic_feature,
             num_forking=num_forking,
             train_sampler=train_sampler,
+            validation_sampler=validation_sampler,
             batch_size=batch_size,
         )

--- a/src/gluonts/mx/model/seq2seq/_mq_dnn_estimator.py
+++ b/src/gluonts/mx/model/seq2seq/_mq_dnn_estimator.py
@@ -31,6 +31,7 @@ from gluonts.mx.block.quantile_output import (
 )
 from gluonts.mx.distribution import DistributionOutput
 from gluonts.mx.trainer import Trainer
+from gluonts.transform import InstanceSampler
 
 from ._forking_estimator import ForkingSeq2SeqEstimator
 
@@ -40,6 +41,10 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
     An :class:`MQDNNEstimator` with a Convolutional Neural Network (CNN) as an
     encoder and a multi-quantile MLP as a decoder. Implements the MQ-CNN
     Forecaster, proposed in [WTN+17]_.
+
+    Note that MQCNN uses ValidationSplitSampler as its default
+    train_sampler. If context_length is less than the length of the input 
+    time series, only one example will be used for training. 
 
     Parameters
     ----------
@@ -135,6 +140,9 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
         Determines whether to use IQF or QF. (default: True).
     batch_size
         The size of the batches to be used training and prediction.
+    train_sampler
+        Controls the sampling of windows during training.
+        
     """
 
     @validated()
@@ -167,6 +175,7 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
         max_ts_len: Optional[int] = None,
         is_iqf: bool = True,
         batch_size: int = 32,
+        train_sampler: Optional[InstanceSampler] = None,
     ) -> None:
 
         assert (distr_output is None) or (quantiles is None)
@@ -269,6 +278,7 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
             scaling_decoder_dynamic_feature=scaling_decoder_dynamic_feature,
             num_forking=num_forking,
             max_ts_len=max_ts_len,
+            train_sampler=train_sampler,
             batch_size=batch_size,
         )
 
@@ -341,6 +351,10 @@ class MQRNNEstimator(ForkingSeq2SeqEstimator):
     encoder and a multi-quantile MLP as a decoder.
 
     Implements the MQ-RNN Forecaster, proposed in [WTN+17]_.
+
+    Note that MQRNN uses ValidationSplitSampler as its default
+    train_sampler. If context_length is less than the length of the input 
+    time series, only one example will be used for training. 
     """
 
     @validated()
@@ -358,6 +372,7 @@ class MQRNNEstimator(ForkingSeq2SeqEstimator):
         num_forking: Optional[int] = None,
         is_iqf: bool = True,
         batch_size: int = 32,
+        train_sampler: Optional[InstanceSampler] = None,
     ) -> None:
 
         assert (
@@ -418,5 +433,6 @@ class MQRNNEstimator(ForkingSeq2SeqEstimator):
             scaling=scaling,
             scaling_decoder_dynamic_feature=scaling_decoder_dynamic_feature,
             num_forking=num_forking,
+            train_sampler=train_sampler,
             batch_size=batch_size,
         )

--- a/src/gluonts/mx/model/seq2seq/_mq_dnn_estimator.py
+++ b/src/gluonts/mx/model/seq2seq/_mq_dnn_estimator.py
@@ -43,8 +43,8 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
     Forecaster, proposed in [WTN+17]_.
 
     Note that MQCNN uses ValidationSplitSampler as its default
-    train_sampler. If context_length is less than the length of the input 
-    time series, only one example will be used for training. 
+    train_sampler. If context_length is less than the length of the input
+    time series, only one example will be used for training.
 
     Parameters
     ----------
@@ -142,7 +142,7 @@ class MQCNNEstimator(ForkingSeq2SeqEstimator):
         The size of the batches to be used training and prediction.
     train_sampler
         Controls the sampling of windows during training.
-        
+
     """
 
     @validated()
@@ -353,8 +353,8 @@ class MQRNNEstimator(ForkingSeq2SeqEstimator):
     Implements the MQ-RNN Forecaster, proposed in [WTN+17]_.
 
     Note that MQRNN uses ValidationSplitSampler as its default
-    train_sampler. If context_length is less than the length of the input 
-    time series, only one example will be used for training. 
+    train_sampler. If context_length is less than the length of the input
+    time series, only one example will be used for training.
     """
 
     @validated()

--- a/src/gluonts/mx/trainer/_base.py
+++ b/src/gluonts/mx/trainer/_base.py
@@ -371,12 +371,16 @@ class Trainer:
 
                 if not any_batches:
                     if is_training:
-                        error_data_type = 'training'
+                        error_data_type = "training"
                     else:
-                        error_data_type = 'validation'
+                        error_data_type = "validation"
                     raise GluonTSDataError(
-                        "No " + error_data_type + " data batch could be constructed; "
-                        "this usually indicates that the " + error_data_type + " dataset "
+                        "No "
+                        + error_data_type
+                        + " data batch could be constructed; "
+                        "this usually indicates that the "
+                        + error_data_type
+                        + " dataset "
                         "is empty, or consists of too short series."
                         " If using a random data sampler, this might "
                         "be caused by not taking enough samples."

--- a/src/gluonts/mx/trainer/_base.py
+++ b/src/gluonts/mx/trainer/_base.py
@@ -370,10 +370,16 @@ class Trainer:
                 it.close()
 
                 if not any_batches:
+                    if is_training:
+                        error_data_type = 'training'
+                    else:
+                        error_data_type = 'validation'
                     raise GluonTSDataError(
-                        "No training data batch could be constructed; "
-                        "this usually indicates that the training dataset "
+                        "No " + error_data_type + " data batch could be constructed; "
+                        "this usually indicates that the " + error_data_type + " dataset "
                         "is empty, or consists of too short series."
+                        " If using a random data sampler, this might "
+                        "be caused by not taking enough samples."
                     )
 
                 # mark epoch end time and log time cost of current epoch


### PR DESCRIPTION
Fixes: https://github.com/awslabs/gluonts/issues/2380

*Description of changes:*
- Lets the user specify what sampler they want to use for the MQCNN and MQRNN models, keeping the default as before. 
- Adding comment to docstring describing default behaviour.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** other change