### PR TITLE
Improve `PandasDataset`

### DIFF
--- a/docs/tutorials/data_manipulation/pandasdataframes.md.template
+++ b/docs/tutorials/data_manipulation/pandasdataframes.md.template
@@ -328,10 +328,11 @@ estimator_with_features = DeepAREstimator(
 )
 ```
 
-Let's now generate single time series and multiple time series
-(as list and as long-dataframe).
+Let's now generate multiple time series, both as a dictionary of data frames,
+and as a single long data frame. We also generate a dedicated data frame of
+static features.
 Note we don't provide `freq` and `timestamp`, because they are automatically
-inferred from the index. We are also not passing the `target` argument, since
+inferred from the time index. We are also not passing the `target` argument, since
 it's default value is "target", which is the target column in our dataframes.
 
 

--- a/docs/tutorials/data_manipulation/pandasdataframes.md.template
+++ b/docs/tutorials/data_manipulation/pandasdataframes.md.template
@@ -298,7 +298,6 @@ def generate_single_ts_with_features(date_range, item_id) -> pd.DataFrame:
     ts = generate_single_ts(date_range, item_id)
     T = ts.shape[0]
     # static features are constant for each series
-    ts["static_cat_1"] = np.random.randint(low=0, high=2) # high is exclusive
     ts["dynamic_real_1"] = np.random.normal(size=T)
     ts["dynamic_real_2"] = np.random.normal(size=T)
     # ... we can have as many static or dynamic features as we like
@@ -322,8 +321,9 @@ estimator_with_features = DeepAREstimator(
     freq=ds.freq,
     prediction_length=prediction_length,
     use_feat_dynamic_real=True,
+    use_feat_static_real=True,
     use_feat_static_cat=True,
-    cardinality=[2,],
+    cardinality=[3,],
     trainer=Trainer(epochs=1),
 )
 ```
@@ -336,48 +336,35 @@ it's default value is "target", which is the target column in our dataframes.
 
 
 ```python
-single_ts = generate_single_ts_with_features(date_range, item_id=0)
-multiple_ts = [generate_single_ts_with_features(date_range, item_id=i) for i in range(N)]
-multiple_ts_long = pd.concat(multiple_ts)
-
-single_ts_dataset = PandasDataset(
-    single_ts,
-    feat_dynamic_real=["dynamic_real_1", "dynamic_real_2"],
-    feat_static_cat=["static_cat_1"],
+multiple_ts = {i: generate_single_ts_with_features(date_range, item_id=i) for i in range(N)}
+static_features = pd.DataFrame(
+    {
+        "color": pd.Categorical(np.random.choice(["red", "green", "blue"], size=N)),
+        "height": np.random.normal(loc=100, scale=15, size=N),
+    },
+    index=list(multiple_ts.keys())
 )
+multiple_ts_long = pd.concat(multiple_ts.values())
+
 multiple_ts_dataset = PandasDataset(
     multiple_ts,
     feat_dynamic_real=["dynamic_real_1", "dynamic_real_2"],
-    feat_static_cat=["static_cat_1"],
-)
-multiple_ts_dataset_dict = PandasDataset(
-    {i: _ts for i, _ts in enumerate(multiple_ts)},
-    feat_dynamic_real=["dynamic_real_1", "dynamic_real_2"],
-    feat_static_cat=["static_cat_1"],
+    static_features=static_features,
 )
 # for long-dataset we use a different constructor and need a `item_id` column
 multiple_ts_long_dataset = PandasDataset.from_long_dataframe(
     multiple_ts_long,
     item_id="item_id",
     feat_dynamic_real=["dynamic_real_1", "dynamic_real_2"],
-    feat_static_cat=["static_cat_1"],
+    static_features=static_features,
 )
 ```
 
 That's it! We can now call `train_and_predict` with all
 the datasets.
 
-
-```python
-train_and_predict(single_ts_dataset, estimator_with_features)
-```
-
 ```python
 train_and_predict(multiple_ts_dataset, estimator_with_features)
-```
-
-```python
-train_and_predict(multiple_ts_dataset_dict, estimator_with_features)
 ```
 
 ```python
@@ -399,13 +386,17 @@ a bunch of metrics for us
 
 
 ```python
-to_pandasdataset = lambda data: PandasDataset(
-    data,
+train = PandasDataset(
+    {item_id: df[:-prediction_length] for item_id, df in multiple_ts.items()},
     feat_dynamic_real=["dynamic_real_1", "dynamic_real_2"],
-    feat_static_cat=["static_cat_1"],
+    static_features=static_features,
 )
-train = to_pandasdataset([ts.iloc[:-prediction_length, :] for ts in multiple_ts])
-test = to_pandasdataset(multiple_ts)
+
+test = PandasDataset(
+    multiple_ts,
+    feat_dynamic_real=["dynamic_real_1", "dynamic_real_2"],
+    static_features=static_features,
+)
 ```
 
 

--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -29,7 +29,6 @@ from gluonts.itertools import SizedIterable
 # - feat_dynamic_cat -> gone, too painful to do now, let's think about it later
 # - TODO have dtype somewhere?
 # - TODO have assertions for stuff being the right dtype?
-# - TODO add the "ignore_last_n_targets" in some way (I don't like it)
 # - TODO benchmark
 # - TODO adjust tests, especially add tests for static features
 
@@ -49,6 +48,7 @@ class PandasDataset:
     timestamp: Optional[str] = None
     freq: Optional[str] = None
     static_features: Optional[pd.DataFrame] = None
+    ignore_last_n_targets: int = 0
     unchecked: bool = True
     assume_sorted: bool = False
     _static_reals: Optional[pd.DataFrame] = None
@@ -142,7 +142,9 @@ class PandasDataset:
             )
 
         start = df.index[0]
-        target = df[self.target].values.transpose()
+        target = df[self.target].values.transpose()[
+            ..., -self.ignore_last_n_targets :
+        ]
 
         entry = {
             "item_id": item_id,

--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -229,14 +229,22 @@ def split_numerical_categorical(df: pd.DataFrame):
     )
 
 
-def category_to_int(df):
+def category_to_int(df: pd.DataFrame):
     """
-    Turns categorical columns from the given DataFrame into integer ones.
+    Return a ``DataFrame`` with categorical columns replaced by integer codes.
+
+    Codes are obtained via ``pd.Categorical.codes``, and range from 0 to N,
+    where N is the number of categories for the column of interest.
     """
-    for col in df.columns:
-        if df[col].dtype == "category":
-            df[col] = pd.Categorical(df[col]).codes
-    return df
+    data = {
+        col: (
+            pd.Categorical(df[col]).codes
+            if df[col].dtype == "category"
+            else df[col]
+        )
+        for col in df.columns
+    }
+    return pd.DataFrame(data=data, index=df.index)
 
 
 def is_uniform(index: pd.PeriodIndex) -> bool:

--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -142,9 +142,9 @@ class PandasDataset:
             )
 
         start = df.index[0]
-        target = df[self.target].values.transpose()[
-            ..., -self.ignore_last_n_targets :
-        ]
+        target = df[self.target].values.transpose()
+        if self.ignore_last_n_targets > 0:
+            target = target[..., : -self.ignore_last_n_targets]
 
         entry = {
             "item_id": item_id,

--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -225,6 +225,8 @@ class PandasDataset:
         for pair in self._pairs:
             yield self._pair_to_dataentry(pair)
 
+        self.unchecked = True
+
     @classmethod
     def from_long_dataframe(
         cls, dataframe: pd.DataFrame, item_id: str, **kwargs

--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -16,7 +16,6 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union
 
 import numpy as np
 import pandas as pd
-from pandas.api.types import is_numeric_dtype
 from pandas.core.indexes.datetimelike import DatetimeIndexOpsMixin
 from toolz import first
 

--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -31,7 +31,7 @@ class PandasDataset:
 
     This class is constructed with a collection of ``pandas.DataFrame``
     objects where each ``DataFrame`` is representing one time series.
-    A ``target`` and a ``timestamp`` columns are essential. Dynamic features
+    Both ``target`` and ``timestamp`` columns are essential. Dynamic features
     of a series can be specified with together with the series' ``DataFrame``,
     while static features can be specified in a separate ``DataFrame`` object
     via the ``static_features`` argument.

--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -23,15 +23,6 @@ from toolz import first
 from gluonts.dataset.common import DataEntry
 from gluonts.itertools import SizedIterable
 
-# NOTE
-# - feat_static_real -> gone, use dedicated dataframe for static features
-# - feat_static_cat -> gone, same as above
-# - feat_dynamic_cat -> gone, too painful to do now, let's think about it later
-# - TODO have dtype somewhere?
-# - TODO have assertions for stuff being the right dtype?
-# - TODO benchmark
-# - TODO adjust tests, especially add tests for static features
-
 
 @dataclass
 class PandasDataset:

--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -123,6 +123,8 @@ class PandasDataset:
         if self._static_cats is not None:
             self._static_cats = category_to_int(self._static_cats)
 
+        self._data_entries = Map(self._pair_to_dataentry, self._pairs)
+
     @property
     def num_feat_static_cat(self):
         return 0 if self._static_cats is None else self._static_cats.shape[1]
@@ -154,21 +156,6 @@ class PandasDataset:
         return [
             max(self._static_cats[c]) + 1 for c in self._static_cats.columns
         ]
-
-    def __len__(self) -> int:
-        return len(self._pairs)
-
-    def __str__(self) -> str:
-        return (
-            f"PandasDataset<"
-            f"size={len(self)}, "
-            f"freq={self.freq}, "
-            f"num_dynamic_real={self.num_feat_dynamic_real}, "
-            f"num_past_dynamic_real={self.num_past_feat_dynamic_real}, "
-            f"num_static_real={self.num_feat_static_real}, "
-            f"num_static_cat={self.num_feat_static_cat}, "
-            f"cardinalities={self.cardinalities}>"
-        )
 
     def _pair_to_dataentry(self, pair) -> DataEntry:
         item_id, df = pair
@@ -224,10 +211,23 @@ class PandasDataset:
         return entry
 
     def __iter__(self):
-        for pair in self._pairs:
-            yield self._pair_to_dataentry(pair)
-
+        yield from self._data_entries
         self.unchecked = True
+
+    def __len__(self) -> int:
+        return len(self._data_entries)
+
+    def __str__(self) -> str:
+        return (
+            f"PandasDataset<"
+            f"size={len(self)}, "
+            f"freq={self.freq}, "
+            f"num_dynamic_real={self.num_feat_dynamic_real}, "
+            f"num_past_dynamic_real={self.num_past_feat_dynamic_real}, "
+            f"num_static_real={self.num_feat_static_real}, "
+            f"num_static_cat={self.num_feat_static_cat}, "
+            f"cardinalities={self.cardinalities}>"
+        )
 
     @classmethod
     def from_long_dataframe(

--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -143,8 +143,6 @@ class PandasDataset:
 
     @property
     def cardinalities(self):
-        if self._static_cats is None:
-            return []
         return [
             max(self._static_cats[c]) + 1 for c in self._static_cats.columns
         ]

--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -1,4 +1,17 @@
-from typing import Any, Dict, Union, List, Optional
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from typing import Dict, Union, List, Optional
 from dataclasses import dataclass
 
 import numpy as np
@@ -19,6 +32,7 @@ from gluonts.itertools import SizedIterable
 # - TODO add the "ignore_last_n_targets" in some way (I don't like it)
 # - TODO benchmark
 # - TODO adjust tests, especially add tests for static features
+
 
 @dataclass
 class PandasDataset:

--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -26,6 +26,47 @@ from gluonts.itertools import SizedIterable
 
 @dataclass
 class PandasDataset:
+    """
+    A dataset type based on ``pandas.DataFrame``.
+
+    This class is constructed with a collection of ``pandas.DataFrame``
+    objects where each ``DataFrame`` is representing one time series.
+    A ``target`` and a ``timestamp`` columns are essential. Dynamic features
+    of a series can be specified with together with the series' ``DataFrame``,
+    while static features can be specified in a separate ``DataFrame`` object
+    via the ``static_features`` argument.
+
+    Parameters
+    ----------
+    dataframes
+        Single ``pd.DataFrame``/``pd.Series`` or a collection as list or dict
+        containing at least ``timestamp`` and ``target`` values.
+        If a Dict is provided, the key will be the associated ``item_id``.
+    target
+        Name of the column that contains the ``target`` time series.
+        For multivariate targets, a list of column names should be provided.
+    timestamp
+        Name of the column that contains the timestamp information.
+    freq
+        Frequency of observations in the time series. Must be a valid pandas
+        frequency.
+    feat_dynamic_real
+        List of column names that contain dynamic real features.
+    static_features
+        ``pd.DataFrame`` containing static features for the series. The index
+        should contain the key of the series in the ``dataframes`` argument.
+    ignore_last_n_targets
+        For target and past dynamic features last ``ignore_last_n_targets``
+        elements are removed when iterating over the data set. This becomes
+        important when the predictor is called.
+    unchecked
+        Whether consistency checks on indexes should be skipped.
+        (Default: ``False``)
+    assume_sorted
+        Whether to assume that indexes are sorted by time, and skip sorting.
+        (Default: ``False``)
+    """
+
     dataframes: Union[
         pd.DataFrame,
         pd.Series,
@@ -40,7 +81,7 @@ class PandasDataset:
     freq: Optional[str] = None
     static_features: Optional[pd.DataFrame] = None
     ignore_last_n_targets: int = 0
-    unchecked: bool = True
+    unchecked: bool = False
     assume_sorted: bool = False
     _static_reals: Optional[pd.DataFrame] = None
     _static_cats: Optional[pd.DataFrame] = None

--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -282,7 +282,7 @@ def infer_freq(index: pd.Index) -> str:
     return freq
 
 
-def remove_last_n(n: int, array: np.ndarray):
+def remove_last_n(n: int, array: np.ndarray) -> np.ndarray:
     """
     Return a new array with last ``n`` elements removed from the
     trailing axis, if ``n`` is positive, and the array itself otherwise.
@@ -292,7 +292,9 @@ def remove_last_n(n: int, array: np.ndarray):
     return array[..., :-n]
 
 
-def split_numerical_categorical(df: pd.DataFrame):
+def split_numerical_categorical(
+    df: pd.DataFrame,
+) -> Tuple[Optional[pd.DataFrame], Optional[pd.DataFrame]]:
     """
     Splits the given DataFrame into two: one containing numerical columns,
     the other containing categorical columns.
@@ -314,7 +316,7 @@ def split_numerical_categorical(df: pd.DataFrame):
     )
 
 
-def category_to_int(df: pd.DataFrame):
+def category_to_int(df: pd.DataFrame) -> pd.DataFrame:
     """
     Return a ``DataFrame`` with categorical columns replaced by integer codes.
 

--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -97,7 +97,7 @@ class PandasDataset:
     def __post_init__(self):
         if isinstance(self.dataframes, dict):
             self._pairs = self.dataframes.items()
-        elif isinstance(self.dataframes, (pd.DataFrame, pd.Series)):
+        elif isinstance(self.dataframes, (pd.Series, pd.DataFrame)):
             self._pairs = [pair_with_item_id(self.dataframes)]
         else:
             assert isinstance(self.dataframes, SizedIterable)
@@ -109,7 +109,7 @@ class PandasDataset:
             assert (
                 self.timestamp is None
             ), "You need to provide `freq` along with `timestamp`"
-            self.freq = infer_freq(infer_freq(first(self._pairs)[1].index))
+            self.freq = infer_freq(first(self._pairs)[1].index)
 
         if self.static_features is not None:
             (
@@ -156,7 +156,7 @@ class PandasDataset:
         ]
 
     def __len__(self) -> int:
-        return len(self.dataframes)
+        return len(self._pairs)
 
     def __str__(self) -> str:
         return (
@@ -194,13 +194,15 @@ class PandasDataset:
             )
 
         entry = {
-            "item_id": item_id,
             "start": df.index[0],
             "target": remove_last_n(
                 self.ignore_last_n_targets,
                 df[self.target].values.transpose(),
             ),
         }
+
+        if item_id is not None:
+            entry["item_id"] = item_id
 
         if self._static_cats is not None:
             entry["feat_static_cat"] = self._static_cats.loc[item_id].values

--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -79,7 +79,7 @@ class PandasDataset:
         Dict[str, pd.DataFrame],
         Dict[str, pd.Series],
     ]
-    target: Union[str, List[str]] = "target"  # TODO meh
+    target: Union[str, List[str]] = "target"
     feat_dynamic_real: Optional[List[str]] = None
     past_feat_dynamic_real: Optional[List[str]] = None
     timestamp: Optional[str] = None

--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -112,8 +112,12 @@ class PandasDataset:
             ), "You need to provide `freq` along with `timestamp`"
             self.freq = infer_freq(first(self._pairs)[1].index)
 
-        self._static_reals = self.static_features.select_dtypes("number").astype(self.dtype)
-        self._static_cats = category_to_int(self.static_features.select_dtypes("category"))
+        self._static_reals = self.static_features.select_dtypes(
+            "number"
+        ).astype(self.dtype)
+        self._static_cats = self.static_features.select_dtypes(
+            "category"
+        ).apply(lambda col: col.cat.codes)
 
         self._data_entries = Map(self._pair_to_dataentry, self._pairs)
 
@@ -297,24 +301,6 @@ def remove_last_n(n: int, array: np.ndarray) -> np.ndarray:
     if n <= 0:
         return array
     return array[..., :-n]
-
-
-def category_to_int(df: pd.DataFrame) -> pd.DataFrame:
-    """
-    Return a ``DataFrame`` with categorical columns replaced by integer codes.
-
-    Codes are obtained via ``pd.Categorical.codes``, and range from 0 to N,
-    where N is the number of categories for the column of interest.
-    """
-    data = {
-        col: (
-            pd.Categorical(df[col]).codes
-            if df[col].dtype == "category"
-            else df[col]
-        )
-        for col in df.columns
-    }
-    return pd.DataFrame(data=data, index=df.index)
 
 
 def is_uniform(index: pd.PeriodIndex) -> bool:

--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -271,7 +271,9 @@ class PandasDataset:
             assert len(static_features) == len(dataframe[item_id].unique())
         else:
             other_static_features = pd.DataFrame()
-        static_features = pd.concat([static_features, other_static_features], axis=1)
+        static_features = pd.concat(
+            [static_features, other_static_features], axis=1
+        )
         return cls(
             dataframes=dataframe.groupby(item_id),
             static_features=static_features,

--- a/test/dataset/test_hierarchical.py
+++ b/test/dataset/test_hierarchical.py
@@ -12,11 +12,10 @@
 # permissions and limitations under the License.
 
 
-# Third-party imports
 import numpy as np
 import pandas as pd
+from toolz.itertoolz import first
 
-# First-party imports
 import pytest
 from gluonts.dataset.hierarchical import HierarchicalTimeSeries
 
@@ -137,7 +136,7 @@ def test_hts_to_dataset(mode: str):
             ds = hts.to_dataset(feat_dynamic_real=features_df)
     else:
         ds = hts.to_dataset(feat_dynamic_real=features_df)
-        entry = next(iter(ds))
+        entry = first(ds)
 
         assert entry["start"] == features_df.index[0]
 

--- a/test/dataset/test_hierarchical.py
+++ b/test/dataset/test_hierarchical.py
@@ -115,6 +115,7 @@ def test_hts_to_dataset(mode: str):
     S = np.vstack(([[1, 1, 1, 1], [1, 1, 0, 0], [0, 0, 1, 1]], np.eye(4)))
     hts = get_random_hts(S=S, periods=PERIODS, freq=FREQ)
 
+    num_bottom_ts = S.shape[1]
     num_features = 10
     num_future_time_steps = {
         "train": 0,
@@ -136,38 +137,19 @@ def test_hts_to_dataset(mode: str):
             ds = hts.to_dataset(feat_dynamic_real=features_df)
     else:
         ds = hts.to_dataset(feat_dynamic_real=features_df)
+        entry = next(iter(ds))
 
-        # In both train and inference modes, the index of the target
-        # dataframe should be same as that of time features since we pad
-        # NaNs in inference mode.
-        assert (ds.dataframes[0].index == features_df.index).all(), (
-            "The index of target dataframe and the features dataframe "
-            "do not match!\n"
-            f"Index of target dataframe: {ds.dataframes[0].index}.\n"
-            f"Index of features dataframe: {features_df.index}."
-        )
+        assert entry["start"] == features_df.index[0]
 
         if mode == "train":
-            # There should be no NaN in the target dataframe after concatenating
-            # with the features dataframe since there are no future time steps.
-            assert not ds.dataframes[0].isnull().values.any(), (
-                "The target dataframe is incorrectly constructed and "
-                "contains NaNs."
+            entry["target"].shape == (num_bottom_ts, PERIODS)
+            entry["feat_dynamic_real"].shape == (num_features, PERIODS)
+        else:
+            entry["target"].shape == (
+                num_bottom_ts,
+                PERIODS + num_future_time_steps,
             )
-        elif mode == "inference":
-            assert ds.ignore_last_n_targets == num_future_time_steps, (
-                "The field `ignore_last_n_targets` is not correctly set "
-                "while creating the hierarchical dataset.\n"
-                f"Expected value: {num_future_time_steps}, "
-                f"Obtained: {ds.ignore_last_n_targets}."
-            )
-
-            # For each target column there would be `num_future_time_steps` NaNs.
-            num_nans_expected = len(ds.target) * num_future_time_steps
-            num_nans = ds.dataframes[0].isnull().values.sum()
-            assert num_nans == num_nans_expected, (
-                "The target dataframe is incorrectly constructed and "
-                "do not contain the correct number of NaNs. \n"
-                f"Expected no. of NaNs: {num_nans_expected}, "
-                f"Obtained: {num_nans}."
+            entry["feat_dynamic_real"].shape == (
+                num_features,
+                PERIODS + num_future_time_steps,
             )

--- a/test/dataset/test_hierarchical.py
+++ b/test/dataset/test_hierarchical.py
@@ -140,17 +140,17 @@ def test_hts_to_dataset(mode: str):
         # In both train and inference modes, the index of the target
         # dataframe should be same as that of time features since we pad
         # NaNs in inference mode.
-        assert (ds.dataframes.index == features_df.index).all(), (
+        assert (ds.dataframes[0].index == features_df.index).all(), (
             "The index of target dataframe and the features dataframe "
             "do not match!\n"
-            f"Index of target dataframe: {ds.dataframes.index}.\n"
+            f"Index of target dataframe: {ds.dataframes[0].index}.\n"
             f"Index of features dataframe: {features_df.index}."
         )
 
         if mode == "train":
             # There should be no NaN in the target dataframe after concatenating
             # with the features dataframe since there are no future time steps.
-            assert not ds.dataframes.isnull().values.any(), (
+            assert not ds.dataframes[0].isnull().values.any(), (
                 "The target dataframe is incorrectly constructed and "
                 "contains NaNs."
             )
@@ -164,7 +164,7 @@ def test_hts_to_dataset(mode: str):
 
             # For each target column there would be `num_future_time_steps` NaNs.
             num_nans_expected = len(ds.target) * num_future_time_steps
-            num_nans = ds.dataframes.isnull().values.sum()
+            num_nans = ds.dataframes[0].isnull().values.sum()
             assert num_nans == num_nans_expected, (
                 "The target dataframe is incorrectly constructed and "
                 "do not contain the correct number of NaNs. \n"

--- a/test/dataset/test_pandas.py
+++ b/test/dataset/test_pandas.py
@@ -211,9 +211,8 @@ def _testcase_series(freq: str, index_type: Callable, dtype=np.float32):
         {
             "start": pd.Period(s.index[0], freq=freq),
             "target": s.values,
-            "item_id": k,
         }
-        for k, s in enumerate(series)
+        for s in series
     ]
 
     return dataset, expected_entries
@@ -277,9 +276,8 @@ def _testcase_dataframes_without_index(
             "start": pd.Period(df["timestamp"][0], freq=freq),
             "target": df[target].values.transpose(),
             "feat_dynamic_real": df[feat_dynamic_real].values.transpose(),
-            "item_id": k,
         }
-        for k, df in enumerate(dataframes)
+        for df in dataframes
     ]
 
     return dataset, expected_entries
@@ -338,9 +336,8 @@ def _testcase_dataframes_with_index(
             "start": pd.Period(df.index[0], freq=freq),
             "target": df[target].values.transpose(),
             "feat_dynamic_real": df[feat_dynamic_real].values.transpose(),
-            "item_id": k,
         }
-        for k, df in enumerate(dataframes)
+        for df in dataframes
     ]
 
     return dataset, expected_entries


### PR DESCRIPTION
*Description of changes:* This PR proposes an improved `PandasDataset` class where:
- Static features are provided through a separate `DataFrame`, whose index contains the `item_id`'s for the dataset, and whose columns dtypes are used to distinguish numerical/categorical features. In particular, categorical features are encoded as integers automatically using pandas
- Overall the code is simplified

In particular, now it is easy to use the class for loading the data from the M5 competition, with a bit of initial (and I believe necessary, and rather simple) pandas manipulation:

```python
# load dates information and sales data
cal = pd.read_csv(
    Path("m5-forecasting-accuracy") / "calendar.csv"
)
df = pd.read_csv(
    Path("m5-forecasting-accuracy")
    / "sales_train_validation.csv",
    index_col=0,
)

# slice out categorical columns
df_feat = df.iloc[:, 1:5].astype("category")

# slice out columns with numerical series data, transpose it
df_series = df.iloc[:, 5:].transpose()
df_series.index = pd.to_datetime(cal.date[: len(df_series.index)])

dataset = PandasDataset(
    dict(df_series),
    static_features=df_feat,
)

print(dataset)
```

gives

```
PandasDataset<size=30490, freq=D, num_dynamic_real=0, num_past_dynamic_real=0, num_static_real=0, num_static_cat=4, cardinalities=[7, 3, 10, 3]>
```

With the current implementation, one would instead need to add static features as “constant dynamic” ones, for the class to then consider only the first value, and this preprocessing step takes quite long since it’s tens of thousands of series.

Still left to do:
- [x] fix other tests
- [x] fix the `past_feat_dynamic_real` story
- [ ] add common dynamic features (M5 has "special events" of a few types, and some other numerical indicators)
- [ ] add proper tests for features
- [x] update documentation
- [x] benchmark performance against previous implementation
- [x] define deprecation path for previous implementation, if we believe it's necessary

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup