### PR TITLE
Change schema.Type to behave like invokable types.

### DIFF
--- a/src/gluonts/dataset/schema/types.py
+++ b/src/gluonts/dataset/schema/types.py
@@ -22,7 +22,7 @@ T = typing.TypeVar("T")
 
 
 class Type:
-    def apply(self, data):
+    def __call__(self, data):
         raise NotImplementedError
 
 
@@ -37,9 +37,9 @@ class Default(GenericType[T]):
 
     def __post_init__(self):
         if self.base is not None:
-            self.value = self.base.apply(self.value)
+            self.value = self.base(self.value)
 
-    def apply(self, data) -> T:
+    def __call__(self, data) -> T:
         return self.value
 
 
@@ -59,7 +59,7 @@ class Array(GenericType[T]):
     dtype: typing.Optional[typing.Type[T]] = None
     time_dim: typing.Optional[int] = None
 
-    def apply(self, data):
+    def __call__(self, data):
         arr = np.asarray(data, dtype=self.dtype)
 
         if arr.ndim != self.ndim:
@@ -72,5 +72,5 @@ class Array(GenericType[T]):
 class Period:
     freq: typing.Optional[str] = None
 
-    def apply(self, data):
+    def __call__(self, data):
         return pd.Period(data, freq=self.freq)

--- a/test/dataset/schema/test_types.py
+++ b/test/dataset/schema/test_types.py
@@ -21,9 +21,9 @@ f32_2d = ty.Array(dtype=np.float32, ndim=2)
 
 def test_array():
     assert np.array_equal(
-        f32_2d.apply([[0, 1, 2]]), np.arange(3, dtype=np.float32).reshape(1, 3)
+        f32_2d([[0, 1, 2]]), np.arange(3, dtype=np.float32).reshape(1, 3)
     )
 
 
 def test_period():
-    assert pd.Period("2020", freq="M") == ty.Period(freq="M").apply("2020")
+    assert pd.Period("2020", freq="M") == ty.Period(freq="M")("2020")


### PR DESCRIPTION
With this change, the types behave like other types in Python, e.g one uses `int(x)` instead of `int.apply(x)`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup