### PR TITLE
Fix frequency inference in `PandasDataset`

### DIFF
--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -121,8 +121,8 @@ class PandasDataset:
 
         assert isinstance(self._pairs, SizedIterable)
 
-        if not self.freq:
-            self.freq = first(self._pairs)[1].index.freqstr
+        if self.freq is None:
+            self.freq = infer_freq(first(self._pairs)[1].index)
 
         self.process = ProcessDataEntry(
             cast(str, self.freq), one_dim_target=self.one_dim_target
@@ -220,6 +220,12 @@ def pair_with_item_id(obj: Union[Tuple, pd.DataFrame, pd.Series]):
     if isinstance(obj, (pd.DataFrame, pd.Series)):
         return (None, obj)
     raise ValueError("input must be a pair, or a pandas Series or DataFrame.")
+
+
+def infer_freq(index: pd.Index):
+    if isinstance(index, pd.PeriodIndex):
+        return index.freqstr
+    return pd.infer_freq(index)
 
 
 def as_dataentry(


### PR DESCRIPTION
*Description of changes:* #2435 broke one of the documentation notebooks in that `PandasDataset` does not infer `freq` anymore when not provided. This PR fixes that.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup