### PR TITLE
Add hierarchical time series reconciliation methods from R/hts: top-down and middle-out

### DIFF
--- a/src/gluonts/ext/r_forecast/R/hierarchical_forecast_methods.R
+++ b/src/gluonts/ext/r_forecast/R/hierarchical_forecast_methods.R
@@ -12,3 +12,57 @@ naive_bottom_up <- function(hts, params) {
     )
     aggts(fcasts1.bu)
 }
+
+top_down_w_average_historical_proportions <- function(hts, params) {
+    h <- params$prediction_length
+    fmethod <- params$fmethod
+    fcasts1.td <- forecast(
+      hts,
+      h = h,
+      method="tdgsa",
+      fmethod = fmethod,
+      parallel = TRUE,
+    )
+    aggts(fcasts1.td)
+}
+
+top_down_w_proportions_of_the_historical_averages <- function(hts, params) {
+    h <- params$prediction_length
+    fmethod <- params$fmethod
+    fcasts1.td <- forecast(
+      hts,
+      h = h,
+      method="tdgsf",
+      fmethod = fmethod,
+      parallel = TRUE,
+    )
+    aggts(fcasts1.td)
+}
+
+top_down_w_forecasts_proportions <- function(hts, params) {
+    h <- params$prediction_length
+    fmethod <- params$fmethod
+    fcasts1.td <- forecast(
+      hts,
+      h = h,
+      method="tdfp",
+      fmethod = fmethod,
+      parallel = TRUE,
+    )
+    aggts(fcasts1.td)
+}
+
+middle_out_w_forecasts_proportions <- function(hts, params) {
+    h <- params$prediction_length
+    fmethod <- params$fmethod
+    level <- params$level
+    fcasts1.mo <- forecast(
+      hts,
+      h = h,
+      method="mo",
+      fmethod = fmethod,
+      parallel = TRUE,
+      level = level
+    )
+    aggts(fcasts1.mo)
+}

--- a/src/gluonts/ext/r_forecast/_hierarchical_predictor.py
+++ b/src/gluonts/ext/r_forecast/_hierarchical_predictor.py
@@ -26,6 +26,10 @@ R_FILE_PREFIX = "hierarchical"
 
 HIERARCHICAL_POINT_FORECAST_METHODS = [
     "naive_bottom_up",
+    "top_down_w_average_historical_proportions",
+    "top_down_w_proportions_of_the_historical_averages",
+    "top_down_w_forecasts_proportions",
+    "middle_out_w_forecasts_proportions",
     # TODO: "mint",
     # TODO: "erm",
     # TODO: "ermParallel",
@@ -99,6 +103,7 @@ class RHierarchicalForecastPredictor(RBasePredictor):
         period: int = None,
         trunc_length: Optional[int] = None,
         params: Optional[Dict] = None,
+        level: Optional[int] = None,
     ) -> None:
 
         super().__init__(
@@ -129,6 +134,7 @@ class RHierarchicalForecastPredictor(RBasePredictor):
             "frequency": self.period,
             "fmethod": fmethod,
             "nonnegative": nonnegative,
+            "level": level
         }
         if params is not None:
             self.params.update(params)

--- a/src/gluonts/ext/r_forecast/_hierarchical_predictor.py
+++ b/src/gluonts/ext/r_forecast/_hierarchical_predictor.py
@@ -73,7 +73,8 @@ class RHierarchicalForecastPredictor(RBasePredictor):
         Is the target non-negative?
     method_name
         Hierarchical forecasting or reconciliation method to be used; mutst be one of:
-        "mint", "naive_bottom_up", "erm", "mint_ols", "depbu_mint", "ermParallel"
+        "naive_bottom_up", "middle_out_w_forecasts_proportions", "top_down_w_average_historical_proportions",
+        "top_down_w_proportions_of_the_historical_averages", "top_down_w_forecasts_proportions",
     fmethod
         The forecasting method to be used for generating base forecasts (i.e., un-reconciled forecasts).
     period
@@ -86,6 +87,10 @@ class RHierarchicalForecastPredictor(RBasePredictor):
     params
         Parameters to be used when calling the forecast method default.
         Note that, as `output_type`, only 'samples' is supported currently.
+    level
+        Level of hierarchy to be used as reference for `middle out` reconciliation (i.e. level=1 means that the level
+        below the highest one will be used as reference to compute the forecasts of all the other levels). This value
+        is required only for `middle out`.
     """
 
     @validated()

--- a/src/gluonts/ext/r_forecast/_hierarchical_predictor.py
+++ b/src/gluonts/ext/r_forecast/_hierarchical_predictor.py
@@ -134,8 +134,11 @@ class RHierarchicalForecastPredictor(RBasePredictor):
             "frequency": self.period,
             "fmethod": fmethod,
             "nonnegative": nonnegative,
-            "level": level
         }
+
+        if level:
+            self.params["level"] = level
+
         if params is not None:
             self.params.update(params)
         self.is_hts = is_hts


### PR DESCRIPTION
*Description of changes:*

Addition of top-down and middle-out reconciliation methods for hierarchical time series, as done in R/hts package.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster: feature** 