### PR TITLE
Loader cache

### DIFF
--- a/src/gluonts/dataset/loader.py
+++ b/src/gluonts/dataset/loader.py
@@ -16,7 +16,7 @@ import io
 import pickle
 from tempfile import TemporaryFile
 from dataclasses import dataclass, field
-from typing import Callable, Iterable, Optional
+from typing import cast, Callable, Iterable, Optional
 
 from pydantic import BaseModel
 
@@ -151,10 +151,10 @@ def TrainDataLoader(
     if cache:
         dataset = PickleCache(dataset)
 
-    dataset = Cyclic(dataset)
+    dataset = cast(Dataset, Cyclic(dataset))
 
     if shuffle_buffer_length:
-        dataset = PseudoShuffled(dataset, shuffle_buffer_length)
+        dataset = cast(Dataset, PseudoShuffled(dataset, shuffle_buffer_length))
 
     transform += Batch(batch_size=batch_size) + AdhocTransform(stack_fn)
     transformed_dataset = transform.apply(dataset, is_train=True)

--- a/src/gluonts/dataset/loader.py
+++ b/src/gluonts/dataset/loader.py
@@ -61,6 +61,9 @@ class Cache:
         else:
             yield from self._iter_cached()
 
+    def __len__(self):
+        return len(self.dataset)
+
 
 @dataclass
 class PickleCache(Cache):
@@ -146,9 +149,9 @@ def TrainDataLoader(
     """
 
     if cache:
-        dataset: Dataset = PickleCache(dataset)
+        dataset = PickleCache(dataset)
 
-    dataset: Dataset = Cyclic(dataset)
+    dataset = Cyclic(dataset)
 
     if shuffle_buffer_length:
         dataset = PseudoShuffled(dataset, shuffle_buffer_length)
@@ -193,7 +196,7 @@ def ValidationDataLoader(
     """
 
     if cache:
-        dataset: Dataset = PickleCache(dataset)
+        dataset = PickleCache(dataset)
 
     transform += Batch(batch_size=batch_size) + AdhocTransform(stack_fn)
     return transform.apply(dataset, is_train=True)

--- a/src/gluonts/dataset/loader.py
+++ b/src/gluonts/dataset/loader.py
@@ -160,12 +160,14 @@ def TrainDataLoader(
     return IterableSlice(batches, num_batches_per_epoch)
 
 
+@env._inject(cache="cache_loader")
 def ValidationDataLoader(
     dataset: Dataset,
     *,
     transform: Transformation = Identity(),
     batch_size: int,
     stack_fn: Callable,
+    cache: bool = False,
 ):
     """
     Construct an iterator of batches for validation purposes.
@@ -189,6 +191,9 @@ def ValidationDataLoader(
     Iterable[DataBatch]
         An iterable sequence of batches.
     """
+
+    if cache:
+        dataset: Dataset = PickleCache(dataset)
 
     transform += Batch(batch_size=batch_size) + AdhocTransform(stack_fn)
     return transform.apply(dataset, is_train=True)

--- a/src/gluonts/env.py
+++ b/src/gluonts/env.py
@@ -29,5 +29,7 @@ class Environment(Settings):
     # we want to be able to disable TQDM, for example when running in sagemaker
     use_tqdm: bool = True
 
+    cache_loader: bool = True
+
 
 env = Environment()


### PR DESCRIPTION
Adding the option to cache the dataset, post transformation.

Currently, this uses `pickle` to dump and load the data, however, we could also look at `arrow`, which could speed things up even more. Another option is to use an in-memory cache.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

This can significantly speed up training, especially when using slow datasources, such as `.json.gz`.

**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup