### PR TITLE
Add `weights` option to `ev`'s Sum and Mean

### DIFF
--- a/src/gluonts/ev/aggregations.py
+++ b/src/gluonts/ev/aggregations.py
@@ -21,7 +21,9 @@ import numpy as np
 class Aggregation:
     axis: Optional[int] = None
 
-    def step(self, values: np.ndarray) -> None:
+    def step(
+        self, values: np.ndarray, weights: Optional[np.ndarray] = None
+    ) -> None:
         raise NotImplementedError
 
     def get(self) -> np.ndarray:
@@ -43,7 +45,12 @@ class Sum(Aggregation):
 
     partial_result: Optional[Union[List[np.ndarray], np.ndarray]] = None
 
-    def step(self, values: np.ndarray) -> None:
+    def step(
+        self, values: np.ndarray, weights: Optional[np.ndarray] = None
+    ) -> None:
+        if weights is not None:
+            values = values * weights
+
         summed_values = np.ma.sum(values, axis=self.axis)
 
         if self.axis is None or self.axis == 0:
@@ -80,7 +87,12 @@ class Mean(Aggregation):
     partial_result: Optional[Union[List[np.ndarray], np.ndarray]] = None
     n: Optional[Union[int, np.ndarray]] = None
 
-    def step(self, values: np.ndarray) -> None:
+    def step(
+        self, values: np.ndarray, weights: Optional[np.ndarray] = None
+    ) -> None:
+        if weights is not None:
+            values = values * weights
+
         if self.axis is None or self.axis == 0:
             summed_values = np.ma.sum(values, axis=self.axis)
             if self.partial_result is None:

--- a/test/ev/test_aggregations.py
+++ b/test/ev/test_aggregations.py
@@ -50,7 +50,6 @@ SUM_RES_AXIS_1 = [
     np.array([3, 3, 3, 12]),
 ]
 
-
 MEAN_RES_AXIS_NONE = [
     np.nan,
     0,
@@ -122,3 +121,103 @@ def test_high_dim():
         actual_mean = mean.get()
         expected_mean = all_values.mean(axis=axis)
         np.testing.assert_almost_equal(actual_mean, expected_mean)
+
+
+WEIGHT_BATCHES = [
+    [
+        np.full((3, 5), 7.21),
+        np.zeros((3, 5)),
+        np.ones((3, 5)),
+    ],
+    [
+        np.array([[1, 1.5], [1, 1.5]]),
+        np.array([[1, 1.5], [1, 1.5]]),
+    ],
+    [
+        np.array([[3, 3, 3], [2, 2, 2], [1, 1, 1]]),
+        np.zeros((1, 3)),
+    ],
+]
+
+RES_WEIGHTED_SUM_AXIS_NONE = [
+    0,
+    2.5,
+    18,
+]
+
+RES_WEIGHTED_SUM_AXIS_0 = [
+    np.zeros(5),
+    np.array([-5, 7.5]),
+    np.array([6, 6, 6]),
+]
+
+RES_WEIGHTED_SUM_AXIS_1 = [
+    np.zeros(9),
+    np.array([0, 0, 7.5, -5]),
+    np.array([9, 6, 3, 0]),
+]
+
+@pytest.mark.parametrize(
+    "value_stream, weight_batches, res_axis_none, res_axis_0, res_axis_1",
+    zip(
+        VALUE_STREAM,
+        WEIGHT_BATCHES,
+        RES_WEIGHTED_SUM_AXIS_NONE,
+        RES_WEIGHTED_SUM_AXIS_0,
+        RES_WEIGHTED_SUM_AXIS_1,
+    ),
+)
+def test_weighted_sum(
+    value_stream, weight_batches, res_axis_none, res_axis_0, res_axis_1
+):
+    for axis, expected_result in zip(
+        [None, 0, 1], [res_axis_none, res_axis_0, res_axis_1]
+    ):
+        sum = Sum(axis=axis)
+        for values, weights in zip(value_stream, weight_batches):
+            sum.step(np.ma.masked_invalid(values), weights)
+        print(sum.get(), expected_result)
+
+        np.testing.assert_almost_equal(sum.get(), expected_result)
+
+
+RES_WEIGHTED_MEAN_AXIS_NONE = [
+    np.nan,
+    0.416_666_666_666_666_666,
+    1.5,
+]
+
+RES_WEIGHTED_MEAN_AXIS_0 = [
+    np.full(5, np.nan),
+    np.array([-1.25, 3.75]),
+    np.array([1.5, 1.5, 1.5]),
+]
+
+RES_WEIGHTED_MEAN_AXIS_1 = [
+    np.full(9, np.nan),
+    np.array([0, 0, 3.75, -5]),
+    np.array([3, 2, 1, 0]),
+]
+
+@pytest.mark.parametrize(
+    "value_stream, weight_batches, res_axis_none, res_axis_0, res_axis_1",
+    zip(
+        VALUE_STREAM,
+        WEIGHT_BATCHES,
+        RES_WEIGHTED_MEAN_AXIS_NONE,
+        RES_WEIGHTED_MEAN_AXIS_0,
+        RES_WEIGHTED_MEAN_AXIS_1,
+    ),
+)
+def test_weighted_mean(
+    value_stream, weight_batches, res_axis_none, res_axis_0, res_axis_1
+):
+    for axis, expected_result in zip(
+        [None, 0, 1], [res_axis_none, res_axis_0, res_axis_1]
+    ):
+        mean = Mean(axis=axis)
+        for values, weights in zip(value_stream, weight_batches):
+            mean.step(np.ma.masked_invalid(values), weights)
+        print(mean.get(), expected_result)
+
+        np.testing.assert_almost_equal(mean.get(), expected_result)


### PR DESCRIPTION
*Description of changes:*
#2215 mentions that a weighted average might be a desirable feature for the evaluation.

Supporting this in the new `ev` module is rather simple if we just multiply by a `weights` array before applying aggregations (see first commit of this PR).

On top of this, calculating **normalized** weighted averages might also be useful. This however would in my opinion add unreasonable complexity to the aggregation code and should not be implemented natively by the `ev` module.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup