### PR TITLE
Make serde.dataclass always kw-only.

### DIFF
--- a/src/gluonts/core/serde/_dataclass.py
+++ b/src/gluonts/core/serde/_dataclass.py
@@ -221,14 +221,9 @@ def _dataclass(
 
     orig_init = dc.__init__
 
-    def _init_(self, *args, **kwargs):
-        # assert len(args) <= len(fields), "Too many arguments"
-        # assert len(args) + len(kwargs) <= len(fields)
-
-        input_kwargs = {
-            field_name: arg for arg, field_name in zip(args, fields)
-        }
-        input_kwargs.update(kwargs)
+    def _init_(self, *args, **input_kwargs):
+        if args:
+            raise TypeError("serde.dataclass is always `kw_only`.")
 
         validated_model = model(**input_kwargs)
         init_kwargs = validated_model.dict()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup