### PR TITLE
Add requirement files to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include src/gluonts/ext/r_forecast/R/*.R
+recursive-include requirements *.txt
 
 prune .devtools
 prune .github


### PR DESCRIPTION
Without this, the source distribution of gluonts don't contain the requirement files, which are needed to execute setup.py

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup