### PR TITLE
Speed up `PandasDataset` further

### DIFF
--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -15,7 +15,6 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import (
     Any,
-    cast,
     Collection,
     Dict,
     Iterator,
@@ -28,7 +27,6 @@ from typing import (
 
 import pandas as pd
 import numpy as np
-from pandas.core.indexes.datetimelike import DatetimeIndexOpsMixin
 from toolz import first
 
 from gluonts.dataset.common import DataEntry, _as_period


### PR DESCRIPTION
*Description of changes:* More speedup following #2435. Testing on Python 3.8.13 with the data from #2363, using the following code:

```python
from pathlib import Path
from time import time
import pandas as pd
from tqdm import tqdm

from gluonts.dataset.pandas import PandasDataset

df = pd.read_parquet(Path(__file__).resolve().parent / "long_df_sample.parquet")

t0 = time()
ds = PandasDataset.from_long_dataframe(
    dataframe=df,
    item_id="item_id",
    timestamp="timestamp",
    freq="M",
)
t1 = time()
print(f"construction time: {t1 - t0}")

N = 3

t0 = time()
for _ in range(N):
    for entry in tqdm(ds):
        pass
t1 = time()
print(f"average iteration time: {(t1 - t0)/N}")
```

Before the PR:

```
construction time: 0.3739509582519531
100%|█████████████████████████████████████████████| 25000/25000 [00:10<00:00, 2294.39it/s]
100%|█████████████████████████████████████████████| 25000/25000 [00:06<00:00, 3660.79it/s]
100%|█████████████████████████████████████████████| 25000/25000 [00:06<00:00, 3618.71it/s]
average iteration time: 8.413320620854696
```

After the PR:

```
construction time: 0.3727140426635742
100%|█████████████████████████████████████████████| 25000/25000 [00:08<00:00, 2825.26it/s]
100%|█████████████████████████████████████████████| 25000/25000 [00:05<00:00, 4383.24it/s]
100%|█████████████████████████████████████████████| 25000/25000 [00:05<00:00, 4380.71it/s]
average iteration time: 6.958552281061809
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup