### PR TITLE
Fix `QuantileForecast.quantile` in case only mean is stored

### DIFF
--- a/src/gluonts/model/forecast.py
+++ b/src/gluonts/model/forecast.py
@@ -718,7 +718,7 @@ class QuantileForecast(Forecast):
 
         inference_quantile = Quantile.parse(inference_quantile).value
 
-        if len(quantiles) == 1 or inference_quantile in quantiles:
+        if len(quantiles) < 2 or inference_quantile in quantiles:
             q_str = Quantile.parse(inference_quantile).name
             return self._forecast_dict.get(q_str, self._nan_out)
 

--- a/test/model/test_forecast.py
+++ b/test/model/test_forecast.py
@@ -53,7 +53,7 @@ MULTIVARIATE_FORECASTS = {
 
 
 @pytest.mark.parametrize("name", FORECASTS.keys())
-def test_Forecast(name):
+def test_forecast(name):
     forecast = FORECASTS[name]
 
     def percentile(value):
@@ -73,6 +73,23 @@ def test_Forecast(name):
     assert forecast.index[0] == START_DATE
 
     forecast.plot()
+
+
+def test_mean_only_forecast():
+    forecast = QuantileForecast(
+        forecast_arrays=np.ones(shape=(1, 12)),
+        start_date=pd.Period("2022-03-04 00", freq="H"),
+        forecast_keys=["mean"],
+    )
+
+    assert forecast.prediction_length == 12
+    assert len(forecast.index) == 12
+    assert forecast.index[0] == pd.Period("2022-03-04 00", freq="H")
+
+    for level in [0.1, 0.5, 0.7]:
+        assert np.isnan(forecast.quantile(level)).all()
+    
+    assert np.equal(forecast.mean, 1).all()
 
 
 @pytest.mark.parametrize(

--- a/test/model/test_forecast.py
+++ b/test/model/test_forecast.py
@@ -88,7 +88,7 @@ def test_mean_only_forecast():
 
     for level in [0.1, 0.5, 0.7]:
         assert np.isnan(forecast.quantile(level)).all()
-    
+
     assert np.equal(forecast.mean, 1).all()
 
 


### PR DESCRIPTION
*Issue #, if available:* Fixes #2498

*Description of changes:* There was a bug into the logic that decided whether to do linear interpolation or not, in the edge case where only mean is stored in the forecast object. This fixes it and adds a test.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup