### PR TITLE
Hierarchical: Make sure the input S matrix is of right dtype

### DIFF
--- a/src/gluonts/mx/model/deepvar_hierarchical/_estimator.py
+++ b/src/gluonts/mx/model/deepvar_hierarchical/_estimator.py
@@ -283,7 +283,7 @@ class DeepVARHierarchicalEstimator(DeepVAREstimator):
             not coherent_train_samples
         ), "Cannot project only during training (and not during prediction)"
 
-        A = constraint_mat(S)
+        A = constraint_mat(S.astype(self.dtype))
         M = null_space_projection_mat(A)
         self.M, self.A = mx.nd.array(M), mx.nd.array(A)
         self.num_samples_for_loss = num_samples_for_loss


### PR DESCRIPTION
Issue #2405

*Description of changes:*

The input aggregation matrix `S` may have wrong `dtype`, which will result in an incorrect projection matrix. This PR makes sure the input `S` has the right `dtype`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup