### PR TITLE
Fix rotbaum random seed and `num_samples` argument.

### DIFF
--- a/src/gluonts/ext/rotbaum/_preprocess.py
+++ b/src/gluonts/ext/rotbaum/_preprocess.py
@@ -45,6 +45,7 @@ class PreprocessGeneric:
         n_ignore_last: int = 0,
         max_n_datapts: int = 400000,
         seed: Optional[int] = None,
+        num_samples: Optional[int] = None,
         **kwargs
     ):
         """
@@ -80,10 +81,10 @@ class PreprocessGeneric:
         self.n_ignore_last = n_ignore_last
         self.max_n_datapts = max_n_datapts
         self.kwargs = kwargs
-        self.num_samples = None
+        self.num_samples = num_samples
         self.feature_data = None
         self.target_data = None
-        if seed:
+        if seed is not None:
             np.random.seed(seed)
 
     def make_features(self, time_series, starting_index):


### PR DESCRIPTION
*Issue #, if available:*
Fixes #2407
*Description of changes:*
Fix so `0` is recognised as a seed. 
Fix so `num_samples` is recognised as an input. 

Updated code output:
```
([[0.0, 49.0, 0.0, 1, 0],
  [0.0, 8.0, 0.0, 1, 0],
  [0.0, 10.0, 0.0, 1, 0],
  [0.0, 8.0, 0.0, 1, 0]],
 [array([22.], dtype=float32),
  array([11.], dtype=float32),
  array([9.], dtype=float32),
  array([4.], dtype=float32)])
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup