### PR TITLE
Add cdf and icdf methods for StudentT distribution

### DIFF
--- a/src/gluonts/torch/distributions/__init__.py
+++ b/src/gluonts/torch/distributions/__init__.py
@@ -21,7 +21,6 @@ from .distribution_output import (
     NegativeBinomialOutput,
     NormalOutput,
     PoissonOutput,
-    StudentTOutput,
 )
 from .generalized_pareto import GeneralizedPareto, GeneralizedParetoOutput
 from .implicit_quantile_network import (
@@ -35,6 +34,7 @@ from .spliced_binned_pareto import (
     SplicedBinnedPareto,
     SplicedBinnedParetoOutput,
 )
+from .studentT import StudentTOutput
 
 __all__ = [
     "AffineTransformed",

--- a/src/gluonts/torch/distributions/distribution_output.py
+++ b/src/gluonts/torch/distributions/distribution_output.py
@@ -24,7 +24,6 @@ from torch.distributions import (
     NegativeBinomial,
     Normal,
     Poisson,
-    StudentT,
 )
 
 from gluonts.core.component import validated
@@ -184,23 +183,6 @@ class NormalOutput(DistributionOutput):
     def domain_map(cls, loc: torch.Tensor, scale: torch.Tensor):
         scale = F.softplus(scale)
         return loc.squeeze(-1), scale.squeeze(-1)
-
-    @property
-    def event_shape(self) -> Tuple:
-        return ()
-
-
-class StudentTOutput(DistributionOutput):
-    args_dim: Dict[str, int] = {"df": 1, "loc": 1, "scale": 1}
-    distr_cls: type = StudentT
-
-    @classmethod
-    def domain_map(
-        cls, df: torch.Tensor, loc: torch.Tensor, scale: torch.Tensor
-    ):
-        scale = F.softplus(scale)
-        df = 2.0 + F.softplus(df)
-        return df.squeeze(-1), loc.squeeze(-1), scale.squeeze(-1)
 
     @property
     def event_shape(self) -> Tuple:

--- a/src/gluonts/torch/distributions/studentT.py
+++ b/src/gluonts/torch/distributions/studentT.py
@@ -22,8 +22,8 @@ from .distribution_output import DistributionOutput
 
 
 class StudentT(TorchStudentT):
-    """Student's t-distribution parametrized by degree of freedom `df`, mean `loc`
-    and scale `scale`.
+    """Student's t-distribution parametrized by degree of freedom `df`,
+    mean `loc` and scale `scale`.
 
     Based on torch.distributions.StudentT, with added `cdf` and `icdf` methods.
     """

--- a/src/gluonts/torch/distributions/studentT.py
+++ b/src/gluonts/torch/distributions/studentT.py
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Union
 
 import torch
 import torch.nn.functional as F
@@ -27,7 +27,13 @@ class StudentT(TorchStudentT):
     Based on torch.distributions.StudentT, but additionally implements `cdf` and `icdf` methods.
     """
 
-    def __init__(self, df, loc=0.0, scale=1.0, validate_args=None):
+    def __init__(
+        self,
+        df: Union[float, torch.Tensor],
+        loc: Union[float, torch.Tensor] = 0.0,
+        scale: Union[float, torch.Tensor] = 1.0,
+        validate_args=None,
+    ):
         super().__init__(
             df=df, loc=loc, scale=scale, validate_args=validate_args
         )
@@ -36,13 +42,13 @@ class StudentT(TorchStudentT):
         scale = self.scale.detach().cpu().numpy()
         self.scipy_student_t = ScipyStudentT(df=df, loc=loc, scale=scale)
 
-    def cdf(self, value):
+    def cdf(self, value: torch.Tensor) -> torch.Tensor:
         if self._validate_args:
             self._validate_sample(value)
         result = self.scipy_student_t.cdf(value.detach().cpu().numpy())
         return torch.tensor(result, device=value.device, dtype=value.dtype)
 
-    def icdf(self, value: torch.Tensor):
+    def icdf(self, value: torch.Tensor) -> torch.Tensor:
         result = self.scipy_student_t.ppf(value.detach().cpu().numpy())
         return torch.tensor(result, device=value.device, dtype=value.dtype)
 

--- a/src/gluonts/torch/distributions/studentT.py
+++ b/src/gluonts/torch/distributions/studentT.py
@@ -1,0 +1,64 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from typing import Dict, Tuple
+
+import torch
+import torch.nn.functional as F
+from scipy.stats import t as ScipyStudentT
+from torch.distributions import StudentT as TorchStudentT
+
+from .distribution_output import DistributionOutput
+
+
+class StudentT(TorchStudentT):
+    """Student's t-distribution parametrized by degree of freedom `df`, mean `loc` and scale `scale`.
+
+    Based on torch.distributions.StudentT, but additionally implements `cdf` and `icdf` methods.
+    """
+
+    def __init__(self, df, loc=0.0, scale=1.0, validate_args=None):
+        super().__init__(
+            df=df, loc=loc, scale=scale, validate_args=validate_args
+        )
+        df = self.df.detach().cpu().numpy()
+        loc = self.loc.detach().cpu().numpy()
+        scale = self.scale.detach().cpu().numpy()
+        self.scipy_student_t = ScipyStudentT(df=df, loc=loc, scale=scale)
+
+    def cdf(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        result = self.scipy_student_t.cdf(value.detach().cpu().numpy())
+        return torch.tensor(result, device=value.device, dtype=value.dtype)
+
+    def icdf(self, value: torch.Tensor):
+        result = self.scipy_student_t.ppf(value.detach().cpu().numpy())
+        return torch.tensor(result, device=value.device, dtype=value.dtype)
+
+
+class StudentTOutput(DistributionOutput):
+    args_dim: Dict[str, int] = {"df": 1, "loc": 1, "scale": 1}
+    distr_cls: type = StudentT
+
+    @classmethod
+    def domain_map(
+        cls, df: torch.Tensor, loc: torch.Tensor, scale: torch.Tensor
+    ):
+        scale = F.softplus(scale)
+        df = 2.0 + F.softplus(df)
+        return df.squeeze(-1), loc.squeeze(-1), scale.squeeze(-1)
+
+    @property
+    def event_shape(self) -> Tuple:
+        return ()

--- a/src/gluonts/torch/distributions/studentT.py
+++ b/src/gluonts/torch/distributions/studentT.py
@@ -22,9 +22,10 @@ from .distribution_output import DistributionOutput
 
 
 class StudentT(TorchStudentT):
-    """Student's t-distribution parametrized by degree of freedom `df`, mean `loc` and scale `scale`.
+    """Student's t-distribution parametrized by degree of freedom `df`, mean `loc`
+    and scale `scale`.
 
-    Based on torch.distributions.StudentT, but additionally implements `cdf` and `icdf` methods.
+    Based on torch.distributions.StudentT, with added `cdf` and `icdf` methods.
     """
 
     def __init__(

--- a/test/torch/distribution/test_studentt.py
+++ b/test/torch/distribution/test_studentt.py
@@ -1,0 +1,32 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import pytest
+
+import numpy as np
+import torch
+
+from gluonts.torch.distributions.studentT import StudentT
+
+
+@pytest.mark.parametrize("df", [0.5, 1.5, 2.4])
+@pytest.mark.parametrize("loc", [-3.0, 0.0])
+@pytest.mark.parametrize("scale", [0.1, 0.8, 2.3])
+def test_custom_studentt_logpdf_matches_scipy_student_logpdf(df, loc, scale):
+    torch_dist = StudentT(df=df, loc=loc, scale=scale)
+    scipy_dist = torch_dist.scipy_student_t
+    x = torch.linspace(-20, 20, 1000)
+    log_pdf_torch = torch_dist.log_prob(x).numpy()
+    log_pdf_scipy = scipy_dist.logpdf(x.numpy())
+
+    assert np.allclose(log_pdf_torch, log_pdf_scipy)


### PR DESCRIPTION
*Description of changes:*
- Implement `cdf` and `icdf` methods for the StudentT distribution. This enables quantile computation for the StudentT `DistributionForecast` (e.g., for `SimpleFeedForwardEstimator`).
- The new `cdf` and `icdf` methods use `scipy.stats.t` under the hood, so  require moving data to CPU and are not differentiable.
- Move `StudentTDistribtuionOutput` to `gluonts.torch.distributions.studentT`.
- Add a test that ensures that torch and scipy versions have the same parametrization.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** enhancement