### PR TITLE
Shell: Add support for `requirements.txt` files.

### DIFF
--- a/src/gluonts/shell/sagemaker/dyn.py
+++ b/src/gluonts/shell/sagemaker/dyn.py
@@ -60,6 +60,21 @@ class Installer:
             ]
         )
 
+    def install_requirement(self, path: Path):
+        subprocess.check_call(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "--upgrade",
+                "--target",
+                str(self.packages),
+                "--requirement",
+                str(path),
+            ]
+        )
+
     def install(self, path):
         if path.is_file():
             if tarfile.is_tarfile(path):
@@ -67,6 +82,9 @@ class Installer:
 
             elif zipfile.is_zipfile(path):
                 self.handle_archive(zipfile.ZipFile, path)
+
+            elif path.match("requirements*.txt"):
+                self.install_requirement(path)
 
             elif path.suffix == ".py":
                 self.copy_install(path)


### PR DESCRIPTION
Allow users to specify requirements files, which are installed using `pip install -r <file>`. This only triggers in folders that are not packages (don't have `setup.py`).

Fixes: #2581

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup