### PR TITLE
Add test cases for `PandasDataset`, fix missing assertion

### DIFF
--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -122,6 +122,9 @@ class PandasDataset:
         assert isinstance(self._pairs, SizedIterable)
 
         if self.freq is None:
+            assert (
+                self.timestamp is None
+            ), "You need to provide `freq` along with `timestamp`"
             self.freq = infer_freq(first(self._pairs)[1].index)
 
         self.process = ProcessDataEntry(

--- a/src/gluonts/testutil/equality.py
+++ b/src/gluonts/testutil/equality.py
@@ -1,0 +1,101 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import pandas as pd
+import numpy as np
+
+
+def assert_recursively_close(
+    obj_a, obj_b, rtol=1e-05, atol=1e-08, equal_nan=True
+):
+    """
+    Asserts that two objects are "close" to each other, recursively.
+
+    Strings or ints are close iff they are equal; floats or numpy arrays are defined
+    close according to the numpy.isclose and numpy.allclose functions, respectively.
+    Lists are close if all of their items are close. Dicts are close if they have the
+    same keys, and elements corresponding to the same key are close.
+
+    Parameters:
+    -----------
+    obj_a
+    obj_b
+        Objects to compare.
+    rtol
+    atol
+        Relative and absolute tolerance for float comparison; see docs for numpy.isclose.
+    equal_nan
+        Indicates whether or not numpy.nan values should be considered equal.
+    """
+    _assert_recursively_close(
+        obj_a, obj_b, location="", rtol=rtol, atol=atol, equal_nan=equal_nan
+    )
+
+
+def _assert_recursively_close(obj_a, obj_b, location, *args, **kwargs):
+    assert type(obj_a) == type(
+        obj_b
+    ), f"types did not match (location: {location}) {type(obj_a)} != {type(obj_b)}"
+    if isinstance(obj_a, (str, int)):
+        assert obj_a == obj_b
+    elif isinstance(obj_a, float):
+        assert np.isclose(obj_a, obj_b, *args, **kwargs)
+    elif isinstance(obj_a, list):
+        assert len(obj_a) == len(
+            obj_b
+        ), f"length did not match (location: {location})"
+        tmp_a = np.asarray(obj_a)
+        tmp_b = np.asarray(obj_b)
+        assert (
+            tmp_a.dtype == tmp_b.dtype
+        ), f"dtypes did not match (location: {location})"
+        if tmp_a.dtype.kind != "O":
+            _assert_recursively_close(
+                tmp_a, tmp_b, location=location, *args, **kwargs
+            )
+        else:
+            for i, (element_a, element_b) in enumerate(zip(obj_a, obj_b)):
+                _assert_recursively_close(
+                    element_a,
+                    element_b,
+                    location=f"{location}.{i}",
+                    *args,
+                    **kwargs,
+                )
+    elif isinstance(obj_a, dict):
+        assert (
+            obj_a.keys() == obj_b.keys()
+        ), f"keys did not match (location: {location})"
+        for k in obj_a:
+            _assert_recursively_close(
+                obj_a[k], obj_b[k], location=f"{location}.{k}", *args, **kwargs
+            )
+    elif isinstance(obj_a, np.ndarray):
+        assert (
+            obj_a.dtype == obj_b.dtype
+        ), f"numpy arrays have different dtype (location: {location})"
+        assert np.allclose(
+            obj_a, obj_b, *args, **kwargs
+        ), f"numpy arrays are not close enough (location: {location})"
+    elif isinstance(obj_a, pd.Period):
+        assert obj_a == obj_b
+    elif obj_a is None:
+        assert obj_b is None
+    else:
+        raise TypeError(f"unsupported type {type(obj_a)}")
+
+
+def assert_recursively_equal(obj_a, obj_b, equal_nan=True):
+    _assert_recursively_close(
+        obj_a, obj_b, location="", rtol=0, atol=0, equal_nan=equal_nan
+    )

--- a/src/gluonts/testutil/equality.py
+++ b/src/gluonts/testutil/equality.py
@@ -21,10 +21,11 @@ def assert_recursively_close(
     """
     Asserts that two objects are "close" to each other, recursively.
 
-    Strings or ints are close iff they are equal; floats or numpy arrays are defined
-    close according to the numpy.isclose and numpy.allclose functions, respectively.
-    Lists are close if all of their items are close. Dicts are close if they have the
-    same keys, and elements corresponding to the same key are close.
+    Strings or ints are close iff they are equal; floats or numpy arrays
+    are defined close according to the numpy.isclose and numpy.allclose
+    functions, respectively. Lists are close if all of their items are close.
+    Dicts are close if they have the same keys, and elements corresponding
+    to the same key are close.
 
     Parameters:
     -----------
@@ -33,7 +34,8 @@ def assert_recursively_close(
         Objects to compare.
     rtol
     atol
-        Relative and absolute tolerance for float comparison; see docs for numpy.isclose.
+        Relative and absolute tolerance for float comparison; see docs for
+        numpy.isclose.
     equal_nan
         Indicates whether or not numpy.nan values should be considered equal.
     """

--- a/src/gluonts/testutil/equality.py
+++ b/src/gluonts/testutil/equality.py
@@ -73,9 +73,7 @@ def _assert_recursively_close(obj_a, obj_b, location, *args, **kwargs):
     elif isinstance(obj_a, float):
         assert np.isclose(obj_a, obj_b, *args, **kwargs)
     elif isinstance(obj_a, list):
-        assert len(obj_a) == len(
-            obj_b
-        ), f"lengths don't match (at {location})"
+        assert len(obj_a) == len(obj_b), f"lengths don't match (at {location})"
         for i, (element_a, element_b) in enumerate(zip(obj_a, obj_b)):
             _assert_recursively_close(
                 element_a,

--- a/src/gluonts/testutil/equality.py
+++ b/src/gluonts/testutil/equality.py
@@ -67,7 +67,7 @@ def assert_recursively_close(
 def _assert_recursively_close(obj_a, obj_b, location, *args, **kwargs):
     assert type(obj_a) == type(
         obj_b
-    ), f"types did not match (location: {location}) {type(obj_a)} != {type(obj_b)}"
+    ), f"types don't match (at {location}) {type(obj_a)} != {type(obj_b)}"
     if isinstance(obj_a, (str, int)):
         assert obj_a == obj_b
     elif isinstance(obj_a, float):
@@ -75,7 +75,7 @@ def _assert_recursively_close(obj_a, obj_b, location, *args, **kwargs):
     elif isinstance(obj_a, list):
         assert len(obj_a) == len(
             obj_b
-        ), f"length did not match (location: {location})"
+        ), f"lengths don't match (at {location})"
         for i, (element_a, element_b) in enumerate(zip(obj_a, obj_b)):
             _assert_recursively_close(
                 element_a,
@@ -87,7 +87,7 @@ def _assert_recursively_close(obj_a, obj_b, location, *args, **kwargs):
     elif isinstance(obj_a, dict):
         assert (
             obj_a.keys() == obj_b.keys()
-        ), f"keys did not match (location: {location})"
+        ), f"keys don't match (at {location})"
         for k in obj_a:
             _assert_recursively_close(
                 obj_a[k], obj_b[k], location=f"{location}.{k}", *args, **kwargs
@@ -95,10 +95,10 @@ def _assert_recursively_close(obj_a, obj_b, location, *args, **kwargs):
     elif isinstance(obj_a, np.ndarray):
         assert (
             obj_a.dtype == obj_b.dtype
-        ), f"numpy arrays have different dtype (location: {location})"
+        ), f"numpy arrays have different dtype (at {location})"
         assert np.allclose(
             obj_a, obj_b, *args, **kwargs
-        ), f"numpy arrays are not close enough (location: {location})"
+        ), f"numpy arrays are not close enough (at {location})"
     elif isinstance(obj_a, pd.Period):
         assert obj_a == obj_b
     elif obj_a is None:

--- a/src/gluonts/testutil/equality.py
+++ b/src/gluonts/testutil/equality.py
@@ -15,6 +15,26 @@ import pandas as pd
 import numpy as np
 
 
+def assert_recursively_equal(obj_a, obj_b, equal_nan=True):
+    """
+    Asserts that two objects are equal, recursively.
+
+    This is based on :func:`assert_recursively_close`, and accepts the
+    same arguments, except that tolerances are set to zero.
+
+    Parameters:
+    -----------
+    obj_a
+    obj_b
+        Objects to compare.
+    equal_nan
+        Indicates whether or not numpy.nan values should be considered equal.
+    """
+    _assert_recursively_close(
+        obj_a, obj_b, location="", rtol=0, atol=0, equal_nan=equal_nan
+    )
+
+
 def assert_recursively_close(
     obj_a, obj_b, rtol=1e-05, atol=1e-08, equal_nan=True
 ):
@@ -56,24 +76,14 @@ def _assert_recursively_close(obj_a, obj_b, location, *args, **kwargs):
         assert len(obj_a) == len(
             obj_b
         ), f"length did not match (location: {location})"
-        tmp_a = np.asarray(obj_a)
-        tmp_b = np.asarray(obj_b)
-        assert (
-            tmp_a.dtype == tmp_b.dtype
-        ), f"dtypes did not match (location: {location})"
-        if tmp_a.dtype.kind != "O":
+        for i, (element_a, element_b) in enumerate(zip(obj_a, obj_b)):
             _assert_recursively_close(
-                tmp_a, tmp_b, location=location, *args, **kwargs
+                element_a,
+                element_b,
+                location=f"{location}.{i}",
+                *args,
+                **kwargs,
             )
-        else:
-            for i, (element_a, element_b) in enumerate(zip(obj_a, obj_b)):
-                _assert_recursively_close(
-                    element_a,
-                    element_b,
-                    location=f"{location}.{i}",
-                    *args,
-                    **kwargs,
-                )
     elif isinstance(obj_a, dict):
         assert (
             obj_a.keys() == obj_b.keys()
@@ -95,9 +105,3 @@ def _assert_recursively_close(obj_a, obj_b, location, *args, **kwargs):
         assert obj_b is None
     else:
         raise TypeError(f"unsupported type {type(obj_a)}")
-
-
-def assert_recursively_equal(obj_a, obj_b, equal_nan=True):
-    _assert_recursively_close(
-        obj_a, obj_b, location="", rtol=0, atol=0, equal_nan=equal_nan
-    )

--- a/test/dataset/test_pandas.py
+++ b/test/dataset/test_pandas.py
@@ -245,7 +245,7 @@ def test_long_csv_3M():
         assert np.allclose(entry["target"], expected_entry["target"])
 
 
-def case_series(freq: str, index_type: Callable, dtype=np.float32):
+def _testcase_series(freq: str, index_type: Callable, dtype=np.float32):
     series = [
         pd.Series(
             np.arange(10, dtype=dtype),
@@ -274,7 +274,7 @@ def case_series(freq: str, index_type: Callable, dtype=np.float32):
     return dataset, expected_entries
 
 
-def case_dataframes_without_index(
+def _testcase_dataframes_without_index(
     freq: str,
     target: Union[str, List[str]],
     feat_dynamic_real: List[str],
@@ -339,7 +339,7 @@ def case_dataframes_without_index(
     return dataset, expected_entries
 
 
-def case_dataframes_with_index(
+def _testcase_dataframes_with_index(
     freq: str,
     index_type: Callable,
     target: Union[str, List[str]],
@@ -402,25 +402,25 @@ def case_dataframes_with_index(
 @pytest.mark.parametrize(
     "dataset, expected_entries",
     [
-        case_series(freq="D", index_type=pd.period_range),
-        case_series(freq="H", index_type=pd.date_range),
-        case_dataframes_without_index(
+        _testcase_series(freq="D", index_type=pd.period_range),
+        _testcase_series(freq="H", index_type=pd.date_range),
+        _testcase_dataframes_without_index(
             freq="D",
             target="A",
             feat_dynamic_real=["B", "C"],
         ),
-        case_dataframes_without_index(
+        _testcase_dataframes_without_index(
             freq="H",
             target=["A", "B"],
             feat_dynamic_real=["C"],
         ),
-        case_dataframes_with_index(
+        _testcase_dataframes_with_index(
             freq="D",
             index_type=pd.period_range,
             target="A",
             feat_dynamic_real=["B", "C"],
         ),
-        case_dataframes_with_index(
+        _testcase_dataframes_with_index(
             freq="H",
             index_type=pd.date_range,
             target=["A", "B"],


### PR DESCRIPTION
*Description of changes:*
- Add different test cases for `PandasDataset` being constructed with `pd.Series` or `pd.DataFrame` collections
- Add test util to recursively compare objects
- Add missing assertion


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup