### PR TITLE
Add default_scale to MeanScaler and enable the option in DeepAR-PyTorch

### DIFF
--- a/src/gluonts/torch/model/deepar/estimator.py
+++ b/src/gluonts/torch/model/deepar/estimator.py
@@ -126,6 +126,10 @@ class DeepAREstimator(PyTorchLightningEstimator):
         (default: ``NegativeLogLikelihood()``).
     scaling
         Whether to automatically scale the target values (default: true).
+    default_scale
+        Default scale that is applied if the context length window is
+        completely unobserved. If not set, the scale in this case will be
+        the mean scale in the batch.
     lags_seq
         Indices of the lagged target values to use as inputs of the RNN
         (default: None, in which case these are automatically determined

--- a/src/gluonts/torch/model/deepar/estimator.py
+++ b/src/gluonts/torch/model/deepar/estimator.py
@@ -170,6 +170,7 @@ class DeepAREstimator(PyTorchLightningEstimator):
         distr_output: DistributionOutput = StudentTOutput(),
         loss: DistributionLoss = NegativeLogLikelihood(),
         scaling: bool = True,
+        default_scale: Optional[float] = None,
         lags_seq: Optional[List[int]] = None,
         time_features: Optional[List[TimeFeature]] = None,
         num_parallel_samples: int = 100,
@@ -209,6 +210,7 @@ class DeepAREstimator(PyTorchLightningEstimator):
         )
         self.embedding_dimension = embedding_dimension
         self.scaling = scaling
+        self.default_scale = default_scale
         self.lags_seq = lags_seq
         self.time_features = (
             time_features
@@ -403,6 +405,7 @@ class DeepAREstimator(PyTorchLightningEstimator):
             dropout_rate=self.dropout_rate,
             lags_seq=self.lags_seq,
             scaling=self.scaling,
+            default_scale=self.default_scale,
             num_parallel_samples=self.num_parallel_samples,
         )
 

--- a/src/gluonts/torch/model/deepar/module.py
+++ b/src/gluonts/torch/model/deepar/module.py
@@ -99,6 +99,7 @@ class DeepARModel(nn.Module):
         distr_output: DistributionOutput = StudentTOutput(),
         lags_seq: Optional[List[int]] = None,
         scaling: bool = True,
+        default_scale: Optional[float] = None,
         num_parallel_samples: int = 100,
     ) -> None:
         super().__init__()
@@ -125,7 +126,9 @@ class DeepARModel(nn.Module):
             embedding_dims=self.embedding_dimension,
         )
         if scaling:
-            self.scaler = MeanScaler(dim=-1, keepdim=True)
+            self.scaler = MeanScaler(
+                dim=-1, keepdim=True, default_scale=default_scale
+            )
         else:
             self.scaler = NOPScaler(dim=-1, keepdim=True)
         self.rnn_input_size = len(self.lags_seq) + self._number_of_features

--- a/src/gluonts/torch/model/deepar/module.py
+++ b/src/gluonts/torch/model/deepar/module.py
@@ -77,6 +77,10 @@ class DeepARModel(nn.Module):
         and ``t-25`` as input.
     scaling
         Whether to apply mean scaling to the observations (target).
+    default_scale
+        Default scale that is applied if the context length window is
+        completely unobserved. If not set, the scale in this case will be
+        the mean scale in the batch.
     num_parallel_samples
         Number of samples to produce when unrolling the RNN in the prediction
         time range.

--- a/src/gluonts/torch/modules/scaler.py
+++ b/src/gluonts/torch/modules/scaler.py
@@ -31,8 +31,10 @@ class MeanScaler(nn.Module):
     keepdim
         controls whether to retain dimension ``dim`` (of length 1) in the
         scale tensor, or suppress it.
-    minimum_scale
+    default_scale
         default scale that is used for elements that are constantly zero
+    minimum_scale
+        minimum possible scale that is used for any item.
         along dimension ``dim``.
     """
 

--- a/src/gluonts/torch/modules/scaler.py
+++ b/src/gluonts/torch/modules/scaler.py
@@ -35,7 +35,6 @@ class MeanScaler(nn.Module):
         default scale that is used for elements that are constantly zero
     minimum_scale
         minimum possible scale that is used for any item.
-        along dimension ``dim``.
     """
 
     @validated()

--- a/src/gluonts/torch/modules/scaler.py
+++ b/src/gluonts/torch/modules/scaler.py
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from typing import Tuple
+from typing import Tuple, Optional
 
 import torch
 import torch.nn as nn
@@ -38,12 +38,20 @@ class MeanScaler(nn.Module):
 
     @validated()
     def __init__(
-        self, dim: int, keepdim: bool = False, minimum_scale: float = 1e-10
+        self,
+        dim: int,
+        keepdim: bool = False,
+        default_scale: Optional[float] = None,
+        minimum_scale: float = 1e-10,
     ):
         super().__init__()
         self.dim = dim
         self.keepdim = keepdim
         self.register_buffer("minimum_scale", torch.tensor(minimum_scale))
+        if default_scale:
+            self.register_buffer("default_scale", torch.tensor(default_scale))
+        else:
+            self.register_buffer("default_scale", torch.tensor(0.0))
 
     def forward(
         self, data: torch.Tensor, weights: torch.Tensor
@@ -57,7 +65,10 @@ class MeanScaler(nn.Module):
         denominator = torch.max(
             total_observed, torch.ones_like(total_observed)
         )
-        default_scale = weighted_sum.sum(dim=0) / denominator
+        if self.default_scale != 0.0:
+            default_scale = self.default_scale
+        else:
+            default_scale = weighted_sum.sum(dim=0) / denominator
 
         # then compute a per-item, per-dimension scale
         denominator = torch.max(total_weight, torch.ones_like(total_weight))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup