### PR TITLE
Add smoke tests for torch models

### DIFF
--- a/src/gluonts/torch/model/mqf2/module.py
+++ b/src/gluonts/torch/model/mqf2/module.py
@@ -17,7 +17,10 @@ import torch
 
 from gluonts.core.component import validated
 from gluonts.torch.model.deepar.module import DeepARModel
-from gluonts.torch.distributions import DistributionOutput
+from gluonts.torch.distributions import (
+    DistributionOutput,
+    MQF2DistributionOutput,
+)
 
 from cpflows.flows import ActNorm
 from cpflows.icnn import PICNN
@@ -35,7 +38,7 @@ class MQF2MultiHorizonModel(DeepARModel):
         num_feat_static_real: int,
         num_feat_static_cat: int,
         cardinality: List[int],
-        distr_output: DistributionOutput,
+        distr_output: Optional[DistributionOutput] = None,
         embedding_dimension: Optional[List[int]] = None,
         num_layers: int = 2,
         hidden_size: int = 40,
@@ -74,7 +77,11 @@ class MQF2MultiHorizonModel(DeepARModel):
             num_layers=num_layers,
             hidden_size=hidden_size,
             dropout_rate=dropout_rate,
-            distr_output=distr_output,
+            distr_output=(
+                distr_output
+                if distr_output is not None
+                else MQF2DistributionOutput(prediction_length)
+            ),
             lags_seq=lags_seq,
             scaling=scaling,
             num_parallel_samples=num_parallel_samples,

--- a/test/torch/model/test_modules.py
+++ b/test/torch/model/test_modules.py
@@ -1,0 +1,74 @@
+import pytest
+import torch
+
+from gluonts.torch.model.deepar import DeepARModel
+from gluonts.torch.model.mqf2 import MQF2MultiHorizonModel
+from gluonts.torch.model.simple_feedforward import SimpleFeedForwardModel
+
+
+def construct_batch(module, batch_size=1):
+    return tuple(
+        [
+            torch.zeros(shape, dtype=module.input_types()[name])
+            for (name, shape) in module.input_shapes(
+                batch_size=batch_size
+            ).items()
+        ]
+    )
+
+
+def assert_shapes_and_dtypes(tensors, shapes, dtypes):
+    if isinstance(tensors, torch.Tensor):
+        assert tensors.shape == shapes
+        assert tensors.dtype == dtypes
+    else:
+        for tensor, shape, dtype in zip(tensors, shapes, dtypes):
+            assert_shapes_and_dtypes(tensor, shape, dtype)
+
+
+@pytest.mark.parametrize(
+    "module, batch_size, expected_shapes, expected_dtypes",
+    [
+        (
+            DeepARModel(
+                freq="1H",
+                context_length=24,
+                prediction_length=12,
+                num_feat_dynamic_real=1,
+                num_feat_static_real=1,
+                num_feat_static_cat=1,
+                cardinality=[1],
+            ),
+            4,
+            (4, 100, 12),
+            torch.float,
+        ),
+        (
+            MQF2MultiHorizonModel(
+                freq="1H",
+                context_length=24,
+                prediction_length=12,
+                num_feat_dynamic_real=1,
+                num_feat_static_real=1,
+                num_feat_static_cat=1,
+                cardinality=[1],
+            ),
+            4,
+            (4, 100, 12),
+            torch.float,
+        ),
+        (
+            SimpleFeedForwardModel(
+                context_length=24,
+                prediction_length=12,
+            ),
+            4,
+            [[(4, 12), (4, 12), (4, 12)], (4, 1), (4, 1)],
+            [[torch.float, torch.float, torch.float], torch.float, torch.float],
+        ),
+    ],
+)
+def test_module_smoke(module, batch_size, expected_shapes, expected_dtypes):
+    batch = construct_batch(module, batch_size=batch_size)
+    outputs = module(*batch)
+    assert_shapes_and_dtypes(outputs, expected_shapes, expected_dtypes)

--- a/test/torch/model/test_modules.py
+++ b/test/torch/model/test_modules.py
@@ -64,7 +64,11 @@ def assert_shapes_and_dtypes(tensors, shapes, dtypes):
             ),
             4,
             [[(4, 12), (4, 12), (4, 12)], (4, 1), (4, 1)],
-            [[torch.float, torch.float, torch.float], torch.float, torch.float],
+            [
+                [torch.float, torch.float, torch.float],
+                torch.float,
+                torch.float,
+            ],
         ),
     ],
 )

--- a/test/torch/model/test_modules.py
+++ b/test/torch/model/test_modules.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
 import pytest
 import torch
 


### PR DESCRIPTION
*Description of changes:* This adds a generic smoke test that can be used to check in new torch models. The idea is that any model will explicitly declare its input type and shape through `input_shapes` and `input_types`, and those can be used to generate a batch and check that the output is as expected.

Also doing minor changes to `MQF2MultiHorizonModel `, and to `SimpleFeedForwardModel` in order to support the test.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup