### PR TITLE
Change SeasonalNaive fallback predictor to nanmean

### DIFF
--- a/src/gluonts/model/seasonal_naive/_predictor.py
+++ b/src/gluonts/model/seasonal_naive/_predictor.py
@@ -83,7 +83,8 @@ class SeasonalNaivePredictor(RepresentablePredictor):
             samples = target[indices].reshape((1, self.prediction_length))
         else:
             samples = np.full(
-                shape=(1, self.prediction_length), fill_value=target.mean()
+                shape=(1, self.prediction_length),
+                fill_value=np.nanmean(target),
             )
 
         return SampleForecast(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Changed SeasonalNaive prediction from `mean` to `nanmean` in case time series is shorter than season_length.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup