### PR TITLE
Fix: add missing params in rotbaum

### DIFF
--- a/src/gluonts/ext/rotbaum/_preprocess.py
+++ b/src/gluonts/ext/rotbaum/_preprocess.py
@@ -476,7 +476,11 @@ class PreprocessOnlyLagFeatures(PreprocessGeneric):
                     *[
                         list(ent[0]) + list(ent[1].values())
                         for ent in [
-                            self._pre_transform(ts[starting_index:end_index])
+                            self._pre_transform(
+                                ts[starting_index:end_index],
+                                self.subtract_mean,
+                                self.count_nans,
+                            )
                             for ts in time_series["past_feat_dynamic_real"]
                         ]
                     ]
@@ -495,7 +499,9 @@ class PreprocessOnlyLagFeatures(PreprocessGeneric):
                                 ts[
                                     starting_index : end_index
                                     + self.forecast_horizon
-                                ]
+                                ],
+                                self.subtract_mean,
+                                self.count_nans,
                             )
                             for ts in time_series["feat_dynamic_real"]
                         ]


### PR DESCRIPTION
Bug fix: self.subtract_mean, self.count_nans were missing from calls to _pre_transform; causing errors if related time series were used.