### PR TITLE
Fix: use right context in DeepVARHierarchicalEstimator

### DIFF
--- a/src/gluonts/mx/model/deepvar_hierarchical/_estimator.py
+++ b/src/gluonts/mx/model/deepvar_hierarchical/_estimator.py
@@ -285,7 +285,8 @@ class DeepVARHierarchicalEstimator(DeepVAREstimator):
 
         A = constraint_mat(S.astype(self.dtype))
         M = null_space_projection_mat(A)
-        self.M, self.A = mx.nd.array(M), mx.nd.array(A)
+        ctx = self.trainer.ctx
+        self.M, self.A = mx.nd.array(M, ctx=ctx), mx.nd.array(A, ctx=ctx)
         self.num_samples_for_loss = num_samples_for_loss
         self.likelihood_weight = likelihood_weight
         self.CRPS_weight = CRPS_weight


### PR DESCRIPTION
*Issue #, if available:*
#2477 

*Description of changes:*
create ndarray A and M with context same as trainer.ctx

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup