### PR TITLE
Add overview of metrics available in ev

### DIFF
--- a/docs/getting_started/metrics.md
+++ b/docs/getting_started/metrics.md
@@ -1,0 +1,25 @@
+## Available metrics
+
+This is a list of metrics provided by the `ev` module. For implementation details see [here](https://github.com/awslabs/gluonts/blob/dev/src/gluonts/ev/metrics.py).
+
+| Metric name                 | Default parameters    | Aggregation |
+| --------------------------- | --------------------- | ----------- |
+| mean_absolute_label         | -                     | Mean        |
+| sum_absolute_label          | -                     | Sum         |
+| MSE                         | forecast type: mean   | Mean        |
+| RMSE                        | forecast type: mean   | Mean        |
+| NRMSE                       | forecast type: mean   | Mean        |
+| SumError                    | forecast type: median | Sum         |
+| SumAbsoluteError            | forecast type: median | Sum         |
+| MAPE                        | forecast type: median | Mean        |
+| SMAPE                       | forecast type: median | Mean        |
+| MASE                        | forecast type: median | Mean        |
+| ND                          | forecast type: median | Mean        |
+| OWA                         | forecast type: median | Mean        |
+| MSIS                        | alpha: 0.05           | Mean        |
+| SumQuantileLoss             | -                     | Mean        |
+| WeightedSumQuantileLoss     | -                     | Mean        |
+| Coverage                    | -                     | Mean        |
+| MeanSumQuantileLoss         | -                     | Mean        |
+| MeanWeightedSumQuantileLoss | -                     | Mean        |
+| MAECoverage                 | -                     | Mean        |

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@
    getting_started/background
    getting_started/concepts
    getting_started/models
+   getting_started/metrics
 
 .. toctree::
    :name: Tutorials


### PR DESCRIPTION
*Description of changes:*
Having an overview of available metrics in the documentation might be useful. This also addresses #2272.

Having the "aggregation" column might be not so useful as it's usually clear by the metric name whether `Sum` or `Mean` is used. Maybe adding a column with the metric definition can also be useful.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup