### PR TITLE
`TrainDatasets` vs. `TrainingDataset` and `TestData`

### DIFF
--- a/src/gluonts/dataset/split.py
+++ b/src/gluonts/dataset/split.py
@@ -209,11 +209,11 @@ class TimeSeriesSlice:
 
 class AbstractBaseSplitter(ABC):
     """
-    Base class for all other splitter.
+    Base class for all other splitters.
     """
 
     @abstractmethod
-    def training_entry(self, entry: DataEntry) -> DataEntry:
+    def split_entry(self, entry: DataEntry) -> DataEntry:
         pass
 
     @abstractmethod
@@ -224,16 +224,16 @@ class AbstractBaseSplitter(ABC):
 
     def split(
         self, dataset: Dataset
-    ) -> Tuple["TrainingDataset", "TestTemplate"]:
+    ) -> Tuple["DatasetSplit", "TestTemplate"]:
         return (
-            TrainingDataset(dataset=dataset, splitter=self),
+            DatasetSplit(dataset=dataset, splitter=self),
             TestTemplate(dataset=dataset, splitter=self),
         )
 
-    def generate_training_entries(
+    def generate_split_entries(
         self, dataset: Dataset
     ) -> Generator[DataEntry, None, None]:
-        yield from map(self.training_entry, dataset)
+        yield from map(self.split_entry, dataset)
 
     def generate_test_pairs(
         self,
@@ -277,7 +277,7 @@ class OffsetSplitter(AbstractBaseSplitter):
 
     offset: int
 
-    def training_entry(self, entry: DataEntry) -> DataEntry:
+    def split_entry(self, entry: DataEntry) -> DataEntry:
         return TimeSeriesSlice(entry)[: self.offset]
 
     def test_pair(
@@ -317,7 +317,7 @@ class DateSplitter(AbstractBaseSplitter):
 
     date: pd.Period
 
-    def training_entry(self, entry: DataEntry) -> DataEntry:
+    def split_entry(self, entry: DataEntry) -> DataEntry:
         return TimeSeriesSlice(entry)[: self.date]
 
     def test_pair(
@@ -438,7 +438,7 @@ class TestTemplate:
     dataset:
         Whole dataset used for testing.
     splitter:
-        A specific splitter that knows how to slices training and
+        A specific splitter that knows how to slice training and
         test data.
     """
 
@@ -481,12 +481,12 @@ class TestTemplate:
 
 
 @dataclass
-class TrainingDataset:
+class DatasetSplit:
     dataset: Dataset
     splitter: AbstractBaseSplitter
 
     def __iter__(self) -> Generator[DataEntry, None, None]:
-        return self.splitter.generate_training_entries(self.dataset)
+        return self.splitter.generate_split_entries(self.dataset)
 
     def __len__(self) -> int:
         return len(self.dataset)
@@ -494,7 +494,7 @@ class TrainingDataset:
 
 def split(
     dataset: Dataset, *, offset: int = None, date: pd.Period = None
-) -> Tuple[TrainingDataset, TestTemplate]:
+) -> Tuple[DatasetSplit, TestTemplate]:
     assert (offset is None) != (
         date is None
     ), "You need to provide ``offset`` or ``date``, but not both."

--- a/src/gluonts/dataset/split.py
+++ b/src/gluonts/dataset/split.py
@@ -84,7 +84,7 @@ from gluonts.dataset.common import TrainDatasets
 
 def to_positive_slice(slice_: slice, length: int) -> slice:
     """
-    Return an equivalent slice with positive bounds, given the
+    Returns an equivalent slice with positive bounds, given the
     length of the sequence it will apply to.
     """
     start, stop = slice_.start, slice_.stop
@@ -222,9 +222,7 @@ class AbstractBaseSplitter(ABC):
     ) -> Tuple[DataEntry, DataEntry]:
         pass
 
-    def split(
-        self, dataset: Dataset
-    ) -> Tuple["DatasetSplit", "TestTemplate"]:
+    def split(self, dataset: Dataset) -> Tuple["DatasetSplit", "TestTemplate"]:
         return (
             DatasetSplit(dataset=dataset, splitter=self),
             TestTemplate(dataset=dataset, splitter=self),
@@ -389,7 +387,7 @@ class TestData:
         return LabelDataset(self)
 
     @classmethod
-    def from_TrainDatasets(self, train_dataset: TrainDatasets) -> "TestData":
+    def from_TrainDatasets(cls, train_dataset: TrainDatasets) -> "TestData":
         prediction_length = train_dataset.metadata.prediction_length
 
         test_template = TestTemplate(

--- a/src/gluonts/dataset/split.py
+++ b/src/gluonts/dataset/split.py
@@ -79,6 +79,7 @@ import pandas as pd
 
 from gluonts.dataset import Dataset, DataEntry
 from gluonts.dataset.field_names import FieldName
+from gluonts.dataset.common import TrainDatasets
 
 
 def to_positive_slice(slice_: slice, length: int) -> slice:
@@ -386,6 +387,21 @@ class TestData:
     @property
     def label(self) -> "LabelDataset":
         return LabelDataset(self)
+
+    @classmethod
+    def from_TrainDatasets(self, train_dataset: TrainDatasets) -> "TestData":
+        prediction_length = train_dataset.metadata.prediction_length
+
+        test_template = TestTemplate(
+            dataset=train_dataset.test,
+            splitter=OffsetSplitter(offset=-prediction_length),
+        )
+
+        test_data = test_template.generate_instances(
+            prediction_length=prediction_length
+        )
+
+        return test_data
 
 
 @dataclass


### PR DESCRIPTION
*Description of changes:*

The datasets provided by GluonTS come in the form of `TrainDatasets`. Recently (starting with #2223), `TrainingDataset` and `TestData` were introduced.

Bridging the gap is a bit tedious as we have to do something like this:

```
dataset = get_dataset("electricity")

prediction_length = dataset.metadata.prediction_length

training_dataset = split(dataset.train, offset=-prediction_length)[0]
test_dataset = split(dataset.test, offset=-prediction_length)[1].generate_instances(prediction_length=prediction_length)
```

To at least make the translation from `TrainDatasets` to `TestData` easier, maybe something like `from_TrainDatasets` (see commit) can be useful because `TrainDatasets` always split by an offset of `prediction_length`.

I'm not super convinced of this myself as it entangles the two approaches more rather than leading to clarity. But maybe this can start a discussion of how training and test data should be dealt with in the future.

Is the plan to switch entirely to the new way eventually?


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup