### PR TITLE
Set default `forecast_type` of ND metric to median

### DIFF
--- a/src/gluonts/ev/metrics.py
+++ b/src/gluonts/ev/metrics.py
@@ -185,7 +185,7 @@ class MASE:
 class ND:
     """Normalized Deviation"""
 
-    forecast_type: str = "mean"
+    forecast_type: str = "0.5"
 
     @staticmethod
     def normalized_deviation(


### PR DESCRIPTION
*Description of changes:*
The ND metric as implemented in #2450 should have as default `forecast_type` the median (50% quantile) rather than the mean. For comparison, in the `evaluation` module, the median is used as well (see [here](https://github.com/awslabs/gluonts/blob/3f8854e52aee8dd60e5dda85405dc71a1e018746/src/gluonts/evaluation/_base.py#L362-L364)). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup