### PR TITLE
Add TemporalFusionTransformer implementation in PyTorch

### DIFF
--- a/docs/bibliography.rst
+++ b/docs/bibliography.rst
@@ -21,6 +21,8 @@ Bibliography
 
 .. [LCY+18] Lai, Guokun, et al. "Modeling long-and short-term temporal patterns with deep neural networks." The 41st International ACM SIGIR Conference on Research & Development in Information Retrieval. ACM, 2018.
 
+.. [LAL+21] Lim, Bryan, Sercan O. Arik, Nicolas Loeff, and Tomas Pfister. "Temporal Fusion Transformers for Interpretable Multi-horizon Time Series Forecasting." International Journal of Forecasting 37.4 (2021): 1748-1764
+
 .. [SSA20] Makridakis, Spyros, Evangelos Spiliotis, and Vassilios Assimakopoulos. "The M4 Competition: 100,000 time series and 61 forecasting methods." International Journal of Forecasting 36.1 (2020): 54-74.
 
 .. [MKH19] Muller, Rafael, Simon Kornblith, and Geoffrey E. Hinton. "When does label smoothing help?." Advances in Neural Information Processing Systems. 2019.

--- a/src/gluonts/dataset/field_names.py
+++ b/src/gluonts/dataset/field_names.py
@@ -28,6 +28,7 @@ class FieldName:
     FEAT_STATIC_REAL = "feat_static_real"
     FEAT_DYNAMIC_CAT = "feat_dynamic_cat"
     FEAT_DYNAMIC_REAL = "feat_dynamic_real"
+    PAST_FEAT_DYNAMIC_CAT = "past_feat_dynamic_cat"
     PAST_FEAT_DYNAMIC_REAL = "past_feat_dynamic_real"
     FEAT_DYNAMIC_REAL_LEGACY = "dynamic_feat"
 

--- a/src/gluonts/model/forecast_generator.py
+++ b/src/gluonts/model/forecast_generator.py
@@ -116,7 +116,7 @@ class QuantileForecastGenerator(ForecastGenerator):
         for batch in inference_data_loader:
             # TODO: Change inputs to dict to avoid assuming matching order in input_names / model signature?
             inputs = [batch.get(k) for k in input_names]
-            outputs = prediction_net(*inputs).cpu().detach().numpy()
+            outputs = predict_to_numpy(prediction_net, inputs)
             if output_transform is not None:
                 outputs = output_transform(batch, outputs)
 

--- a/src/gluonts/model/forecast_generator.py
+++ b/src/gluonts/model/forecast_generator.py
@@ -114,8 +114,9 @@ class QuantileForecastGenerator(ForecastGenerator):
         **kwargs
     ) -> Iterator[Forecast]:
         for batch in inference_data_loader:
-            inputs = [batch[k] for k in input_names]
-            outputs = predict_to_numpy(prediction_net, inputs)
+            # TODO: Change inputs to dict to avoid assuming matching order in input_names / model signature?
+            inputs = [batch.get(k) for k in input_names]
+            outputs = prediction_net(*inputs).cpu().detach().numpy()
             if output_transform is not None:
                 outputs = output_transform(batch, outputs)
 

--- a/src/gluonts/mx/model/tft/_estimator.py
+++ b/src/gluonts/mx/model/tft/_estimator.py
@@ -50,12 +50,13 @@ from gluonts.transform import (
     ValidationSplitSampler,
     VstackFeatures,
 )
+from gluonts.transform.split import TFTInstanceSplitter
 
 from ._network import (
     TemporalFusionTransformerPredictionNetwork,
     TemporalFusionTransformerTrainingNetwork,
 )
-from ._transform import BroadcastTo, TFTInstanceSplitter
+from ._transform import BroadcastTo
 
 
 def _default_feat_args(dims_or_cardinalities: List[int]):

--- a/src/gluonts/mx/model/tft/_transform.py
+++ b/src/gluonts/mx/model/tft/_transform.py
@@ -11,19 +11,15 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from typing import Iterator, List
-
 import numpy as np
 
 from gluonts.core.component import validated
 from gluonts.dataset.common import DataEntry
 from gluonts.dataset.field_names import FieldName
 from gluonts.transform import (
-    InstanceSplitter,
     MapTransformation,
     target_transformation_length,
 )
-from gluonts.transform.sampler import InstanceSampler
 
 
 class BroadcastTo(MapTransformation):
@@ -47,95 +43,3 @@ class BroadcastTo(MapTransformation):
             (data[self.field].shape[:-1] + (length,)),
         )
         return data
-
-
-class TFTInstanceSplitter(InstanceSplitter):
-    @validated()
-    def __init__(
-        self,
-        instance_sampler: InstanceSampler,
-        past_length: int,
-        future_length: int,
-        target_field: str = FieldName.TARGET,
-        is_pad_field: str = FieldName.IS_PAD,
-        start_field: str = FieldName.START,
-        forecast_start_field: str = FieldName.FORECAST_START,
-        observed_value_field: str = FieldName.OBSERVED_VALUES,
-        lead_time: int = 0,
-        output_NTC: bool = True,
-        time_series_fields: List[str] = [],
-        past_time_series_fields: List[str] = [],
-        dummy_value: float = 0.0,
-    ) -> None:
-        super().__init__(
-            target_field=target_field,
-            is_pad_field=is_pad_field,
-            start_field=start_field,
-            forecast_start_field=forecast_start_field,
-            instance_sampler=instance_sampler,
-            past_length=past_length,
-            future_length=future_length,
-            lead_time=lead_time,
-            output_NTC=output_NTC,
-            time_series_fields=time_series_fields,
-            dummy_value=dummy_value,
-        )
-
-        assert past_length > 0, "The value of `past_length` should be > 0"
-
-        self.observed_value_field = observed_value_field
-        self.past_ts_fields = past_time_series_fields
-
-    def flatmap_transform(
-        self, data: DataEntry, is_train: bool
-    ) -> Iterator[DataEntry]:
-        pl = self.future_length
-        lt = self.lead_time
-        target = data[self.target_field]
-
-        sampled_indices = self.instance_sampler(target)
-
-        slice_cols = (
-            self.ts_fields
-            + self.past_ts_fields
-            + [self.target_field, self.observed_value_field]
-        )
-        for i in sampled_indices:
-            pad_length = max(self.past_length - i, 0)
-            d = data.copy()
-
-            for field in slice_cols:
-                if i >= self.past_length:
-                    past_piece = d[field][..., i - self.past_length : i]
-                else:
-                    pad_block = np.full(
-                        shape=d[field].shape[:-1] + (pad_length,),
-                        fill_value=self.dummy_value,
-                        dtype=d[field].dtype,
-                    )
-                    past_piece = np.concatenate(
-                        [pad_block, d[field][..., :i]], axis=-1
-                    )
-                future_piece = d[field][..., (i + lt) : (i + lt + pl)]
-                if field in self.ts_fields:
-                    piece = np.concatenate([past_piece, future_piece], axis=-1)
-                    if self.output_NTC:
-                        piece = piece.transpose()
-                    d[field] = piece
-                else:
-                    if self.output_NTC:
-                        past_piece = past_piece.transpose()
-                        future_piece = future_piece.transpose()
-                    if field not in self.past_ts_fields:
-                        d[self._past(field)] = past_piece
-                        d[self._future(field)] = future_piece
-                        del d[field]
-                    else:
-                        d[field] = past_piece
-            pad_indicator = np.zeros(self.past_length)
-            if pad_length > 0:
-                pad_indicator[:pad_length] = 1
-            d[self._past(self.is_pad_field)] = pad_indicator
-            d[self.forecast_start_field] = d[self.start_field] + i + lt
-
-            yield d

--- a/src/gluonts/torch/model/tft/__init__.py
+++ b/src/gluonts/torch/model/tft/__init__.py
@@ -1,0 +1,22 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from .module import TemporalFusionTransformerModel
+from .lightning_module import TemporalFusionTransformerLightningModule
+from .estimator import TemporalFusionTransformerEstimator
+
+__all__ = [
+    "TemporalFusionTransformerModel",
+    "TemporalFusionTransformerLightningModule",
+    "TemporalFusionTransformerEstimator",
+]

--- a/src/gluonts/torch/model/tft/__init__.py
+++ b/src/gluonts/torch/model/tft/__init__.py
@@ -11,9 +11,9 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from .module import TemporalFusionTransformerModel
-from .lightning_module import TemporalFusionTransformerLightningModule
 from .estimator import TemporalFusionTransformerEstimator
+from .lightning_module import TemporalFusionTransformerLightningModule
+from .module import TemporalFusionTransformerModel
 
 __all__ = [
     "TemporalFusionTransformerModel",

--- a/src/gluonts/torch/model/tft/estimator.py
+++ b/src/gluonts/torch/model/tft/estimator.py
@@ -74,7 +74,7 @@ class TemporalFusionTransformerEstimator(PyTorchLightningEstimator):
 
     For example, if the dataset contains key "feat_static_real" with shape
     [batch_size, 3], we can, e.g.,
-    - set ``static_dims = [3]`` to treat all five dimensions as a single feature
+    - set ``static_dims = [3]`` to treat all three dimensions as a single feature
     - set ``static_dims = [1, 1, 1]`` to treat each dimension as a separate feature
     - set ``static_dims = [2, 1]`` to treat the first two dims as a single feature
 

--- a/src/gluonts/torch/model/tft/estimator.py
+++ b/src/gluonts/torch/model/tft/estimator.py
@@ -23,10 +23,8 @@ from gluonts.model.forecast_generator import QuantileForecastGenerator
 from gluonts.time_feature import TimeFeature, time_features_from_frequency_str
 from gluonts.torch.model.estimator import PyTorchLightningEstimator
 from gluonts.torch.model.predictor import PyTorchPredictor
-from gluonts.torch.modules.loss import DistributionLoss, NegativeLogLikelihood
 from gluonts.torch.util import IterableDataset
 from gluonts.transform import (
-    AddAgeFeature,
     AddObservedValuesIndicator,
     AddTimeFeatures,
     AsNumpyArray,

--- a/src/gluonts/torch/model/tft/estimator.py
+++ b/src/gluonts/torch/model/tft/estimator.py
@@ -11,48 +11,41 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from typing import List, Optional, Iterable, Dict, Any
+from typing import Any, Dict, Iterable, List, Optional
 
 import torch
-from torch.utils.data import DataLoader
-
 from gluonts.core.component import validated
 from gluonts.dataset.common import Dataset
 from gluonts.dataset.field_names import FieldName
-from gluonts.itertools import Cyclic, PseudoShuffled, IterableSlice
-from gluonts.time_feature import (
-    TimeFeature,
-    time_features_from_frequency_str,
-)
+from gluonts.itertools import Cyclic, IterableSlice, PseudoShuffled
 from gluonts.model.forecast_generator import QuantileForecastGenerator
-from gluonts.torch.modules.loss import DistributionLoss, NegativeLogLikelihood
-from gluonts.transform import (
-    Transformation,
-    Chain,
-    RemoveFields,
-    SetField,
-    AsNumpyArray,
-    AddObservedValuesIndicator,
-    AddTimeFeatures,
-    AddAgeFeature,
-    VstackFeatures,
-    InstanceSplitter,
-    ValidationSplitSampler,
-    TestSplitSampler,
-    ExpectedNumInstanceSampler,
-    SelectFields,
-)
-from gluonts.torch.util import (
-    IterableDataset,
-)
+from gluonts.time_feature import TimeFeature, time_features_from_frequency_str
 from gluonts.torch.model.estimator import PyTorchLightningEstimator
 from gluonts.torch.model.predictor import PyTorchPredictor
+from gluonts.torch.modules.loss import DistributionLoss, NegativeLogLikelihood
+from gluonts.torch.util import IterableDataset
+from gluonts.transform import (
+    AddAgeFeature,
+    AddObservedValuesIndicator,
+    AddTimeFeatures,
+    AsNumpyArray,
+    Chain,
+    ExpectedNumInstanceSampler,
+    InstanceSplitter,
+    RemoveFields,
+    SelectFields,
+    SetField,
+    TestSplitSampler,
+    Transformation,
+    ValidationSplitSampler,
+    VstackFeatures,
+)
 from gluonts.transform.sampler import InstanceSampler
+from torch.utils.data import DataLoader
 
-from .module import TemporalFusionTransformerModel
 from .lightning_module import TemporalFusionTransformerLightningModule
+from .module import TemporalFusionTransformerModel
 from .transformation import TFTInstanceSplitter
-
 
 PREDICTION_INPUT_NAMES = [
     "feat_static_cat",

--- a/src/gluonts/torch/model/tft/estimator.py
+++ b/src/gluonts/torch/model/tft/estimator.py
@@ -72,6 +72,13 @@ TRAINING_INPUT_NAMES = PREDICTION_INPUT_NAMES + [
 ]
 
 
+def _default_feat_args(dims_or_cardinalities: List[int]):
+    if dims_or_cardinalities:
+        return dims_or_cardinalities
+    else:
+        return [1]
+
+
 class TemporalFusionTransformerEstimator(PyTorchLightningEstimator):
     """
     Estimator class to train a Temporal Fusion Transformer model, as described in [SFG17]_.
@@ -256,7 +263,26 @@ class TemporalFusionTransformerEstimator(PyTorchLightningEstimator):
         self,
     ) -> TemporalFusionTransformerLightningModule:
         model = TemporalFusionTransformerModel(
-            freq=self.freq,
+            context_length=self.context_length,
+            prediction_length=self.prediction_length,
+            d_var=self.variable_dim,
+            d_hidden=self.hidden_dim,
+            num_heads=self.num_heads,
+            quantiles=self.quantiles,
+            d_past_feat_dynamic_real=_default_feat_args(
+                self.past_dynamic_dims
+            ),
+            c_past_feat_dynamic_cat=_default_feat_args(
+                self.past_dynamic_cardinalities
+            ),
+            d_feat_dynamic_real=_default_feat_args(
+                [1] * len(self.time_features) + self.dynamic_dims
+            ),
+            c_feat_dynamic_cat=_default_feat_args(self.dynamic_cardinalities),
+            d_feat_static_real=_default_feat_args(self.static_dims),
+            c_feat_static_cat=_default_feat_args(self.static_cardinalities),
+            dropout_rate=self.dropout_rate,
+            scaling=self.scaling,
         )
         return TemporalFusionTransformerLightningModule(
             model=model,

--- a/src/gluonts/torch/model/tft/estimator.py
+++ b/src/gluonts/torch/model/tft/estimator.py
@@ -39,11 +39,11 @@ from gluonts.transform import (
     VstackFeatures,
 )
 from gluonts.transform.sampler import InstanceSampler
+from gluonts.transform.split import TFTInstanceSplitter
 from torch.utils.data import DataLoader
 
 from .lightning_module import TemporalFusionTransformerLightningModule
 from .module import TemporalFusionTransformerModel
-from .transformation import TFTInstanceSplitter
 
 PREDICTION_INPUT_NAMES = [
     "past_target",

--- a/src/gluonts/torch/model/tft/estimator.py
+++ b/src/gluonts/torch/model/tft/estimator.py
@@ -1,0 +1,178 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from typing import List, Optional, Iterable, Dict, Any
+
+import torch
+from torch.utils.data import DataLoader
+
+from gluonts.core.component import validated
+from gluonts.dataset.common import Dataset
+from gluonts.dataset.field_names import FieldName
+from gluonts.itertools import Cyclic, PseudoShuffled, IterableSlice
+from gluonts.time_feature import (
+    TimeFeature,
+    time_features_from_frequency_str,
+)
+from gluonts.model.forecast_generator import QuantileForecastGenerator
+from gluonts.torch.modules.loss import DistributionLoss, NegativeLogLikelihood
+from gluonts.transform import (
+    Transformation,
+    Chain,
+    RemoveFields,
+    SetField,
+    AsNumpyArray,
+    AddObservedValuesIndicator,
+    AddTimeFeatures,
+    AddAgeFeature,
+    VstackFeatures,
+    InstanceSplitter,
+    ValidationSplitSampler,
+    TestSplitSampler,
+    ExpectedNumInstanceSampler,
+    SelectFields,
+)
+from gluonts.torch.util import (
+    IterableDataset,
+)
+from gluonts.torch.model.estimator import PyTorchLightningEstimator
+from gluonts.torch.model.predictor import PyTorchPredictor
+from gluonts.transform.sampler import InstanceSampler
+
+
+class TemporalFusionTransformer(PyTorchLightningEstimator):
+    @validated()
+    def __init__(
+        self,
+        freq: str,
+        prediction_length: int,
+        context_length: Optional[int] = None,
+        num_layers: int = 2,
+        hidden_size: int = 40,
+        lr: float = 1e-3,
+        weight_decay: float = 1e-8,
+        dropout_rate: float = 0.1,
+        patience: int = 10,
+        num_feat_dynamic_cat: int = 0,
+        num_feat_dynamic_real: int = 0,
+        num_feat_static_cat: int = 0,
+        num_feat_static_real: int = 0,
+        num_past_feat_dynamic_cat: int = 0,
+        num_past_feat_dynamic_real: int = 0,
+        dynamic_cardinalities: Optional[List[int]] = None,
+        static_cardinalities: Optional[List[int]] = None,
+        past_dynamic_cardinalities: Optional[List[int]] = None,
+        embedding_dimension: Optional[List[int]] = None,
+        scaling: bool = True,
+        lags_seq: Optional[List[int]] = None,
+        time_features: Optional[List[TimeFeature]] = None,
+        batch_size: int = 32,
+        num_batches_per_epoch: int = 50,
+        trainer_kwargs: Optional[Dict[str, Any]] = None,
+        train_sampler: Optional[InstanceSampler] = None,
+        validation_sampler: Optional[InstanceSampler] = None,
+        quantiles: Optional[List[float]] = None,
+    ) -> None:
+        default_trainer_kwargs = {
+            "max_epochs": 100,
+            "gradient_clip_val": 10.0,
+        }
+        if trainer_kwargs is not None:
+            default_trainer_kwargs.update(trainer_kwargs)
+        super().__init__(trainer_kwargs=default_trainer_kwargs)
+
+        self.freq = freq
+        self.context_length = (
+            context_length if context_length is not None else prediction_length
+        )
+        self.prediction_length = prediction_length
+        self.patience = patience
+        self.num_layers = num_layers
+        self.hidden_size = hidden_size
+        self.lr = lr
+        self.weight_decay = weight_decay
+        self.dropout_rate = dropout_rate
+        self.num_feat_dynamic_real = num_feat_dynamic_real
+        self.num_feat_static_cat = num_feat_static_cat
+        self.num_feat_static_real = num_feat_static_real
+        self.cardinality = (
+            cardinality if cardinality and num_feat_static_cat > 0 else [1]
+        )
+        self.embedding_dimension = embedding_dimension
+        self.scaling = scaling
+        self.lags_seq = lags_seq
+        self.time_features = (
+            time_features
+            if time_features is not None
+            else time_features_from_frequency_str(self.freq)
+        )
+
+        self.batch_size = batch_size
+        self.num_batches_per_epoch = num_batches_per_epoch
+
+        self.train_sampler = train_sampler or ExpectedNumInstanceSampler(
+            num_instances=1.0, min_future=prediction_length
+        )
+        self.validation_sampler = validation_sampler or ValidationSplitSampler(
+            min_future=prediction_length
+        )
+        if quantiles is None:
+            quantiles = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+        self.quantiles = quantiles
+        # TODO
+
+    def create_transformation(self) -> Transformation:
+        remove_field_names = []
+        # TODO
+
+    def _create_instance_splitter(self, mode: str):
+        # TODO
+        pass
+
+    def create_training_data_loader(
+        self,
+        data: Dataset,
+        module: TemporalFusionTransformerLightningModule,
+        shuffle_buffer_length: Optional[int] = None,
+        **kwargs,
+    ) -> Iterable:
+        # TODO
+        pass
+
+    def create_lightning_module(
+        self,
+    ) -> TemporalFusionTransformerLightningModule:
+        # TODO
+        pass
+
+    def create_predictor(
+        self,
+        transformation: Transformation,
+        module: TemporalFusionTransformerLightningModule,
+    ) -> PyTorchPredictor:
+        # TODO
+        prediction_splitter = self._create_instance_splitter(module, "test")
+
+        return PyTorchPredictor(
+            input_transform=transformation + prediction_splitter,
+            input_names=PREDICTION_INPUT_NAMES,
+            prediction_net=module,
+            batch_size=self.batch_size,
+            prediction_length=self.prediction_length,
+            device=torch.device(
+                "cuda" if torch.cuda.is_available() else "cpu"
+            ),
+            forecast_generator=QuantileForecastGenerator(
+                quantiles=[str(q) for q in self.quantiles]
+            ),
+        )

--- a/src/gluonts/torch/model/tft/estimator.py
+++ b/src/gluonts/torch/model/tft/estimator.py
@@ -74,7 +74,7 @@ def _default_feat_args(dims_or_cardinalities: List[int]):
 
 class TemporalFusionTransformerEstimator(PyTorchLightningEstimator):
     """
-    Estimator class to train a Temporal Fusion Transformer model, as described in [SFG17]_.
+    Estimator class to train a Temporal Fusion Transformer model, as described in [LAL+21]_.
 
     Parameters
     ----------
@@ -83,7 +83,7 @@ class TemporalFusionTransformerEstimator(PyTorchLightningEstimator):
     prediction_length
         Length of the prediction horizon.
     context_length
-        Number of steps to unroll the RNN for before computing predictions
+        Number of previous time series values provided as input to the encoder.
         (default: None, in which case context_length = prediction_length).
     quantiles
         List of quantiles that the model will learn to predict.
@@ -91,9 +91,9 @@ class TemporalFusionTransformerEstimator(PyTorchLightningEstimator):
     num_heads
         Number of attention heads in self-attention layer in the decoder.
     hidden_dim
-        Size of the LSTM & transformer hidden states
+        Size of the LSTM & transformer hidden states.
     variable_dim
-        Size of the feature embeddings
+        Size of the feature embeddings.
     static_dims
         Sizes of the real-valued static features.
     dynamic_dims

--- a/src/gluonts/torch/model/tft/estimator.py
+++ b/src/gluonts/torch/model/tft/estimator.py
@@ -49,12 +49,12 @@ from .module import TemporalFusionTransformerModel
 PREDICTION_INPUT_NAMES = [
     "past_target",
     "past_observed_values",
-    "past_feat_dynamic_real",
-    "past_feat_dynamic_cat",
-    "feat_dynamic_real",
-    "feat_dynamic_cat",
     "feat_static_real",
     "feat_static_cat",
+    "feat_dynamic_real",
+    "feat_dynamic_cat",
+    "past_feat_dynamic_real",
+    "past_feat_dynamic_cat",
 ]
 
 TRAINING_INPUT_NAMES = PREDICTION_INPUT_NAMES + [
@@ -65,7 +65,23 @@ TRAINING_INPUT_NAMES = PREDICTION_INPUT_NAMES + [
 
 class TemporalFusionTransformerEstimator(PyTorchLightningEstimator):
     """
-    Estimator class to train a Temporal Fusion Transformer model, as described in [LAL+21]_.
+    Estimator class to train a Temporal Fusion Transformer (TFT) model, as described in [LAL+21]_.
+
+    TFT internally performs feature selection when making forecasts. For this
+    reason, the dimensions of real-valued features can be grouped together if
+    they correspond to the same variable (e.g., treat weather features as a
+    one feature and holiday indicators as another feature).
+
+    For example, if the dataset contains key "feat_static_real" with shape
+    [batch_size, 3], we can, e.g.,
+    - set ``static_dims = [3]`` to treat all five dimensions as a single feature
+    - set ``static_dims = [1, 1, 1]`` to treat each dimension as a separate feature
+    - set ``static_dims = [2, 1]`` to treat the first two dims as a single feature
+
+    See ``gluonts.torch.model.tft.TemporalFusionTransformerModel.input_shapes``
+    for more details on how the model configuration corresponds to the expected
+    input shapes.
+
 
     Parameters
     ----------

--- a/src/gluonts/torch/model/tft/estimator.py
+++ b/src/gluonts/torch/model/tft/estimator.py
@@ -48,28 +48,20 @@ from .module import TemporalFusionTransformerModel
 from .transformation import TFTInstanceSplitter
 
 PREDICTION_INPUT_NAMES = [
-    "feat_static_cat",
-    "feat_static_real",
-    "feat_dynamic_cat",
-    "feat_dynamic_real",
-    "past_feat_dynamic_cat",
-    "past_feat_dynamic_real",
     "past_target",
     "past_observed_values",
-    "past_is_pad",
+    "past_feat_dynamic_real",
+    "past_feat_dynamic_cat",
+    "feat_dynamic_real",
+    "feat_dynamic_cat",
+    "feat_static_real",
+    "feat_static_cat",
 ]
 
 TRAINING_INPUT_NAMES = PREDICTION_INPUT_NAMES + [
     "future_target",
     "future_observed_values",
 ]
-
-
-def _default_feat_args(dims_or_cardinalities: List[int]):
-    if dims_or_cardinalities:
-        return dims_or_cardinalities
-    else:
-        return [1]
 
 
 class TemporalFusionTransformerEstimator(PyTorchLightningEstimator):

--- a/src/gluonts/torch/model/tft/layers.py
+++ b/src/gluonts/torch/model/tft/layers.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
 from typing import List, Optional, Tuple
 
 import torch

--- a/src/gluonts/torch/model/tft/layers.py
+++ b/src/gluonts/torch/model/tft/layers.py
@@ -8,6 +8,55 @@ from gluonts.torch.modules.feature import (
 )
 
 
+class StdScaler(nn.Module):
+    """
+    Computes a std scaling  value along dimension ``dim``, and scales the data accordingly.
+
+    Parameters
+    ----------
+    dim
+        dimension along which to compute the scale
+    keepdim
+        controls whether to retain dimension ``dim`` (of length 1) in the
+        scale tensor, or suppress it.
+    minimum_scale
+        default scale that is used for elements that are constantly zero
+        along dimension ``dim``.
+    """
+
+    @validated()
+    def __init__(
+        self, dim: int, keepdim: bool = False, minimum_scale: float = 1e-5
+    ):
+        super().__init__()
+        assert dim > 0, (
+            "Cannot compute scale along dim = 0 (batch dimension), please"
+            " provide dim > 0"
+        )
+        self.dim = dim
+        self.keepdim = keepdim
+        self.register_buffer("minimum_scale", torch.tensor(minimum_scale))
+
+    def forward(
+        self, data: torch.Tensor, weights: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        assert (
+            data.shape == weights.shape
+        ), "data and weights must have same shape"
+        with torch.no_grad():
+            denominator = weights.sum(self.dim, keepdim=self.keepdim)
+            denominator = denominator.clamp_min(1.0)
+            loc = (data * weights).sum(
+                self.dim, keepdim=self.keepdim
+            ) / denominator
+
+            variance = (((data - loc) * weights) ** 2).sum(
+                self.dim, keepdim=self.keepdim
+            ) / denominator
+            scale = torch.sqrt(variance + self.minimum_scale)
+            return (data - loc) / scale, loc, scale
+
+
 class FeatureEmbedder(BaseFeatureEmbedder):
     def forward(self, features: torch.Tensor) -> List[torch.Tensor]:
         concat_features = super().forward(features=features)

--- a/src/gluonts/torch/model/tft/layers.py
+++ b/src/gluonts/torch/model/tft/layers.py
@@ -1,0 +1,300 @@
+import torch
+import torch.nn as nn
+
+from typing import List, Optional, Tuple
+from gluonts.core.component import validated
+from gluonts.torch.modules.feature import (
+    FeatureEmbedder as BaseFeatureEmbedder,
+)
+
+
+class FeatureEmbedder(BaseFeatureEmbedder):
+    def forward(self, features: torch.Tensor) -> List[torch.Tensor]:
+        concat_features = super(FeatureEmbedder, self)(features=features)
+
+        if self._num_features > 1:
+            features = torch.chunk(concat_features, self._num_features, dim=-1)
+        else:
+            features = [concat_features]
+
+        return features
+
+
+class GatedLinearUnit(nn.Module):
+    @validated()
+    def __init__(self, dim: int = -1, nonlinear: bool = True):
+        super().__init__()
+        self.dim = dim
+        self.nonlinear = nonlinear
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        value, gate = torch.chunk(x, chunks=2, dim=self.dim)
+        if self.nonlinear:
+            value = torch.tanh(value)
+        gate = torch.sigmoid(gate)
+        return gate * value
+
+
+class GatedResidualNetwork(nn.Module):
+    @validated()
+    def __init__(
+        self,
+        d_hidden: int,
+        d_input: Optional[int] = None,
+        d_output: Optional[int] = None,
+        d_static: Optional[int] = None,
+        dropout: float = 0.0,
+    ):
+        super().__init__()
+        self.d_hidden = d_hidden
+        self.d_input = d_input or d_hidden
+        self.d_static = d_static or 0
+        if d_output is None:
+            self.d_output = self.d_input
+            self.add_skip = False
+        else:
+            self.d_output = d_output
+            if d_output != self.d_input:
+                self.add_skip = True
+                self.skip_proj = nn.Linear(
+                    in_features=self.d_input,
+                    out_features=self.d_output,
+                )
+            else:
+                self.add_skip = False
+
+        self.mlp = nn.Sequential(
+            nn.Linear(
+                in_features=self.d_input + self.d_static,
+                out_features=self.d_hidden,
+            ),
+            nn.ELU(),
+            nn.Linear(
+                in_features=self.d_hidden,
+                out_features=self.d_hidden,
+            ),
+            nn.Dropout(p=dropout),
+            nn.Linear(
+                in_features=self.d_hidden,
+                out_features=self.d_output * 2,
+            ),
+            GatedLinearUnit(nonlinear=False),
+        )
+        self.layer_norm = nn.LayerNorm([self.d_output])
+
+    def forward(
+        self, x: torch.Tensor, c: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        if self.add_skip:
+            skip = self.skip_proj(x)
+        else:
+            skip = x
+        if self.d_static > 0 and c is None:
+            raise ValueError("static variable is expected.")
+        if self.d_static == 0 and c is not None:
+            raise ValueError("static variable is not accepted.")
+        if c is not None:
+            x = torch.concat([x, c], dim=-1)
+        x = self.mlp(x)
+        x = self.layer_norm(x + skip)
+        return x
+
+
+class VariableSelectionNetwork(nn.Module):
+    @validated()
+    def __init__(
+        self,
+        d_hidden: int,
+        num_vars: int,
+        dropout: float = 0.0,
+        add_static: bool = False,
+    ) -> None:
+        super().__init__()
+        self.d_hidden = d_hidden
+        self.num_vars = num_vars
+        self.add_static = add_static
+
+        self.weight_network = GatedResidualNetwork(
+            d_hidden=self.d_hidden,
+            d_input=self.d_hidden * self.n_vars,
+            d_output=self.num_vars,
+            d_static=self.d_hidden if add_static else None,
+            dropout=dropout,
+        )
+        self.variable_networks = nn.ModuleList(
+            [
+                GatedResidualNetwork(d_hidden=d_hidden, dropout=dropout)
+                for _ in range(num_vars)
+            ]
+        )
+
+    def forward(
+        self,
+        variables: List[torch.Tensor],
+        static: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        flatten = torch.cat(variables, dim=-1)
+        if static is not None:
+            static = static.expand_as(variables[0])
+        weight = self.weight_network(flatten, static)
+        weight = torch.softmax(weight.unsqueeze(-2), dim=-1)
+
+        var_encodings = [
+            net(var) for var, net in zip(variables, self.variable_network)
+        ]
+        var_encodings = torch.stack(var_encodings, dim=-1)
+
+        var_encodings = torch.sum(var_encodings * weight, dim=-1)
+
+        return var_encodings, weight
+
+
+class TemporalFusionEncoder(nn.Module):
+    @validated()
+    def __init__(
+        self,
+        d_input: int,
+        d_hidden: int,
+    ):
+        super().__init__()
+
+        self.encoder_lstm = nn.LSTM(
+            input_size=d_input, hidden_size=d_hidden, batch_first=True
+        )
+        self.decoder_lstm = nn.LSTM(
+            input_size=d_input, hidden_size=d_hidden, batch_first=True
+        )
+
+        self.gate = nn.Sequential(
+            nn.Linear(in_features=d_hidden, out_features=d_hidden * 2),
+            nn.GLU(),
+        )
+        if d_input != d_hidden:
+            self.skip_proj = nn.Linear(
+                in_features=d_input, out_features=d_hidden
+            )
+            self.add_skip = True
+        else:
+            self.add_skip = False
+
+        self.lnorm = nn.LayerNorm(d_hidden)
+
+    def forward(
+        self,
+        ctx_input: torch.Tensor,
+        tgt_input: Optional[torch.Tensor] = None,
+        states: Optional[List[torch.Tensor]] = None,
+    ):
+        ctx_encodings, states = self.encoder_lstm(ctx_input, states)
+
+        if tgt_input is not None:
+            tgt_encodings, _ = self.decoder_lstm(tgt_input, states)
+            encodings = torch.cat((ctx_encodings, tgt_encodings), dim=1)
+            skip = torch.cat((ctx_input, tgt_input), dim=1)
+        else:
+            encodings = ctx_encodings
+            skip = ctx_input
+
+        if self.add_skip:
+            skip = self.skip_proj(skip)
+        encodings = self.gate(encodings)
+        encodings = self.lnorm(skip + encodings)
+        return encodings
+
+
+class TemporalFusionDecoder(nn.Module):
+    @validated()
+    def __init__(
+        self,
+        context_length: int,
+        prediction_length: int,
+        d_hidden: int,
+        d_var: int,
+        num_heads: int,
+        dropout: float = 0.0,
+    ):
+        super().__init__()
+        self.context_length = context_length
+        self.prediction_length = prediction_length
+
+        self.enrich = GatedResidualNetwork(
+            d_hidden=d_hidden,
+            d_static=d_var,
+            dropout=dropout,
+        )
+
+        self.attention = nn.MultiheadAttention(
+            embed_dim=d_hidden,
+            num_heads=num_heads,
+            dropout=dropout,
+            batch_first=True,
+        )
+
+        self.att_net = nn.Sequential(
+            nn.Linear(in_features=d_hidden, out_features=d_hidden * 2),
+            nn.GLU(),
+        )
+        self.att_lnorm = nn.LayerNorm(d_hidden)
+
+        self.ff_net = nn.Sequential(
+            GatedResidualNetwork(d_hidden=d_hidden, dropout=dropout),
+            nn.Linear(in_features=d_hidden, out_features=d_hidden * 2),
+            nn.GLU(),
+        )
+        self.ff_lnorm = nn.LayerNorm(d_hidden)
+
+        self.register_buffer(
+            "attn_mask",
+            self._generate_subsequent_mask(
+                prediction_length, prediction_length + context_length
+            ),
+        )
+
+    @staticmethod
+    def _generate_subsequent_mask(
+        target_length: int, source_length: int
+    ) -> torch.Tensor:
+        mask = (
+            torch.triu(torch.ones(source_length, target_length)) == 1
+        ).transpose(0, 1)
+        mask = (
+            mask.float()
+            .masked_fill(mask == 0, float("-inf"))
+            .masked_fill(mask == 1, float(0.0))
+        )
+        return mask
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        static: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
+        causal: bool = True,
+    ) -> torch.Tensor:
+        expanded_static = static.expand_as(x)
+        # static.repeat((1, self.context_length + self.prediction_length, 1))
+
+        skip = x[:, self.context_length :, ...]
+        x = self.enrich(x, expanded_static)
+
+        # does not work on GPU :-(
+        # mask_pad = torch.ones_like(mask)[:, 0:1, ...]
+        # mask_pad = mask_pad.repeat((1, self.prediction_length))
+        # key_padding_mask = torch.cat((mask, mask_pad), dim=1).bool()
+
+        query_key_value = x
+        attn_output, _ = self.attention(
+            query=query_key_value[:, self.context_length :, ...],
+            key=query_key_value,
+            value=query_key_value,
+            # key_padding_mask=key_padding_mask,
+            attn_mask=self.attn_mask if causal else None,
+        )
+        att = self.att_net(attn_output)
+
+        x = x[:, self.context_length :, ...]
+        x = self.att_lnorm(x + att)
+        x = self.ff_net(x)
+        x = self.ff_lnorm(x + skip)
+
+        return x

--- a/src/gluonts/torch/model/tft/layers.py
+++ b/src/gluonts/torch/model/tft/layers.py
@@ -1,60 +1,11 @@
+from typing import List, Optional, Tuple
+
 import torch
 import torch.nn as nn
-
-from typing import List, Optional, Tuple
 from gluonts.core.component import validated
 from gluonts.torch.modules.feature import (
     FeatureEmbedder as BaseFeatureEmbedder,
 )
-
-
-class StdScaler(nn.Module):
-    """
-    Computes a std scaling  value along dimension ``dim``, and scales the data accordingly.
-
-    Parameters
-    ----------
-    dim
-        dimension along which to compute the scale
-    keepdim
-        controls whether to retain dimension ``dim`` (of length 1) in the
-        scale tensor, or suppress it.
-    minimum_scale
-        default scale that is used for elements that are constantly zero
-        along dimension ``dim``.
-    """
-
-    @validated()
-    def __init__(
-        self, dim: int, keepdim: bool = False, minimum_scale: float = 1e-5
-    ):
-        super().__init__()
-        assert dim > 0, (
-            "Cannot compute scale along dim = 0 (batch dimension), please"
-            " provide dim > 0"
-        )
-        self.dim = dim
-        self.keepdim = keepdim
-        self.register_buffer("minimum_scale", torch.tensor(minimum_scale))
-
-    def forward(
-        self, data: torch.Tensor, weights: torch.Tensor
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        assert (
-            data.shape == weights.shape
-        ), "data and weights must have same shape"
-        with torch.no_grad():
-            denominator = weights.sum(self.dim, keepdim=self.keepdim)
-            denominator = denominator.clamp_min(1.0)
-            loc = (data * weights).sum(
-                self.dim, keepdim=self.keepdim
-            ) / denominator
-
-            variance = (((data - loc) * weights) ** 2).sum(
-                self.dim, keepdim=self.keepdim
-            ) / denominator
-            scale = torch.sqrt(variance + self.minimum_scale)
-            return (data - loc) / scale, loc, scale
 
 
 class FeatureEmbedder(BaseFeatureEmbedder):

--- a/src/gluonts/torch/model/tft/lightning_module.py
+++ b/src/gluonts/torch/model/tft/lightning_module.py
@@ -1,2 +1,6 @@
+import torch.nn as nn
+
+
 class TemporalFusionTransformerLightningModule:
-    pass
+    def __init__(self, model: nn.Module, lr: float, patience: int):
+        self.model = model

--- a/src/gluonts/torch/model/tft/lightning_module.py
+++ b/src/gluonts/torch/model/tft/lightning_module.py
@@ -1,0 +1,2 @@
+class TemporalFusionTransformerLightningModule:
+    pass

--- a/src/gluonts/torch/model/tft/lightning_module.py
+++ b/src/gluonts/torch/model/tft/lightning_module.py
@@ -1,6 +1,10 @@
+import pytorch_lightning as pl
 import torch.nn as nn
 
 
-class TemporalFusionTransformerLightningModule:
+class TemporalFusionTransformerLightningModule(pl.LightningModule):
     def __init__(self, model: nn.Module, lr: float, patience: int):
+        super().__init__()
         self.model = model
+        self.lr = lr
+        self.patience = patience

--- a/src/gluonts/torch/model/tft/lightning_module.py
+++ b/src/gluonts/torch/model/tft/lightning_module.py
@@ -1,5 +1,5 @@
-import torch
 import pytorch_lightning as pl
+import torch
 from gluonts.core.component import validated
 from gluonts.itertools import select
 from torch.optim.lr_scheduler import ReduceLROnPlateau

--- a/src/gluonts/torch/model/tft/lightning_module.py
+++ b/src/gluonts/torch/model/tft/lightning_module.py
@@ -1,6 +1,6 @@
 import torch
 import pytorch_lightning as pl
-import torch.nn as nn
+from gluonts.core.component import validated
 from gluonts.itertools import select
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 
@@ -27,6 +27,7 @@ class TemporalFusionTransformerLightningModule(pl.LightningModule):
         Patience parameter for learning rate scheduler, default: ``10``.
     """
 
+    @validated()
     def __init__(
         self,
         model: TemporalFusionTransformerModel,
@@ -35,7 +36,7 @@ class TemporalFusionTransformerLightningModule(pl.LightningModule):
         weight_decay: float = 0.0,
     ):
         super().__init__()
-        self.save_hyperparameters(ignore=["model"])
+        self.save_hyperparameters()
         self.model = model
         self.lr = lr
         self.patience = patience

--- a/src/gluonts/torch/model/tft/lightning_module.py
+++ b/src/gluonts/torch/model/tft/lightning_module.py
@@ -1,10 +1,114 @@
+import torch
 import pytorch_lightning as pl
 import torch.nn as nn
+from gluonts.itertools import select
+from torch.optim.lr_scheduler import ReduceLROnPlateau
+
+from .module import TemporalFusionTransformerModel
 
 
 class TemporalFusionTransformerLightningModule(pl.LightningModule):
-    def __init__(self, model: nn.Module, lr: float, patience: int):
+    """
+    A ``pl.LightningModule`` class that can be used to train a
+    ``TemporalFusionTransformerModel`` with PyTorch Lightning.
+
+    This is a thin layer around a (wrapped) ``TemporalFusionTransformerModel``
+    object, that exposes the methods to evaluate training and validation loss.
+
+    Parameters
+    ----------
+    model
+        ``TemporalFusionTransformerModel`` to be trained.
+    lr
+        Learning rate, default: ``1e-3``.
+    weight_decay
+        Weight decay regularization parameter, default: ``1e-8``.
+    patience
+        Patience parameter for learning rate scheduler, default: ``10``.
+    """
+
+    def __init__(
+        self,
+        model: TemporalFusionTransformerModel,
+        lr: float = 1e-3,
+        patience: int = 10,
+        weight_decay: float = 0.0,
+    ):
         super().__init__()
+        self.save_hyperparameters(ignore=["model"])
         self.model = model
         self.lr = lr
         self.patience = patience
+        self.weight_decay = weight_decay
+        self.example_input_array = tuple(
+            [
+                torch.zeros(shape, dtype=self.model.input_types()[name])
+                for (name, shape) in self.model.input_shapes().items()
+            ]
+        )
+
+    def forward(self, *args, **kwargs):
+        return self.model(*args, **kwargs)
+
+    def training_step(self, batch, batch_idx: int):  # type: ignore
+        """
+        Execute training step.
+        """
+        train_loss = self.model.loss(
+            **select(self.model.input_shapes(), batch, ignore_missing=True),
+            future_observed_values=batch["future_observed_values"],
+            future_target=batch["future_target"],
+        ).mean()
+
+        self.log(
+            "train_loss",
+            train_loss,
+            on_epoch=True,
+            on_step=False,
+            prog_bar=True,
+        )
+
+        return train_loss
+
+    def validation_step(self, batch, batch_idx: int):  # type: ignore
+        """
+        Execute validation step.
+        """
+        val_loss = self.model.loss(
+            **select(self.model.input_shapes(), batch, ignore_missing=True),
+            future_observed_values=batch["future_observed_values"],
+            future_target=batch["future_target"],
+        ).mean()
+
+        self.log(
+            "val_loss",
+            val_loss,
+            on_epoch=True,
+            on_step=False,
+            prog_bar=True,
+        )
+
+        return val_loss
+
+    def configure_optimizers(self):
+        """
+        Returns the optimizer to use.
+        """
+        optimizer = torch.optim.Adam(
+            self.model.parameters(),
+            lr=self.lr,
+            weight_decay=self.weight_decay,
+        )
+
+        return {
+            "optimizer": optimizer,
+            "lr_scheduler": {
+                "scheduler": ReduceLROnPlateau(
+                    optimizer=optimizer,
+                    mode="min",
+                    factor=0.5,
+                    patience=self.patience,
+                ),
+                "monitor": "train_loss",
+            },
+        }

--- a/src/gluonts/torch/model/tft/lightning_module.py
+++ b/src/gluonts/torch/model/tft/lightning_module.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
 import pytorch_lightning as pl
 import torch
 from gluonts.core.component import validated

--- a/src/gluonts/torch/model/tft/module.py
+++ b/src/gluonts/torch/model/tft/module.py
@@ -44,12 +44,12 @@ class TemporalFusionTransformerModel(nn.Module):
         self,
         context_length: int,
         prediction_length: int,
-        d_feat_static_real: List[int] = None,  #  Defaults to [1]
-        c_feat_static_cat: List[int] = None,  #  Defaults to [1]
-        d_feat_dynamic_real: List[int] = None,  # Defaults to [1]
-        c_feat_dynamic_cat: List[int] = None,  # Defaults to []
-        d_past_feat_dynamic_real: List[int] = None,  # Defaults to []
-        c_past_feat_dynamic_cat: List[int] = None,  # Defaults to []
+        d_feat_static_real: Optional[List[int]] = None,  #  Defaults to [1]
+        c_feat_static_cat: Optional[List[int]] = None,  #  Defaults to [1]
+        d_feat_dynamic_real: Optional[List[int]] = None,  # Defaults to [1]
+        c_feat_dynamic_cat: Optional[List[int]] = None,  # Defaults to []
+        d_past_feat_dynamic_real: Optional[List[int]] = None,  # Defaults to []
+        c_past_feat_dynamic_cat: Optional[List[int]] = None,  # Defaults to []
         quantiles: Optional[List[float]] = None,
         num_heads: int = 4,
         d_hidden: int = 32,

--- a/src/gluonts/torch/model/tft/module.py
+++ b/src/gluonts/torch/model/tft/module.py
@@ -275,12 +275,12 @@ class TemporalFusionTransformerModel(nn.Module):
         self,
         past_target: torch.Tensor,  # [N, T]
         past_observed_values: torch.Tensor,  # [N, T]
-        past_feat_dynamic_real: torch.Tensor,  # [N, T, D_pr]
-        past_feat_dynamic_cat: torch.Tensor,  # [N, T, D_pc]
-        feat_dynamic_real: torch.Tensor,  # [N, T + H, D_dr]
-        feat_dynamic_cat: torch.Tensor,  # [N, T + H, D_dc]
-        feat_static_real: torch.Tensor,  # [N, D_sr]
-        feat_static_cat: torch.Tensor,  # [N, D_sc]
+        past_feat_dynamic_real: Optional[torch.Tensor] = None,  # [N, T, D_pr]
+        past_feat_dynamic_cat: Optional[torch.Tensor] = None,  # [N, T, D_pc]
+        feat_dynamic_real: Optional[torch.Tensor] = None,  # [N, T + H, D_dr]
+        feat_dynamic_cat: Optional[torch.Tensor] = None,  # [N, T + H, D_dc]
+        feat_static_real: Optional[torch.Tensor] = None,  # [N, D_sr]
+        feat_static_cat: Optional[torch.Tensor] = None,  # [N, D_sc]
     ) -> torch.Tensor:
         (
             past_covariates,  # [[N, T, d_var], ...]
@@ -326,14 +326,14 @@ class TemporalFusionTransformerModel(nn.Module):
         self,
         past_target: torch.Tensor,
         past_observed_values: torch.Tensor,
-        past_feat_dynamic_real: torch.Tensor,
-        past_feat_dynamic_cat: torch.Tensor,
-        feat_dynamic_real: torch.Tensor,
-        feat_dynamic_cat: torch.Tensor,
-        feat_static_real: torch.Tensor,
-        feat_static_cat: torch.Tensor,
         future_target: torch.Tensor,
         future_observed_values: torch.Tensor,
+        past_feat_dynamic_real: Optional[torch.Tensor] = None,
+        past_feat_dynamic_cat: Optional[torch.Tensor] = None,
+        feat_dynamic_real: Optional[torch.Tensor] = None,
+        feat_dynamic_cat: Optional[torch.Tensor] = None,
+        feat_static_real: Optional[torch.Tensor] = None,
+        feat_static_cat: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         preds = self.forward(
             past_target=past_target,

--- a/src/gluonts/torch/model/tft/module.py
+++ b/src/gluonts/torch/model/tft/module.py
@@ -18,6 +18,11 @@ from .layers import (
 
 
 class TemporalFusionTransformerModel(nn.Module):
+    """Temporal Fusion Transformer neural network.
+
+    Partially based on the implementation in github.com/kashif/pytorch-transformer-ts.
+    """
+
     @validated()
     def __init__(
         self,

--- a/src/gluonts/torch/model/tft/module.py
+++ b/src/gluonts/torch/model/tft/module.py
@@ -1,0 +1,270 @@
+import torch
+import torch.nn as nn
+
+from typing import List, Optional, Dict, Tuple
+from gluonts.core.component import validated
+
+from .layers import (
+    FeatureEmbedder,
+    VariableSelectionNetwork,
+    GatedResidualNetwork,
+    TemporalFusionDecoder,
+    TemporalFusionEncoder,
+)
+
+
+class TemporalFusionTransformerModel(nn.Module):
+    @validated()
+    def __init__(
+        self,
+        context_length: int,
+        prediction_length: int,
+        num_feat_static_real: int,
+        num_feat_dynamic_real: int,
+        num_past_feat_dynamic_real: int,
+        cardinalities_static: List[int],
+        cardinalities_dynamic: List[int],
+        cardinalities_past_dynamic: List[int],
+        quantiles: Optional[List[float]] = None,
+        num_heads: int = 4,
+        d_hidden: int = 32,
+        d_var: int = 32,
+        dropout_rate: float = 0.1,
+        scaling: bool = True,
+    ) -> None:
+        super().__init__()
+
+        self.context_length = context_length
+        self.prediction_length = prediction_length
+        self.num_heads = num_heads
+        self.d_hidden = d_hidden
+        self.d_var = d_var
+        self.dropout_rate = dropout_rate
+        if quantiles is None:
+            quantiles = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+        self.quantiles = quantiles
+
+        self.num_feat_static_real = num_feat_static_real
+        self.num_feat_dynamic_real = num_feat_dynamic_real
+        self.num_past_feat_dynamic_real = num_past_feat_dynamic_real
+        self.cardinalities_static = cardinalities_static or []
+        self.cardinalities_dynamic = cardinalities_dynamic or []
+        self.cardinalities_past_dynamic = cardinalities_past_dynamic or []
+        self.num_feat_static_cat = len(self.cardinalities_static)
+        self.num_feat_dynamic_cat = len(self.cardinalities_dynamic)
+        self.num_past_feat_dynamic_cat = len(self.cardinalities_past_dynamic)
+
+        self.num_feat_static = (
+            self.num_feat_static_real + self.num_feat_static_cat
+        )
+        self.num_feat_dynamic = (
+            self.num_feat_dynamic_real + self.num_feat_dynamic_cat
+        )
+        self.num_past_feat_dynamic = (
+            self.num_past_feat_dynamic_real + self.num_past_feat_dynamic_cat
+        )
+
+        self.target_proj = nn.Linear(in_features=1, out_features=self.d_var)
+        # Past dynamic features
+        if self.num_past_feat_dynamic_real:
+            self.past_feat_dynamic_proj = nn.Linear(
+                in_features=self.num_past_feat_dynamic_real,
+                out_features=self.d_var,
+            )
+        else:
+            self.past_feat_dynamic_proj = None
+
+        if self.cardinalities_past_dynamic:
+            self.past_feat_dynamic_embed = FeatureEmbedder(
+                cardinalities=cardinalities_past_dynamic,
+                embedding_dims=[d_var] * self.num_past_feat_dynamic_cat,
+            )
+        else:
+            self.past_feat_dynamic_embed = None
+
+        # Known dynamic features
+        if self.num_feat_dynamic_real:
+            self.feat_dynamic_proj = nn.Linear(
+                in_features=self.num_feat_dynamic_real,
+                out_features=self.d_var,
+            )
+        else:
+            self.feat_dynamic_proj = None
+
+        if self.cardinalities_dynamic:
+            self.feat_dynamic_embed = FeatureEmbedder(
+                cardinalities=cardinalities_dynamic,
+                embedding_dims=[d_var] * self.num_feat_dynamic_cat,
+            )
+        else:
+            self.feat_dynamic_embed = None
+
+        # Static features
+        if self.num_feat_static_real:
+            self.feat_static_proj = nn.Linear(
+                in_features=self.num_feat_static_real,
+                out_features=self.d_var,
+            )
+        else:
+            self.feat_static_proj = None
+
+        if self.cardinalities_static:
+            self.feat_static_embed = FeatureEmbedder(
+                cardinalities=cardinalities_static,
+                embedding_dims=[d_var] * self.num_feat_static_cat,
+            )
+        else:
+            self.feat_static_embed = None
+
+        self.static_selector = VariableSelectionNetwork(
+            d_hidden=self.d_var,
+            num_vars=self.num_feat_static,
+            dropout=self.dropout_rate,
+        )
+        self.context_selector = VariableSelectionNetwork(
+            d_hidden=self.d_var,
+            num_vars=self.num_past_feat_dynamic + self.num_feat_dynamic + 1,
+            add_static=True,
+            dropout=self.dropout_rate,
+        )
+        self.target_selector = VariableSelectionNetwork(
+            d_hidden=self.d_var,
+            num_vars=self.num_feat_dynamic,
+            add_static=True,
+            dropout=self.dropout_rate,
+        )
+        self.selection = GatedResidualNetwork(
+            d_hidden=self.d_var,
+            dropout=self.dropout_rate,
+        )
+        self.enrichment = GatedResidualNetwork(
+            d_hidden=self.d_var,
+            dropout=self.dropout_rate,
+        )
+        self.state_h = GatedResidualNetwork(
+            d_hidden=self.d_var,
+            output_dim=self.d_hidden,
+            dropout=self.dropout_rate,
+        )
+        self.state_c = GatedResidualNetwork(
+            d_hidden=self.d_var,
+            output_dim=self.d_hidden,
+            dropout_rate=self.dropout_rate,
+        )
+        self.temporal_encoder = TemporalFusionEncoder(
+            context_length=self.context_length,
+            prediction_length=self.prediction_length,
+            d_input=self.d_var,
+            d_hidden=self.d_hidden,
+        )
+        self.temporal_decoder = TemporalFusionDecoder(
+            context_length=self.context_length,
+            prediction_length=self.prediction_length,
+            d_hidden=self.d_hidden,
+            d_var=self.d_var,
+            num_heads=self.num_heads,
+            dropout=self.dropout_rate,
+        )
+        self.output = IncrementalQuantileOutput(quantiles=self.quantiles)
+        self.output_proj = self.output.get_quantile_proj()
+
+    def input_shapes(self, batch_size=1) -> Dict[str, Tuple[int, ...]]:
+        return {
+            "past_target": (batch_size, self.context_length),
+            "past_observed_values": (batch_size, self.context_length),
+            "past_feat_dynamic_real": (
+                batch_size,
+                self.context_length,
+                self.num_feat_dynamic_real,
+            ),
+            "past_feat_dynamic_cat": (
+                batch_size,
+                self.context_length,
+                self.num_past_feat_dynamic_cat,
+            ),
+            "feat_dynamic_real": (
+                batch_size,
+                self.context_length + self.prediction_length,
+                self.num_feat_dynamic_real,
+            ),
+            "feat_dynamic_cat": (
+                batch_size,
+                self.context_length + self.prediction_length,
+                self.num_feat_dynamic_cat,
+            ),
+            "feat_static_real": (batch_size, self.num_feat_static_real),
+            "feat_static_cat": (batch_size, self.num_feat_static_cat),
+        }
+
+    def input_types(self) -> Dict[str, torch.dtype]:
+        return {
+            "past_target": torch.float,
+            "past_observed_values": torch.float,
+            "past_feat_dynamic_real": torch.float,
+            "past_feat_dynamic_cat": torch.long,
+            "feat_dynamic_real": torch.float,
+            "feat_dynamic_cat": torch.long,
+            "feat_static_real": torch.float,
+            "feat_static_cat": torch.long,
+        }
+
+    def forward(
+        self,
+        past_target: torch.Tensor,
+        past_observed_values: torch.Tensor,
+        past_feat_dynamic_real: torch.Tensor,
+        past_feat_dynamic_cat: torch.Tensor,
+        feat_dynamic_real: torch.Tensor,
+        feat_dynamic_cat: torch.Tensor,
+        feat_static_real: torch.Tensor,
+        feat_static_cat: torch.Tensor,
+    ) -> torch.Tensor:
+        (
+            past_covariates,
+            future_covariates,
+            static_covariates,
+            offset,
+            scale,
+        ) = self._preprocess(
+            past_target,
+            past_observed_values,
+            past_feat_dynamic_real,
+            past_feat_dynamic_cat,
+            feat_dynamic_real,
+            feat_dynamic_cat,
+            feat_static_real,
+            feat_static_cat,
+        )
+
+        static_var, _ = self.static_selector(static_covariates)
+        c_selection = self.selection(static_var).expand_dims(axis=1)
+        c_enrichment = self.enrichment(static_var).expand_dims(axis=1)
+        c_h = self.state_h(static_var)
+        c_c = self.state_c(static_var)
+
+        ctx_input, _ = self.ctx_selector(past_covariates, c_selection)
+        tgt_input, _ = self.tgt_selector(future_covariates, c_selection)
+
+        encoding = self.temporal_encoder(ctx_input, tgt_input, [c_h, c_c])
+        decoding = self.temporal_decoder(
+            encoding, c_enrichment, past_observed_values
+        )
+        preds = self.output_proj(decoding)
+        return self._postprocess(preds, offset, scale)
+
+    def loss(
+        self,
+        past_target: torch.Tensor,
+        past_observed_values: torch.Tensor,
+        past_feat_dynamic_real: torch.Tensor,
+        past_feat_dynamic_cat: torch.Tensor,
+        feat_dynamic_real: torch.Tensor,
+        feat_dynamic_cat: torch.Tensor,
+        feat_static_real: torch.Tensor,
+        feat_static_cat: torch.Tensor,
+        future_target: torch.Tensor,
+        future_observed_values: torch.Tensor,
+    ):
+        preds = self.forward()  # [N, T, Q]
+        loss = self.quantile_loss(future_target, preds)  # [N, T]
+        return masked_average(loss, future_observed_values)  # [N]

--- a/src/gluonts/torch/model/tft/module.py
+++ b/src/gluonts/torch/model/tft/module.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
 from typing import Dict, List, Optional, Tuple
 
 import torch

--- a/src/gluonts/torch/model/tft/module.py
+++ b/src/gluonts/torch/model/tft/module.py
@@ -1,21 +1,19 @@
+from typing import Dict, List, Optional, Tuple
+
 import torch
 import torch.nn as nn
-
-from typing import List, Optional, Dict, Tuple
 from gluonts.core.component import validated
-from gluonts.torch.modules.scaler import MeanScaler, NOPScaler
 from gluonts.torch.modules.quantile_output import QuantileOutput
+from gluonts.torch.modules.scaler import StdScaler
 from gluonts.torch.util import weighted_average
-
 
 from .layers import (
     FeatureEmbedder,
     FeatureProjector,
-    VariableSelectionNetwork,
     GatedResidualNetwork,
-    StdScaler,
     TemporalFusionDecoder,
     TemporalFusionEncoder,
+    VariableSelectionNetwork,
 )
 
 

--- a/src/gluonts/torch/model/tft/transformation.py
+++ b/src/gluonts/torch/model/tft/transformation.py
@@ -1,0 +1,1 @@
+from gluonts.mx.model.tft._transform import TFTInstanceSplitter

--- a/src/gluonts/torch/model/tft/transformation.py
+++ b/src/gluonts/torch/model/tft/transformation.py
@@ -1,1 +1,0 @@
-from gluonts.mx.model.tft._transform import TFTInstanceSplitter

--- a/src/gluonts/torch/modules/quantile_output.py
+++ b/src/gluonts/torch/modules/quantile_output.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
 from typing import List
 import torch
 from gluonts.torch.distributions.distribution_output import Output

--- a/src/gluonts/torch/modules/quantile_output.py
+++ b/src/gluonts/torch/modules/quantile_output.py
@@ -1,0 +1,59 @@
+from typing import List
+import torch
+from gluonts.torch.distributions.distribution_output import Output
+from gluonts.core.component import validated
+
+
+class QuantileOutput(Output):
+    """
+    Output layer using a quantile loss and projection layer to connect the
+    quantile output to the network.
+
+    Parameters
+    ----------
+    quantiles
+        list of quantiles to compute loss over.
+
+    quantile_weights
+        weights of the quantiles.
+    """
+
+    @validated()
+    def __init__(self, quantiles: List[float]) -> None:
+        assert len(quantiles) > 0
+        assert all(0.0 < q < 1.0 for q in quantiles)
+        self._quantiles = quantiles
+        self.num_quantiles = len(self._quantiles)
+        self.args_dim = {"quantiles_pred": self.num_quantiles}
+
+    @property
+    def quantiles(self) -> List[float]:
+        return self._quantiles
+
+    def domain_map(self, quantiles_pred: torch.Tensor):
+        return quantiles_pred
+
+    def quantile_loss(
+        self, y_true: torch.Tensor, y_pred: torch.Tensor
+    ) -> torch.Tensor:
+        """Compute mean quantile loss.
+
+        Parameters
+        ----------
+        y_true
+            Ground truth values, shape [N_1, ..., N_k]
+        y_pred
+            Predicted quantiles, shape [N_1, ..., N_k num_quantiles]
+
+        Returns
+        -------
+        loss
+            Quantile loss, shape [N_1, ..., N_k]
+        """
+        y_true = y_true.unsqueeze(-1)
+        quantiles = torch.tensor(
+            self.quantiles, dtype=y_pred.dtype, device=y_pred.device
+        )
+        return 2 * (
+            (y_true - y_pred) * ((y_true <= y_pred).float() - quantiles)
+        ).abs().sum(dim=-1)

--- a/src/gluonts/torch/modules/scaler.py
+++ b/src/gluonts/torch/modules/scaler.py
@@ -123,3 +123,52 @@ class NOPScaler(nn.Module):
             keepdim=self.keepdim,
         )
         return data, scale
+
+
+class StdScaler(nn.Module):
+    """
+    Computes a std scaling  value along dimension ``dim``, and scales the data accordingly.
+
+    Parameters
+    ----------
+    dim
+        dimension along which to compute the scale
+    keepdim
+        controls whether to retain dimension ``dim`` (of length 1) in the
+        scale tensor, or suppress it.
+    minimum_scale
+        default scale that is used for elements that are constantly zero
+        along dimension ``dim``.
+    """
+
+    @validated()
+    def __init__(
+        self, dim: int, keepdim: bool = False, minimum_scale: float = 1e-5
+    ):
+        super().__init__()
+        assert dim > 0, (
+            "Cannot compute scale along dim = 0 (batch dimension), please"
+            " provide dim > 0"
+        )
+        self.dim = dim
+        self.keepdim = keepdim
+        self.register_buffer("minimum_scale", torch.tensor(minimum_scale))
+
+    def forward(
+        self, data: torch.Tensor, weights: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        assert (
+            data.shape == weights.shape
+        ), "data and weights must have same shape"
+        with torch.no_grad():
+            denominator = weights.sum(self.dim, keepdim=self.keepdim)
+            denominator = denominator.clamp_min(1.0)
+            loc = (data * weights).sum(
+                self.dim, keepdim=self.keepdim
+            ) / denominator
+
+            variance = (((data - loc) * weights) ** 2).sum(
+                self.dim, keepdim=self.keepdim
+            ) / denominator
+            scale = torch.sqrt(variance + self.minimum_scale)
+            return (data - loc) / scale, loc, scale

--- a/src/gluonts/transform/split.py
+++ b/src/gluonts/transform/split.py
@@ -477,3 +477,103 @@ class ContinuousTimeInstanceSplitter(FlatMapTransformation):
             r.update(keep_cols)
 
             yield r
+
+
+class TFTInstanceSplitter(InstanceSplitter):
+    """Instance splitter used by the Temporal Fusion Transformer model.
+
+    Unlike ``InstanceSplitter``, this class returns known dynamic features as
+    a single tensor of shape [..., context_length + prediction_length, ...]
+    without splitting it into past & future parts. Moreover, this class supports
+    dynamic features that are known in the past.
+    """
+
+    @validated()
+    def __init__(
+        self,
+        instance_sampler: InstanceSampler,
+        past_length: int,
+        future_length: int,
+        target_field: str = FieldName.TARGET,
+        is_pad_field: str = FieldName.IS_PAD,
+        start_field: str = FieldName.START,
+        forecast_start_field: str = FieldName.FORECAST_START,
+        observed_value_field: str = FieldName.OBSERVED_VALUES,
+        lead_time: int = 0,
+        output_NTC: bool = True,
+        time_series_fields: List[str] = [],
+        past_time_series_fields: List[str] = [],
+        dummy_value: float = 0.0,
+    ) -> None:
+        super().__init__(
+            target_field=target_field,
+            is_pad_field=is_pad_field,
+            start_field=start_field,
+            forecast_start_field=forecast_start_field,
+            instance_sampler=instance_sampler,
+            past_length=past_length,
+            future_length=future_length,
+            lead_time=lead_time,
+            output_NTC=output_NTC,
+            time_series_fields=time_series_fields,
+            dummy_value=dummy_value,
+        )
+
+        assert past_length > 0, "The value of `past_length` should be > 0"
+
+        self.observed_value_field = observed_value_field
+        self.past_ts_fields = past_time_series_fields
+
+    def flatmap_transform(
+        self, data: DataEntry, is_train: bool
+    ) -> Iterator[DataEntry]:
+        pl = self.future_length
+        lt = self.lead_time
+        target = data[self.target_field]
+
+        sampled_indices = self.instance_sampler(target)
+
+        slice_cols = (
+            self.ts_fields
+            + self.past_ts_fields
+            + [self.target_field, self.observed_value_field]
+        )
+        for i in sampled_indices:
+            pad_length = max(self.past_length - i, 0)
+            d = data.copy()
+
+            for field in slice_cols:
+                if i >= self.past_length:
+                    past_piece = d[field][..., i - self.past_length : i]
+                else:
+                    pad_block = np.full(
+                        shape=d[field].shape[:-1] + (pad_length,),
+                        fill_value=self.dummy_value,
+                        dtype=d[field].dtype,
+                    )
+                    past_piece = np.concatenate(
+                        [pad_block, d[field][..., :i]], axis=-1
+                    )
+                future_piece = d[field][..., (i + lt) : (i + lt + pl)]
+                if field in self.ts_fields:
+                    piece = np.concatenate([past_piece, future_piece], axis=-1)
+                    if self.output_NTC:
+                        piece = piece.transpose()
+                    d[field] = piece
+                else:
+                    if self.output_NTC:
+                        past_piece = past_piece.transpose()
+                        future_piece = future_piece.transpose()
+                    if field not in self.past_ts_fields:
+                        d[self._past(field)] = past_piece
+                        d[self._future(field)] = future_piece
+                        del d[field]
+                    else:
+                        d[field] = past_piece
+            pad_indicator = np.zeros(self.past_length)
+            if pad_length > 0:
+                pad_indicator[:pad_length] = 1
+            d[self._past(self.is_pad_field)] = pad_indicator
+            d[self.forecast_start_field] = d[self.start_field] + i + lt
+
+            yield d

--- a/test/torch/model/test_estimators.py
+++ b/test/torch/model/test_estimators.py
@@ -24,6 +24,7 @@ from gluonts.torch.model.deepar import DeepAREstimator
 from gluonts.torch.model.forecast import DistributionForecast
 from gluonts.torch.model.mqf2 import MQF2MultiHorizonEstimator
 from gluonts.torch.model.simple_feedforward import SimpleFeedForwardEstimator
+from gluonts.torch.model.tft import TemporalFusionTransformerEstimator
 from gluonts.torch.modules.loss import NegativeLogLikelihood, QuantileLoss
 from gluonts.torch.distributions import ImplicitQuantileNetworkOutput
 
@@ -48,6 +49,13 @@ from gluonts.torch.distributions import ImplicitQuantileNetworkOutput
             trainer_kwargs=dict(max_epochs=2),
         ),
         lambda dataset: SimpleFeedForwardEstimator(
+            prediction_length=dataset.metadata.prediction_length,
+            batch_size=4,
+            num_batches_per_epoch=3,
+            trainer_kwargs=dict(max_epochs=2),
+        ),
+        lambda dataset: TemporalFusionTransformerEstimator(
+            freq=dataset.metadata.freq,
             prediction_length=dataset.metadata.prediction_length,
             batch_size=4,
             num_batches_per_epoch=3,
@@ -115,6 +123,16 @@ def test_estimator_constant_dataset(estimator_constructor):
             num_feat_static_real=1,
             num_feat_static_cat=2,
             cardinality=[2, 2],
+            trainer_kwargs=dict(max_epochs=2),
+        ),
+        lambda freq, prediction_length: TemporalFusionTransformerEstimator(
+            freq=freq,
+            prediction_length=prediction_length,
+            batch_size=4,
+            num_batches_per_epoch=3,
+            dynamic_dims=[3],
+            static_dims=[1],
+            static_cardinalities=[2, 2],
             trainer_kwargs=dict(max_epochs=2),
         ),
     ],

--- a/test/torch/model/test_modules.py
+++ b/test/torch/model/test_modules.py
@@ -17,6 +17,7 @@ import torch
 from gluonts.torch.model.deepar import DeepARModel
 from gluonts.torch.model.mqf2 import MQF2MultiHorizonModel
 from gluonts.torch.model.simple_feedforward import SimpleFeedForwardModel
+from gluonts.torch.model.tft import TemporalFusionTransformerModel
 
 
 def construct_batch(module, batch_size=1):
@@ -82,6 +83,22 @@ def assert_shapes_and_dtypes(tensors, shapes, dtypes):
                 torch.float,
                 torch.float,
             ],
+        ),
+        (
+            TemporalFusionTransformerModel(
+                context_length=24,
+                prediction_length=12,
+                quantiles=[0.2, 0.25, 0.5, 0.9, 0.95],
+                d_past_feat_dynamic_real=[1],
+                d_feat_dynamic_real=[2, 5],
+                d_feat_static_real=[3, 1, 1],
+                c_past_feat_dynamic_cat=[2, 2, 2],
+                c_feat_dynamic_cat=[2],
+                c_feat_static_cat=[2, 2],
+            ),
+            4,
+            (4, 5, 12),  # (batch_size, len(quantiles), prediction_length)
+            torch.float,
         ),
     ],
 )

--- a/test/torch/model/test_tft.py
+++ b/test/torch/model/test_tft.py
@@ -1,0 +1,139 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from typing import List
+
+import torch
+import pytest
+
+from gluonts.torch.model.tft import (
+    TemporalFusionTransformerModel,
+    TemporalFusionTransformerLightningModule,
+)
+
+
+@pytest.mark.parametrize(
+    "d_past_feat_dynamic_real, c_past_feat_dynamic_cat, d_feat_dynamic_real, c_feat_dynamic_cat, d_feat_static_real, c_feat_static_cat, quantiles",
+    [
+        ([3], [4, 2], [5], [5, 5, 5], [5, 2], [4], [0.1, 0.5, 0.9]),
+        ([1], [4, 2], [2, 4], [2], [2], [4, 2, 2], [0.05, 0.25]),
+    ],
+)
+def test_tft_modules(
+    d_past_feat_dynamic_real: List[int],
+    c_past_feat_dynamic_cat: List[int],
+    d_feat_dynamic_real: List[int],
+    c_feat_dynamic_cat: List[int],
+    d_feat_static_real: List[int],
+    c_feat_static_cat: List[int],
+    quantiles: List[float],
+):
+    batch_size = 4
+    prediction_length = 6
+    context_length = 12
+
+    model = TemporalFusionTransformerModel(
+        context_length=context_length,
+        prediction_length=prediction_length,
+        d_past_feat_dynamic_real=d_past_feat_dynamic_real,
+        c_past_feat_dynamic_cat=c_past_feat_dynamic_cat,
+        d_feat_dynamic_real=d_feat_dynamic_real,
+        c_feat_dynamic_cat=c_feat_dynamic_cat,
+        d_feat_static_real=d_feat_static_real,
+        c_feat_static_cat=c_feat_static_cat,
+        quantiles=quantiles,
+    )
+
+    feat_static_cat = torch.zeros(
+        batch_size, len(c_feat_static_cat), dtype=torch.long
+    )
+    feat_static_real = torch.ones(batch_size, sum(d_feat_static_real))
+    feat_dynamic_cat = torch.zeros(
+        batch_size,
+        prediction_length + context_length,
+        len(c_feat_dynamic_cat),
+        dtype=torch.long,
+    )
+    feat_dynamic_real = torch.ones(
+        batch_size,
+        prediction_length + context_length,
+        sum(d_feat_dynamic_real),
+    )
+    past_feat_dynamic_cat = torch.zeros(
+        batch_size,
+        context_length,
+        len(c_past_feat_dynamic_cat),
+        dtype=torch.long,
+    )
+    past_feat_dynamic_real = torch.ones(
+        batch_size, context_length, sum(d_past_feat_dynamic_real)
+    )
+    past_target = torch.ones(batch_size, context_length)
+    past_observed_values = torch.ones(batch_size, context_length)
+    future_target = torch.ones(batch_size, prediction_length)
+    future_observed_values = torch.ones(batch_size, prediction_length)
+
+    (
+        past_covariates,
+        future_covariates,
+        static_covariates,
+        loc,
+        scale,
+    ) = model._preprocess(
+        past_target,
+        past_observed_values,
+        past_feat_dynamic_real,
+        past_feat_dynamic_cat,
+        feat_dynamic_real,
+        feat_dynamic_cat,
+        feat_static_real,
+        feat_static_cat,
+    )
+    for x in past_covariates:
+        assert x.shape == (batch_size, context_length, model.d_var)
+    for x in future_covariates:
+        assert x.shape == (batch_size, prediction_length, model.d_var)
+    for x in static_covariates:
+        assert x.shape == (batch_size, model.d_var)
+    assert loc.shape == scale.shape == (batch_size, 1)
+
+    output = model(
+        past_target,
+        past_observed_values,
+        past_feat_dynamic_real,
+        past_feat_dynamic_cat,
+        feat_dynamic_real,
+        feat_dynamic_cat,
+        feat_static_real,
+        feat_static_cat,
+    )
+
+    assert output.shape == (batch_size, len(quantiles), prediction_length)
+
+    batch = dict(
+        past_target=past_target,
+        past_observed_values=past_observed_values,
+        past_feat_dynamic_real=past_feat_dynamic_real,
+        past_feat_dynamic_cat=past_feat_dynamic_cat,
+        feat_dynamic_real=feat_dynamic_real,
+        feat_dynamic_cat=feat_dynamic_cat,
+        feat_static_real=feat_static_real,
+        feat_static_cat=feat_static_cat,
+        future_target=future_target,
+        future_observed_values=future_observed_values,
+    )
+
+    lightning_module = TemporalFusionTransformerLightningModule(model=model)
+
+    assert lightning_module.training_step(batch, batch_idx=0).shape == ()
+    assert lightning_module.validation_step(batch, batch_idx=0).shape == ()

--- a/test/torch/model/test_tft.py
+++ b/test/torch/model/test_tft.py
@@ -90,14 +90,14 @@ def test_tft_modules(
         loc,
         scale,
     ) = model._preprocess(
-        past_target,
-        past_observed_values,
-        past_feat_dynamic_real,
-        past_feat_dynamic_cat,
-        feat_dynamic_real,
-        feat_dynamic_cat,
-        feat_static_real,
-        feat_static_cat,
+        past_target=past_target,
+        past_observed_values=past_observed_values,
+        feat_static_real=feat_static_real,
+        feat_static_cat=feat_static_cat,
+        feat_dynamic_real=feat_dynamic_real,
+        feat_dynamic_cat=feat_dynamic_cat,
+        past_feat_dynamic_real=past_feat_dynamic_real,
+        past_feat_dynamic_cat=past_feat_dynamic_cat,
     )
     for x in past_covariates:
         assert x.shape == (batch_size, context_length, model.d_var)
@@ -108,14 +108,14 @@ def test_tft_modules(
     assert loc.shape == scale.shape == (batch_size, 1)
 
     output = model(
-        past_target,
-        past_observed_values,
-        past_feat_dynamic_real,
-        past_feat_dynamic_cat,
-        feat_dynamic_real,
-        feat_dynamic_cat,
-        feat_static_real,
-        feat_static_cat,
+        past_target=past_target,
+        past_observed_values=past_observed_values,
+        feat_static_real=feat_static_real,
+        feat_static_cat=feat_static_cat,
+        feat_dynamic_real=feat_dynamic_real,
+        feat_dynamic_cat=feat_dynamic_cat,
+        past_feat_dynamic_real=past_feat_dynamic_real,
+        past_feat_dynamic_cat=past_feat_dynamic_cat,
     )
 
     assert output.shape == (batch_size, len(quantiles), prediction_length)


### PR DESCRIPTION
*Description of changes:*

Unlike the MXNet implementation of TFT, the PyTorch versions of model/estimator are compatible with the dataset schema used by DeepAR. For example, if we construct the estimator with as follows
```python
estimator = TemporalFusionTransformerEstimator(
   ...,
   dynamic_dims=[2, 5, 7],
   dynamic_cardinalities=[6, 5, 5, 4, 2],
   past_dynamic_dims=[3, 3],
   past_dynamic_cardinalities=[5, 2, 4],
)
```
it will expect to receive a dataset, where each time series has keys
- `"feat_dynamic_real"`: shape `[..., sum(dynamic_dims)]` (inside the network this will feature get partitioned into 3 chunks of dim 2, 5, 7)
- `"feat_dynamic_cat"`: shape `[..., len(dynamic_cardinalities)]`
- `"past_feat_dynamic_real"`: shape `[..., sum(past_dynamic_dims)]`
- `"past_feat_dynamic_cat"`: shape `[..., len(past_dynamic_cardinalities)]`


*To do:*
- [x] Move `QuantileOutput` and `TFTInstanceSplitter` to a another folder?
- [x] Benchmarking
- [x] Add tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup