### PR TITLE
Add NaN validation to Evaluator

### DIFF
--- a/src/gluonts/evaluation/_base.py
+++ b/src/gluonts/evaluation/_base.py
@@ -104,7 +104,7 @@ def aggregate_valid(
 
 
 def validate_forecast(
-    forecast: Forecast, quantiles: Iterable[Union[float, str]]
+    forecast: Forecast, quantiles: Iterable[Quantile]
 ) -> bool:
     """Validates a Forecast object by checking it for `NaN` values.
     The supplied quantiles and mean (if available) are checked.
@@ -128,7 +128,9 @@ def validate_forecast(
         mean_fcst = None
 
     valid = ~np.isnan(mean_fcst).any() if mean_fcst is not None else True
-    valid &= all(~np.isnan(forecast.quantile(q)).any() for q in quantiles)
+    valid &= all(
+        ~np.isnan(forecast.quantile(q.value)).any() for q in quantiles
+    )
 
     return valid
 

--- a/src/gluonts/evaluation/_base.py
+++ b/src/gluonts/evaluation/_base.py
@@ -106,7 +106,7 @@ def aggregate_valid(
 def validate_forecast(
     forecast: Forecast, quantiles: Iterable[Union[float, str]]
 ) -> bool:
-    """Validates a Forecast object by checking it for NaN values.
+    """Validates a Forecast object by checking it for `NaN` values.
     The supplied quantiles and mean (if available) are checked.
 
     Parameters
@@ -119,7 +119,7 @@ def validate_forecast(
 
     Returns
     -------
-        True, if the forecast's mean and quantiles have no NaN values,
+        True, if the forecast's mean and quantiles have no `NaN` values,
         else False.
     """
     try:
@@ -180,11 +180,14 @@ class Evaluator:
     ignore_invalid_values
         Ignore `NaN` and `inf` values in the timeseries when calculating
         metrics.
-    aggregation_strategy:
+    aggregation_strategy
         Function for aggregating per timeseries metrics.
         Available options are:
         aggregate_valid | aggregate_all | aggregate_no_nan
         The default function is aggregate_no_nan.
+    strict
+        Raise an error when forecast contains `NaN` values.
+        Defaults to True.
     """
 
     default_quantiles = 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9
@@ -200,6 +203,7 @@ class Evaluator:
         chunk_size: int = 32,
         aggregation_strategy: Callable = aggregate_no_nan,
         ignore_invalid_values: bool = True,
+        strict: bool = True,
     ) -> None:
         self.quantiles = tuple(map(Quantile.parse, quantiles))
         self.seasonality = seasonality
@@ -210,6 +214,7 @@ class Evaluator:
         self.chunk_size = chunk_size
         self.aggregation_strategy = aggregation_strategy
         self.ignore_invalid_values = ignore_invalid_values
+        self.strict = strict
 
     def __call__(
         self,
@@ -360,6 +365,14 @@ class Evaluator:
     def get_metrics_per_ts(
         self, time_series: Union[pd.Series, pd.DataFrame], forecast: Forecast
     ) -> Mapping[str, Union[float, str, None, np.ma.core.MaskedConstant]]:
+        if not validate_forecast(forecast, self.quantiles):
+            if self.strict:
+                raise ValueError("Forecast contains NaN values.")
+            else:
+                logging.warning(
+                    "Forecast contains NaN values. Metrics may be incorrect."
+                )
+
         pred_target = np.array(self.extract_pred_target(time_series, forecast))
         past_data = np.array(self.extract_past_data(time_series, forecast))
 

--- a/src/gluonts/evaluation/_base.py
+++ b/src/gluonts/evaluation/_base.py
@@ -103,6 +103,36 @@ def aggregate_valid(
     }
 
 
+def validate_forecast(
+    forecast: Forecast, quantiles: Iterable[Union[float, str]]
+) -> bool:
+    """Validates a Forecast object by checking it for NaN values.
+    The supplied quantiles and mean (if available) are checked.
+
+    Parameters
+    ----------
+    forecast
+        The forecast object.
+    quantiles
+        List of strings of the form 'p10' or floats in [0, 1] with
+        the quantile levels.
+
+    Returns
+    -------
+        True, if the forecast's mean and quantiles have no NaN values,
+        else False.
+    """
+    try:
+        mean_fcst = getattr(forecast, "mean", None)
+    except NotImplementedError:
+        mean_fcst = None
+
+    valid = ~np.isnan(mean_fcst).any() if mean_fcst is not None else True
+    valid &= all(~np.isnan(forecast.quantile(q)).any() for q in quantiles)
+
+    return valid
+
+
 class Evaluator:
     """
     Evaluator class, to compute accuracy metrics by comparing observations to

--- a/test/evaluation/test_evaluator.py
+++ b/test/evaluation/test_evaluator.py
@@ -430,7 +430,7 @@ INPUT_TYPE = [list, list, list, iter, iter, list]
 )
 def test_metrics(timeseries, res, has_nans, input_type):
     ts_datastructure = pd.Series
-    evaluator = Evaluator(quantiles=QUANTILES, num_workers=None)
+    evaluator = Evaluator(quantiles=QUANTILES, num_workers=None, strict=False)
     agg_metrics, _ = calculate_metrics(
         timeseries,
         evaluator,
@@ -454,7 +454,7 @@ def test_metrics(timeseries, res, has_nans, input_type):
 def test_metrics_mp(timeseries, res, has_nans, input_type):
     ts_datastructure = pd.Series
     # Default will be multiprocessing evaluator
-    evaluator = Evaluator(quantiles=QUANTILES, num_workers=4)
+    evaluator = Evaluator(quantiles=QUANTILES, num_workers=4, strict=False)
     agg_metrics, item_metrics = calculate_metrics(
         timeseries,
         evaluator,
@@ -643,7 +643,7 @@ def test_evaluation_with_QuantileForecast():
     index = pd.period_range(start=start, freq="1D", periods=len(target))
     ts = pd.Series(index=index, data=target)
 
-    ev = Evaluator(quantiles=("0.1", "0.2", "0.5"))
+    ev = Evaluator(quantiles=("0.1", "0.2", "0.5"), strict=False)
 
     fcst = [
         QuantileForecast(
@@ -873,6 +873,7 @@ def test_custom_eval_fn(
     evaluator = Evaluator(
         quantiles=QUANTILES,
         custom_eval_fn={eval_name: [eval_fn, agg_str, fcst_type]},
+        strict=False,
     )
 
     agg_metrics, item_metrics = calculate_metrics(

--- a/test/evaluation/test_evaluator.py
+++ b/test/evaluation/test_evaluator.py
@@ -430,7 +430,9 @@ INPUT_TYPE = [list, list, list, iter, iter, list]
 )
 def test_metrics(timeseries, res, has_nans, input_type):
     ts_datastructure = pd.Series
-    evaluator = Evaluator(quantiles=QUANTILES, num_workers=None, strict=False)
+    evaluator = Evaluator(
+        quantiles=QUANTILES, num_workers=None, allow_nan_forecast=True
+    )
     agg_metrics, _ = calculate_metrics(
         timeseries,
         evaluator,
@@ -454,7 +456,9 @@ def test_metrics(timeseries, res, has_nans, input_type):
 def test_metrics_mp(timeseries, res, has_nans, input_type):
     ts_datastructure = pd.Series
     # Default will be multiprocessing evaluator
-    evaluator = Evaluator(quantiles=QUANTILES, num_workers=4, strict=False)
+    evaluator = Evaluator(
+        quantiles=QUANTILES, num_workers=4, allow_nan_forecast=True
+    )
     agg_metrics, item_metrics = calculate_metrics(
         timeseries,
         evaluator,
@@ -643,7 +647,7 @@ def test_evaluation_with_QuantileForecast():
     index = pd.period_range(start=start, freq="1D", periods=len(target))
     ts = pd.Series(index=index, data=target)
 
-    ev = Evaluator(quantiles=("0.1", "0.2", "0.5"), strict=False)
+    ev = Evaluator(quantiles=("0.1", "0.2", "0.5"), allow_nan_forecast=True)
 
     fcst = [
         QuantileForecast(
@@ -873,7 +877,7 @@ def test_custom_eval_fn(
     evaluator = Evaluator(
         quantiles=QUANTILES,
         custom_eval_fn={eval_name: [eval_fn, agg_str, fcst_type]},
-        strict=False,
+        allow_nan_forecast=True,
     )
 
     agg_metrics, item_metrics = calculate_metrics(


### PR DESCRIPTION
*Issue #, if available:* #2560

*Description of changes:*
This PR adds NaN validation to the evaluator via a `strict` parameter which defaults to True. When `strict` is `True`, an error is raised if the forecasts contain NaN values, otherwise a warning is logged. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup