### PR TITLE
Better DeepAR lags for business day frequency time series.

### DIFF
--- a/src/gluonts/time_feature/lag.py
+++ b/src/gluonts/time_feature/lag.py
@@ -115,7 +115,6 @@ def get_lags_for_frequency(
             offset.n / 7.0
         )
     elif offset_name == "B":
-        # todo find good lags for business day
         lags = _make_lags_for_day(
             offset.n, days_in_week=5, days_in_month=22
         ) + _make_lags_for_week(offset.n / 5.0)

--- a/src/gluonts/time_feature/lag.py
+++ b/src/gluonts/time_feature/lag.py
@@ -71,12 +71,15 @@ def get_lags_for_frequency(
             _make_lags(k * 24 // multiple, 1) for k in range(1, num_cycles + 1)
         ]
 
-    def _make_lags_for_day(multiple, num_cycles=4):
+    def _make_lags_for_day(
+        multiple, num_cycles=4, days_in_week=7, days_in_month=30
+    ):
         # We use previous ``num_cycles`` weeks to generate lags
         # We use the last month (in addition to 4 weeks) to generate lag.
         return [
-            _make_lags(k * 7 // multiple, 1) for k in range(1, num_cycles + 1)
-        ] + [_make_lags(30 // multiple, 1)]
+            _make_lags(k * days_in_week // multiple, 1)
+            for k in range(1, num_cycles + 1)
+        ] + [_make_lags(days_in_month // multiple, 1)]
 
     def _make_lags_for_week(multiple, num_cycles=3):
         # We use previous ``num_cycles`` years to generate lags
@@ -113,7 +116,9 @@ def get_lags_for_frequency(
         )
     elif offset_name == "B":
         # todo find good lags for business day
-        lags = []
+        lags = _make_lags_for_day(
+            offset.n, days_in_week=5, days_in_month=22
+        ) + _make_lags_for_week(offset.n / 5.0)
     elif offset_name == "H":
         lags = (
             _make_lags_for_hour(offset.n)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently the default lags for the DeepAR model on business day frequency data is just [1, 2, 3, 4, 5, 6, 7]. This pull request implements a version of the lags for daily data, but assuming 5 days in a week and 22 days in a month.

It ignores that not all Mondays-Fridays are business days.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup