### PR TITLE
Include loss computation in torch DeepAR module, decouple MQF2

### DIFF
--- a/src/gluonts/torch/model/deepar/lightning_module.py
+++ b/src/gluonts/torch/model/deepar/lightning_module.py
@@ -81,8 +81,6 @@ class DeepARLightningModule(pl.LightningModule):
             past_observed_values=batch["past_observed_values"],
             future_observed_values=batch["future_observed_values"],
             loss=self.loss,
-            future_only=False,
-            aggregate_by=torch.mean,
         ).mean()
 
     def training_step(self, batch, batch_idx: int):  # type: ignore

--- a/src/gluonts/torch/model/deepar/lightning_module.py
+++ b/src/gluonts/torch/model/deepar/lightning_module.py
@@ -17,7 +17,6 @@ from torch.optim.lr_scheduler import ReduceLROnPlateau
 
 from gluonts.core.component import validated
 from gluonts.torch.modules.loss import DistributionLoss, NegativeLogLikelihood
-from gluonts.torch.util import weighted_average
 
 from .module import DeepARModel
 

--- a/src/gluonts/torch/model/deepar/lightning_module.py
+++ b/src/gluonts/torch/model/deepar/lightning_module.py
@@ -80,8 +80,9 @@ class DeepARLightningModule(pl.LightningModule):
             future_target=batch["future_target"],
             past_observed_values=batch["past_observed_values"],
             future_observed_values=batch["future_observed_values"],
-            future_only=False,
             loss=self.loss,
+            future_only=False,
+            aggregate_by=torch.mean,
         ).mean()
 
     def training_step(self, batch, batch_idx: int):  # type: ignore

--- a/src/gluonts/torch/model/deepar/lightning_module.py
+++ b/src/gluonts/torch/model/deepar/lightning_module.py
@@ -16,6 +16,7 @@ import torch
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 
 from gluonts.core.component import validated
+from gluonts.itertools import select
 from gluonts.torch.modules.loss import DistributionLoss, NegativeLogLikelihood
 
 from .module import DeepARModel
@@ -70,24 +71,17 @@ class DeepARLightningModule(pl.LightningModule):
     def forward(self, *args, **kwargs):
         return self.model(*args, **kwargs)
 
-    def _compute_loss(self, batch):
-        return self.model.loss(
-            feat_static_cat=batch["feat_static_cat"],
-            feat_static_real=batch["feat_static_real"],
-            past_time_feat=batch["past_time_feat"],
-            past_target=batch["past_target"],
-            future_time_feat=batch["future_time_feat"],
-            future_target=batch["future_target"],
-            past_observed_values=batch["past_observed_values"],
-            future_observed_values=batch["future_observed_values"],
-            loss=self.loss,
-        ).mean()
-
     def training_step(self, batch, batch_idx: int):  # type: ignore
         """
         Execute training step.
         """
-        train_loss = self._compute_loss(batch)
+        train_loss = self.model.loss(
+            **select(self.model.input_shapes(), batch),
+            future_observed_values=batch["future_observed_values"],
+            future_target=batch["future_target"],
+            loss=self.loss,
+        ).mean()
+
         self.log(
             "train_loss",
             train_loss,
@@ -95,16 +89,24 @@ class DeepARLightningModule(pl.LightningModule):
             on_step=False,
             prog_bar=True,
         )
+
         return train_loss
 
     def validation_step(self, batch, batch_idx: int):  # type: ignore
         """
         Execute validation step.
         """
-        val_loss = self._compute_loss(batch)
+        val_loss = self.model.loss(
+            **select(self.model.input_shapes(), batch),
+            future_observed_values=batch["future_observed_values"],
+            future_target=batch["future_target"],
+            loss=self.loss,
+        ).mean()
+
         self.log(
             "val_loss", val_loss, on_epoch=True, on_step=False, prog_bar=True
         )
+
         return val_loss
 
     def configure_optimizers(self):

--- a/src/gluonts/torch/model/deepar/module.py
+++ b/src/gluonts/torch/model/deepar/module.py
@@ -24,7 +24,14 @@ from gluonts.torch.distributions import (
 )
 from gluonts.torch.modules.scaler import MeanScaler, NOPScaler
 from gluonts.torch.modules.feature import FeatureEmbedder
-from gluonts.torch.util import lagged_sequence_values
+from gluonts.torch.modules.loss import DistributionLoss, NegativeLogLikelihood
+from gluonts.torch.util import (
+    lagged_sequence_values,
+    repeat_along_dim,
+    unsqueeze_expand,
+    weighted_average,
+)
+from gluonts.itertools import prod
 
 
 class DeepARModel(nn.Module):
@@ -97,11 +104,12 @@ class DeepARModel(nn.Module):
     ) -> None:
         super().__init__()
 
+        assert distr_output.event_shape == ()
+
         self.context_length = context_length
         self.prediction_length = prediction_length
         self.distr_output = distr_output
         self.param_proj = distr_output.get_args_proj(hidden_size)
-        self.target_shape = distr_output.event_shape
         self.num_feat_dynamic_real = num_feat_dynamic_real
         self.num_feat_static_cat = num_feat_static_cat
         self.num_feat_static_real = num_feat_static_real
@@ -118,9 +126,9 @@ class DeepARModel(nn.Module):
             embedding_dims=self.embedding_dimension,
         )
         if scaling:
-            self.scaler = MeanScaler(dim=1, keepdim=True)
+            self.scaler = MeanScaler(dim=-1, keepdim=True)
         else:
-            self.scaler = NOPScaler(dim=1, keepdim=True)
+            self.scaler = NOPScaler(dim=-1, keepdim=True)
         self.rnn_input_size = len(self.lags_seq) + self._number_of_features
         self.rnn = nn.LSTM(
             input_size=self.rnn_input_size,
@@ -152,7 +160,7 @@ class DeepARModel(nn.Module):
                 self._past_length,
                 self.num_feat_dynamic_real,
             ),
-            "past_target": (batch_size, self._past_length) + self.target_shape,
+            "past_target": (batch_size, self._past_length),
             "past_observed_values": (batch_size, self._past_length),
             "future_time_feat": (
                 batch_size,
@@ -203,7 +211,7 @@ class DeepARModel(nn.Module):
             shape: ``(batch_size, past_length, num_feat_dynamic_real)``.
         past_target
             Tensor of past target values,
-            shape: ``(batch_size, past_length, *target_shape)``.
+            shape: ``(batch_size, past_length)``.
         past_observed_values
             Tensor of observed values indicators,
             shape: ``(batch_size, past_length)``.
@@ -212,7 +220,7 @@ class DeepARModel(nn.Module):
             shape: ``(batch_size, prediction_length, num_feat_dynamic_real)``.
         future_target
             (Optional) tensor of future target values,
-            shape: ``(batch_size, prediction_length, *target_shape)``.
+            shape: ``(batch_size, prediction_length)``.
 
         Returns
         -------
@@ -224,13 +232,13 @@ class DeepARModel(nn.Module):
             - Static input to the RNN
             - Output state from the RNN
         """
-        context = past_target[:, -self.context_length :]
-        observed_context = past_observed_values[:, -self.context_length :]
+        context = past_target[..., -self.context_length :]
+        observed_context = past_observed_values[..., -self.context_length :]
         _, scale = self.scaler(context, observed_context)
 
-        prior_input = past_target[:, : -self.context_length] / scale
+        prior_input = past_target[..., : -self.context_length] / scale
         input = (
-            torch.cat((context, future_target[:, :-1]), dim=1) / scale
+            torch.cat((context, future_target[..., :-1]), dim=-1) / scale
             if future_target is not None
             else context / scale
         )
@@ -238,26 +246,28 @@ class DeepARModel(nn.Module):
         embedded_cat = self.embedder(feat_static_cat)
         static_feat = torch.cat(
             (embedded_cat, feat_static_real, scale.log()),
-            dim=1,
+            dim=-1,
         )
-        expanded_static_feat = static_feat.unsqueeze(1).expand(
-            -1, input.shape[1], -1
+        expanded_static_feat = unsqueeze_expand(
+            static_feat, dim=-2, size=input.shape[-1]
         )
 
         time_feat = (
             torch.cat(
                 (
-                    past_time_feat[:, -self.context_length + 1 :, ...],
+                    past_time_feat[..., -self.context_length + 1 :, :],
                     future_time_feat,
                 ),
-                dim=1,
+                dim=-2,
             )
             if future_time_feat is not None
-            else past_time_feat[:, -self.context_length + 1 :, ...]
+            else past_time_feat[..., -self.context_length + 1 :, :]
         )
 
         features = torch.cat((expanded_static_feat, time_feat), dim=-1)
-        lags = lagged_sequence_values(self.lags_seq, prior_input, input)
+        lags = lagged_sequence_values(
+            self.lags_seq, prior_input, input, dim=-1
+        )
         rnn_input = torch.cat((lags, features), dim=-1)
 
         output, new_state = self.rnn(rnn_input)
@@ -318,7 +328,7 @@ class DeepARModel(nn.Module):
             shape: ``(batch_size, past_length, num_feat_dynamic_real)``.
         past_target
             Tensor of past target values,
-            shape: ``(batch_size, past_length, *target_shape)``.
+            shape: ``(batch_size, past_length)``.
         past_observed_values
             Tensor of observed values indicators,
             shape: ``(batch_size, past_length)``.
@@ -376,9 +386,7 @@ class DeepARModel(nn.Module):
                 dim=-1,
             )
             next_lags = lagged_sequence_values(
-                self.lags_seq,
-                repeated_past_target,
-                scaled_next_sample,
+                self.lags_seq, repeated_past_target, scaled_next_sample, dim=-1
             )
             rnn_input = torch.cat((next_lags, next_features), dim=-1)
 
@@ -397,5 +405,74 @@ class DeepARModel(nn.Module):
 
         return future_samples_concat.reshape(
             (-1, num_parallel_samples, self.prediction_length)
-            + self.target_shape,
+        )
+
+    def loss(
+        self,
+        feat_static_cat: torch.Tensor,
+        feat_static_real: torch.Tensor,
+        past_time_feat: torch.Tensor,
+        past_target: torch.Tensor,
+        past_observed_values: torch.Tensor,
+        future_time_feat: torch.Tensor,
+        future_target: torch.Tensor,
+        future_observed_values: torch.Tensor,
+        future_only: bool = True,
+        loss: DistributionLoss = NegativeLogLikelihood(),
+    ) -> torch.Tensor:
+        extra_dims = len(future_target.shape) - len(past_target.shape)
+        repeats = prod(future_target.shape[:extra_dims])
+        feat_static_cat = repeat_along_dim(feat_static_cat, 0, repeats)
+        feat_static_real = repeat_along_dim(feat_static_real, 0, repeats)
+        past_time_feat = repeat_along_dim(past_time_feat, 0, repeats)
+        past_target = repeat_along_dim(past_target, 0, repeats)
+        past_observed_values = repeat_along_dim(
+            past_observed_values, 0, repeats
+        )
+        future_time_feat = repeat_along_dim(future_time_feat, 0, repeats)
+
+        future_target_reshaped = future_target.reshape(
+            prod(future_target.shape[: extra_dims + 1]),
+            *future_target.shape[extra_dims + 1 :]
+        )
+
+        params, scale, _, _, _ = self.unroll_lagged_rnn(
+            feat_static_cat,
+            feat_static_real,
+            past_time_feat,
+            past_target,
+            past_observed_values,
+            future_time_feat,
+            future_target_reshaped,
+        )
+
+        if future_only:
+            distr = self.output_distribution(
+                params, scale, trailing_n=self.prediction_length
+            )
+            target = future_target_reshaped
+            observed_values = future_observed_values
+        else:
+            distr = self.output_distribution(params, scale)
+            context_target = past_target[:, -self.context_length + 1 :]
+            target = torch.cat(
+                (context_target, future_target_reshaped),
+                dim=1,
+            )
+            context_observed = past_observed_values[
+                :, -self.context_length + 1 :
+            ]
+            observed_values = torch.cat(
+                (context_observed, future_observed_values), dim=1
+            )
+
+        loss_values = loss(distr, target)
+        loss_values = loss_values.reshape(
+            *future_target.shape[: extra_dims + 1], *loss_values.shape[1:]
+        )
+
+        return weighted_average(
+            loss_values,
+            weights=observed_values,
+            dim=tuple(range(extra_dims + 1, len(future_target.shape))),
         )

--- a/src/gluonts/torch/model/deepar/module.py
+++ b/src/gluonts/torch/model/deepar/module.py
@@ -406,10 +406,25 @@ class DeepARModel(nn.Module):
             (-1, num_parallel_samples, self.prediction_length)
         )
 
-    def log_prob(self, *args, **kwargs) -> torch.Tensor:
-        return -self.loss(  # type: ignore
-            *args,
-            **kwargs,
+    def log_prob(
+        self,
+        feat_static_cat: torch.Tensor,
+        feat_static_real: torch.Tensor,
+        past_time_feat: torch.Tensor,
+        past_target: torch.Tensor,
+        past_observed_values: torch.Tensor,
+        future_time_feat: torch.Tensor,
+        future_target: torch.Tensor,
+    ) -> torch.Tensor:
+        return -self.loss(
+            feat_static_cat=feat_static_cat,
+            feat_static_real=feat_static_real,
+            past_time_feat=past_time_feat,
+            past_target=past_target,
+            past_observed_values=past_observed_values,
+            future_time_feat=future_time_feat,
+            future_target=future_target,
+            future_observed_values=torch.ones_like(future_target),
             loss=NegativeLogLikelihood(),
             future_only=True,
             aggregate_by=torch.sum,

--- a/src/gluonts/torch/model/deepar/module.py
+++ b/src/gluonts/torch/model/deepar/module.py
@@ -29,7 +29,6 @@ from gluonts.torch.util import (
     lagged_sequence_values,
     repeat_along_dim,
     unsqueeze_expand,
-    weighted_average,
 )
 from gluonts.itertools import prod
 
@@ -471,8 +470,6 @@ class DeepARModel(nn.Module):
             *future_target.shape[: extra_dims + 1], *loss_values.shape[1:]
         )
 
-        return weighted_average(
-            loss_values,
-            weights=observed_values,
-            dim=tuple(range(extra_dims + 1, len(future_target.shape))),
+        return (loss_values * observed_values).sum(
+            dim=tuple(range(extra_dims + 1, len(future_target.shape)))
         )

--- a/src/gluonts/torch/model/deepar/module.py
+++ b/src/gluonts/torch/model/deepar/module.py
@@ -406,6 +406,15 @@ class DeepARModel(nn.Module):
             (-1, num_parallel_samples, self.prediction_length)
         )
 
+    def log_prob(self, *args, **kwargs) -> torch.Tensor:
+        return -self.loss(
+            *args,
+            **kwargs,
+            loss=NegativeLogLikelihood(),
+            future_only=True,
+            aggregate_by=torch.sum,
+        )
+
     def loss(
         self,
         feat_static_cat: torch.Tensor,
@@ -417,8 +426,8 @@ class DeepARModel(nn.Module):
         future_target: torch.Tensor,
         future_observed_values: torch.Tensor,
         loss: DistributionLoss = NegativeLogLikelihood(),
-        future_only: bool = True,
-        aggregate_by=torch.sum,
+        future_only: bool = False,
+        aggregate_by=torch.mean,
     ) -> torch.Tensor:
         extra_dims = len(future_target.shape) - len(past_target.shape)
         repeats = prod(future_target.shape[:extra_dims])

--- a/src/gluonts/torch/model/deepar/module.py
+++ b/src/gluonts/torch/model/deepar/module.py
@@ -416,8 +416,9 @@ class DeepARModel(nn.Module):
         future_time_feat: torch.Tensor,
         future_target: torch.Tensor,
         future_observed_values: torch.Tensor,
-        future_only: bool = True,
         loss: DistributionLoss = NegativeLogLikelihood(),
+        future_only: bool = True,
+        aggregate_by=torch.sum,
     ) -> torch.Tensor:
         extra_dims = len(future_target.shape) - len(past_target.shape)
         repeats = prod(future_target.shape[:extra_dims])
@@ -470,6 +471,7 @@ class DeepARModel(nn.Module):
             *future_target.shape[: extra_dims + 1], *loss_values.shape[1:]
         )
 
-        return (loss_values * observed_values).sum(
-            dim=tuple(range(extra_dims + 1, len(future_target.shape)))
+        return aggregate_by(
+            loss_values * observed_values,
+            dim=tuple(range(extra_dims + 1, len(future_target.shape))),
         )

--- a/src/gluonts/torch/model/mqf2/lightning_module.py
+++ b/src/gluonts/torch/model/mqf2/lightning_module.py
@@ -19,7 +19,6 @@ from torch.optim.lr_scheduler import ReduceLROnPlateau
 
 from gluonts.core.component import validated
 from gluonts.torch.modules.loss import DistributionLoss, EnergyScore
-from gluonts.torch.model.deepar.lightning_module import DeepARLightningModule
 from . import MQF2MultiHorizonModel
 
 

--- a/src/gluonts/torch/model/mqf2/lightning_module.py
+++ b/src/gluonts/torch/model/mqf2/lightning_module.py
@@ -13,7 +13,9 @@
 
 from typing import Dict
 
+import pytorch_lightning as pl
 import torch
+from torch.optim.lr_scheduler import ReduceLROnPlateau
 
 from gluonts.core.component import validated
 from gluonts.torch.modules.loss import DistributionLoss, EnergyScore
@@ -21,7 +23,7 @@ from gluonts.torch.model.deepar.lightning_module import DeepARLightningModule
 from . import MQF2MultiHorizonModel
 
 
-class MQF2MultiHorizonLightningModule(DeepARLightningModule):
+class MQF2MultiHorizonLightningModule(pl.LightningModule):
     r"""
     LightningModule class for the model MQF2 proposed in the paper
     ``Multivariate Quantile Function Forecaster``
@@ -55,12 +57,18 @@ class MQF2MultiHorizonLightningModule(DeepARLightningModule):
         weight_decay: float = 1e-8,
         patience: int = 10,
     ) -> None:
-        super().__init__(
-            model=model,
-            loss=loss,
-            lr=lr,
-            weight_decay=weight_decay,
-            patience=patience,
+        super().__init__()
+        self.save_hyperparameters()
+        self.model = model
+        self.loss = loss
+        self.lr = lr
+        self.weight_decay = weight_decay
+        self.patience = patience
+        self.example_input_array = tuple(
+            [
+                torch.zeros(shape, dtype=self.model.input_types()[name])
+                for (name, shape) in self.model.input_shapes().items()
+            ]
         )
 
     def forward(self, *args, **kwargs):
@@ -96,7 +104,7 @@ class MQF2MultiHorizonLightningModule(DeepARLightningModule):
 
         picnn = self.model.picnn
 
-        hidden_state, scale = self.model.unroll_lagged_rnn(
+        _, scale, hidden_state, _, _ = self.model.unroll_lagged_rnn(
             feat_static_cat,
             feat_static_real,
             past_time_feat,
@@ -105,6 +113,8 @@ class MQF2MultiHorizonLightningModule(DeepARLightningModule):
             future_time_feat,
             future_target,
         )
+
+        hidden_state = hidden_state[:, : self.model.context_length]
 
         distr = self.model.output_distribution(picnn, hidden_state, scale)
 
@@ -117,3 +127,50 @@ class MQF2MultiHorizonLightningModule(DeepARLightningModule):
         loss_values = self.loss(distr, target)
 
         return loss_values.mean()
+
+    def training_step(self, batch, batch_idx: int):  # type: ignore
+        """
+        Execute training step.
+        """
+        train_loss = self._compute_loss(batch)
+        self.log(
+            "train_loss",
+            train_loss,
+            on_epoch=True,
+            on_step=False,
+            prog_bar=True,
+        )
+        return train_loss
+
+    def validation_step(self, batch, batch_idx: int):  # type: ignore
+        """
+        Execute validation step.
+        """
+        val_loss = self._compute_loss(batch)
+        self.log(
+            "val_loss", val_loss, on_epoch=True, on_step=False, prog_bar=True
+        )
+        return val_loss
+
+    def configure_optimizers(self):
+        """
+        Returns the optimizer to use.
+        """
+        optimizer = torch.optim.Adam(
+            self.model.parameters(),
+            lr=self.lr,
+            weight_decay=self.weight_decay,
+        )
+
+        return {
+            "optimizer": optimizer,
+            "lr_scheduler": {
+                "scheduler": ReduceLROnPlateau(
+                    optimizer=optimizer,
+                    mode="min",
+                    factor=0.5,
+                    patience=self.patience,
+                ),
+                "monitor": "train_loss",
+            },
+        }

--- a/src/gluonts/torch/model/mqf2/module.py
+++ b/src/gluonts/torch/model/mqf2/module.py
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 import torch
 

--- a/src/gluonts/torch/modules/scaler.py
+++ b/src/gluonts/torch/modules/scaler.py
@@ -41,10 +41,6 @@ class MeanScaler(nn.Module):
         self, dim: int, keepdim: bool = False, minimum_scale: float = 1e-10
     ):
         super().__init__()
-        assert dim > 0, (
-            "Cannot compute scale along dim = 0 (batch dimension), please"
-            " provide dim > 0"
-        )
         self.dim = dim
         self.keepdim = keepdim
         self.register_buffer("minimum_scale", torch.tensor(minimum_scale))

--- a/src/gluonts/torch/util.py
+++ b/src/gluonts/torch/util.py
@@ -131,7 +131,7 @@ def lagged_sequence_values(
         end_index = -lag_index if lag_index > 0 else None
         lags_values.append(
             slice_along_dim(
-                full_sequence, dim=dim, slc=slice(begin_index, end_index)
+                full_sequence, dim=dim, slice_=slice(begin_index, end_index)
             )
         )
 

--- a/src/gluonts/torch/util.py
+++ b/src/gluonts/torch/util.py
@@ -91,6 +91,7 @@ def lagged_sequence_values(
     indices: List[int],
     prior_sequence: torch.Tensor,
     sequence: torch.Tensor,
+    dim: int,
 ) -> torch.Tensor:
     """
     Constructs an array of lagged values from a given sequence.
@@ -104,10 +105,12 @@ def lagged_sequence_values(
         will have observations from times ``t`` and ``t-24``.
     prior_sequence
         Tensor containing the input sequence prior to the time range for
-        which the output is required (shape: ``(N, H, C)``).
+        which the output is required.
     sequence
         Tensor containing the input sequence in the time range where the
-        output is required (shape: ``(N, T, C)``).
+        output is required.
+    dim
+        Time dimension.
 
     Returns
     -------
@@ -115,22 +118,25 @@ def lagged_sequence_values(
         A tensor of shape ``(N, T, L)``: if ``I = len(indices)``,
         and ``sequence.shape = (N, T, C)``, then ``L = C * I``.
     """
-    assert max(indices) <= prior_sequence.shape[1], (
+    assert max(indices) <= prior_sequence.shape[dim], (
         f"lags cannot go further than prior sequence length, found lag"
         f" {max(indices)} while prior sequence is only"
-        f"{prior_sequence.shape[1]}-long"
+        f"{prior_sequence.shape[dim]}-long"
     )
 
-    full_sequence = torch.cat((prior_sequence, sequence), dim=1)
+    full_sequence = torch.cat((prior_sequence, sequence), dim=dim)
 
     lags_values = []
     for lag_index in indices:
-        begin_index = -lag_index - sequence.shape[1]
+        begin_index = -lag_index - sequence.shape[dim]
         end_index = -lag_index if lag_index > 0 else None
-        lags_values.append(full_sequence[:, begin_index:end_index, ...])
+        lags_values.append(
+            slice_along_dim(
+                full_sequence, dim=dim, slc=slice(begin_index, end_index)
+            )
+        )
 
-    lags = torch.stack(lags_values, dim=-1)
-    return lags.reshape(lags.shape[0], lags.shape[1], -1)
+    return torch.stack(lags_values, dim=-1)
 
 
 class IterableDataset(torch.utils.data.IterableDataset):
@@ -139,3 +145,24 @@ class IterableDataset(torch.utils.data.IterableDataset):
 
     def __iter__(self):
         yield from self.iterable
+
+
+def unsqueeze_expand(a, dim, size):
+    a = a.unsqueeze(dim)
+    sizes = list(a.shape)
+    sizes[dim] = size
+    return a.expand(*sizes)
+
+
+def slice_along_dim(a, dim, slc):
+    idx = [slice(None)] * len(a.shape)
+    idx[dim] = slc
+    return a[idx]
+
+
+def repeat_along_dim(a, dim, repeats):
+    if repeats == 1:
+        return a
+    r = [1] * len(a.shape)
+    r[dim] = repeats
+    return a.repeat(*r)

--- a/test/torch/model/test_deepar_modules.py
+++ b/test/torch/model/test_deepar_modules.py
@@ -106,7 +106,7 @@ def test_deepar_modules(
 
     assert samples.shape == (batch_size, 100, prediction_length)
 
-    log_densities = model.loss(
+    log_densities = model.log_prob(
         feat_static_cat,
         feat_static_real,
         past_time_feat,
@@ -114,12 +114,11 @@ def test_deepar_modules(
         past_observed_values,
         future_time_feat,
         future_target,
-        future_observed_values,
     )
 
     assert log_densities.shape == (batch_size,)
 
-    log_densities = model.loss(
+    log_densities = model.log_prob(
         feat_static_cat,
         feat_static_real,
         past_time_feat,
@@ -127,7 +126,6 @@ def test_deepar_modules(
         past_observed_values,
         future_time_feat,
         samples.transpose(0, 1),  # TODO: ugly!
-        torch.ones_like(samples).transpose(0, 1),  # TODO: ugly!
     )
 
     assert log_densities.shape == (100, batch_size)

--- a/test/torch/model/test_deepar_modules.py
+++ b/test/torch/model/test_deepar_modules.py
@@ -106,6 +106,32 @@ def test_deepar_modules(
 
     assert samples.shape == (batch_size, 100, prediction_length)
 
+    log_densities = model.loss(
+        feat_static_cat,
+        feat_static_real,
+        past_time_feat,
+        past_target,
+        past_observed_values,
+        future_time_feat,
+        future_target,
+        future_observed_values,
+    )
+
+    assert log_densities.shape == (batch_size,)
+
+    log_densities = model.loss(
+        feat_static_cat,
+        feat_static_real,
+        past_time_feat,
+        past_target,
+        past_observed_values,
+        future_time_feat,
+        samples.transpose(0, 1),  # TODO: ugly!
+        torch.ones_like(samples).transpose(0, 1),  # TODO: ugly!
+    )
+
+    assert log_densities.shape == (100, batch_size)
+
     batch = dict(
         feat_static_cat=feat_static_cat,
         feat_static_real=feat_static_real,

--- a/test/torch/model/test_mqf2_modules.py
+++ b/test/torch/model/test_mqf2_modules.py
@@ -70,7 +70,7 @@ def test_mqf2_modules(
     future_target = torch.ones(batch_size, prediction_length)
     future_observed_values = torch.ones(batch_size, prediction_length)
 
-    hidden_state, scale = model.unroll_lagged_rnn(
+    _, scale, hidden_state, _, _ = model.unroll_lagged_rnn(
         feat_static_cat,
         feat_static_real,
         past_time_feat,
@@ -79,6 +79,8 @@ def test_mqf2_modules(
         future_time_feat,
         future_target,
     )
+
+    hidden_state = hidden_state[:, :context_length]
 
     assert scale.shape == (batch_size, 1)
 

--- a/test/torch/test_torch_util.py
+++ b/test/torch/test_torch_util.py
@@ -23,22 +23,25 @@ from gluonts.torch.util import (
 
 
 @pytest.mark.parametrize(
-    "lag_indices, prior_sequence, sequence",
+    "lag_indices, prior_sequence, sequence, output_shape",
     [
         (
             [0, 1, 5, 10, 20],
             torch.randn((4, 100)),
             torch.randn((4, 8)),
+            (4, 8, 5),
         ),
         (
             [0, 1, 5, 10, 20],
             torch.randn((4, 100, 1)),
             torch.randn((4, 8, 1)),
+            (4, 8, 1, 5),
         ),
         (
             [0, 1, 5, 10, 20],
             torch.randn((4, 100, 2)),
             torch.randn((4, 8, 2)),
+            (4, 8, 2, 5),
         ),
     ],
 )
@@ -46,8 +49,10 @@ def test_lagged_sequence_values(
     lag_indices: List[int],
     prior_sequence: torch.Tensor,
     sequence: torch.Tensor,
+    output_shape: tuple,
 ):
     res = lagged_sequence_values(lag_indices, prior_sequence, sequence, dim=1)
+    assert res.shape == output_shape
     full_sequence = torch.cat((prior_sequence, sequence), dim=1)
     for t in range(res.shape[1]):
         expected_lags_t = torch.stack(


### PR DESCRIPTION
*Description of changes:* This moves the loss computation to the `DeepARModel` class. This way the model is more usable in its own right, and can be used for density estimation directly. A few changes are added that clean up the handling of shapes in the class. In particular, the model is now forced to deal with univariate data (`distr_output.event_dim == 1`), as it was anyway broken for other cases (for example, arrays are sliced along the `-1` axis irrespectively of `distr_output.event_dim`, which was wrong).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup