### PR TITLE
Fix: avoid automatic device detection via serialized tensors when deserializing `PyTorchPredictor`.

### DIFF
--- a/src/gluonts/torch/model/predictor.py
+++ b/src/gluonts/torch/model/predictor.py
@@ -133,6 +133,9 @@ class PyTorchPredictor(Predictor):
     def deserialize(
         cls, path: Path, device: Optional[torch.device] = None
     ) -> "PyTorchPredictor":
+        if device is None:
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+
         # deserialize constructor parameters
         with (path / "parameters.json").open("r") as fp:
             parameters = load_json(fp.read())


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When `map_location=None` is passed to `torch.load`, it automatically loads the tensors to the device they were serialized on. It results in runtime errors when the model is trained using a GPU and serialized, but inference is done on CPU when predictor is constructed by `deserialize` method of PytorchPredictor with `device=None`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup