### PR TITLE
Add missing value imputation to Seasonal Naive

### DIFF
--- a/src/gluonts/model/seasonal_naive/_predictor.py
+++ b/src/gluonts/model/seasonal_naive/_predictor.py
@@ -18,8 +18,13 @@ import numpy as np
 from gluonts.core.component import validated
 from gluonts.dataset.common import DataEntry
 from gluonts.dataset.util import forecast_start
+from gluonts.dataset.field_names import FieldName
 from gluonts.model.forecast import Forecast, SampleForecast
 from gluonts.model.predictor import RepresentablePredictor
+from gluonts.transform.feature import (
+    LastValueImputation,
+    MissingValueImputation,
+)
 from gluonts.time_feature import get_seasonality
 
 
@@ -44,6 +49,10 @@ class SeasonalNaivePredictor(RepresentablePredictor):
         Number of time points to predict
     season_length
         Length of the seasonality pattern of the input data
+    imputation_method
+        The imputation method to use in case of missing values.
+        Defaults to `LastValueImputation` which replaces each missing
+        value with the last value that was not missing.
     """
 
     @validated()
@@ -52,6 +61,9 @@ class SeasonalNaivePredictor(RepresentablePredictor):
         freq: str,
         prediction_length: int,
         season_length: Optional[int] = None,
+        imputation_method: Optional[
+            MissingValueImputation
+        ] = LastValueImputation(),
     ) -> None:
         super().__init__(prediction_length=prediction_length)
 
@@ -65,15 +77,20 @@ class SeasonalNaivePredictor(RepresentablePredictor):
             if season_length is not None
             else get_seasonality(freq)
         )
+        self.imputation_method = imputation_method
 
     def predict_item(self, item: DataEntry) -> Forecast:
-        target = np.asarray(item["target"], np.float32)
+        target = np.asarray(item[FieldName.TARGET], np.float32)
         len_ts = len(target)
         forecast_start_time = forecast_start(item)
 
         assert (
             len_ts >= 1
         ), "all time series should have at least one data point"
+
+        if np.isnan(target).any():
+            target = target.copy()
+            target = self.imputation_method(target)
 
         if len_ts >= self.season_length:
             indices = [

--- a/test/model/seasonal_naive/test_seasonal_naive.py
+++ b/test/model/seasonal_naive/test_seasonal_naive.py
@@ -1,0 +1,97 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gluonts.model.seasonal_naive import SeasonalNaivePredictor
+from gluonts.transform.feature import LastValueImputation, LeavesMissingValues
+
+FREQ = "D"
+START_DATE = "2023"
+
+
+def get_prediction(
+    target,
+    prediction_length=1,
+    season_length=1,
+    imputation_method=LastValueImputation(),
+):
+    pred = SeasonalNaivePredictor(
+        freq=FREQ,
+        prediction_length=prediction_length,
+        season_length=season_length,
+        imputation_method=imputation_method,
+    )
+    item = {
+        "target": np.asarray(target),
+        "start": pd.Period(START_DATE, freq=FREQ),
+    }
+    forecast = pred.predict_item(item)
+
+    return forecast
+
+
+@pytest.mark.parametrize(
+    "data, expected_output, prediction_length, season_length, imputation_method",
+    [
+        ([1, 1, 1], [1], 1, 1, LastValueImputation()),
+        ([1, 1, 1], [1, 1], 2, 1, LastValueImputation()),
+        ([1, 1, 1], [1, 1, 1], 3, 1, LastValueImputation()),
+        ([1, 1, 1], [1], 1, 2, LastValueImputation()),
+        ([1, 1, 1], [1, 1], 2, 2, LastValueImputation()),
+        ([1, 1, 1], [1, 1, 1], 3, 2, LastValueImputation()),
+        ([1, 1, 1], [1], 1, 3, LastValueImputation()),
+        ([1, 1, 1], [1, 1], 2, 3, LastValueImputation()),
+        ([1, 1, 1], [1, 1, 1], 3, 3, LastValueImputation()),
+        ([np.nan], [0], 1, 1, LastValueImputation()),
+        ([1, 3, np.nan], [1], 1, 3, LastValueImputation()),
+        ([1, 3, np.nan], [1, 3], 2, 3, LastValueImputation()),
+        ([1, 3, np.nan], [1, 3, 3], 3, 3, LastValueImputation()),
+        ([1, 2, 3], [3], 1, 1, LastValueImputation()),
+        ([1, 2, 3], [3, 3], 2, 1, LastValueImputation()),
+        ([1, 2, 3], [3, 3, 3], 3, 1, LastValueImputation()),
+        ([1, 2, 3], [2], 1, 2, LastValueImputation()),
+        ([1, 2, 3], [2, 3], 2, 2, LastValueImputation()),
+        ([1, 2, 3], [2, 3, 2], 3, 2, LastValueImputation()),
+        ([1, 2, 3], [1], 1, 3, LastValueImputation()),
+        ([1, 2, 3], [1, 2], 2, 3, LastValueImputation()),
+        ([1, 2, 3], [1, 2, 3], 3, 3, LastValueImputation()),
+        ([1, 1, 1], [1], 1, None, LastValueImputation()),
+        ([1, 1, 1], [1, 1], 2, None, LastValueImputation()),
+        ([1, 1, 1], [1, 1, 1], 3, None, LastValueImputation()),
+        ([1, 3, np.nan], [3], 1, None, LastValueImputation()),
+        ([1, 3, np.nan], [3, 3], 2, None, LastValueImputation()),
+        ([1, 3, np.nan], [3, 3, 3], 3, None, LastValueImputation()),
+        ([1, 3, np.nan], [np.nan], 1, 1, LeavesMissingValues()),
+        ([1, 3, np.nan], [np.nan] * 2, 2, 1, LeavesMissingValues()),
+        ([1, 3, np.nan], [np.nan] * 3, 3, 1, LeavesMissingValues()),
+        ([1, 3, np.nan], [3], 1, 2, LeavesMissingValues()),
+        ([1, 3, np.nan], [3, np.nan], 2, 2, LeavesMissingValues()),
+        ([1, 3, np.nan], [3, np.nan, 3], 3, 2, LeavesMissingValues()),
+    ],
+)
+def test_predictor(
+    data, expected_output, prediction_length, season_length, imputation_method
+):
+
+    prediction = get_prediction(
+        data,
+        prediction_length=prediction_length,
+        season_length=season_length,
+        imputation_method=imputation_method,
+    )
+    assert prediction.samples.shape == (1, prediction_length)
+
+    np.testing.assert_equal(prediction.mean, expected_output)


### PR DESCRIPTION
*Issue #, if available:* #2560

*Description of changes:*
This PR adds missing value imputation to `SeasonalNaivePredictor`. Previously, the predictor would return `nan` as forecast if the value at previous season was `nan`. I have set the default imputation strategy to `LastValueImputation` which makes sense in the case of `SeasonalNaivePredictor` but we can change this to something else.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup