### PR TITLE
Add assertion to split function ensuring valid windows

### DIFF
--- a/src/gluonts/dataset/split.py
+++ b/src/gluonts/dataset/split.py
@@ -355,9 +355,8 @@ class DateSplitter(AbstractBaseSplitter):
         input_slice = slice(None, base + offset)
         label_slice = slice(base + offset, base + offset + prediction_length)
         assert (
-            base + offset + prediction_length
-            <= entry[FieldName.TARGET].shape[-1]
-        ), "Offset too short to generate windows"
+            label_slice.stop <= entry[FieldName.TARGET].shape[-1]
+        ), "Date is too early to generate windows"
         return (
             slice_data_entry(
                 entry, input_slice, prediction_length=prediction_length

--- a/src/gluonts/dataset/split.py
+++ b/src/gluonts/dataset/split.py
@@ -356,7 +356,7 @@ class DateSplitter(AbstractBaseSplitter):
         label_slice = slice(base + offset, base + offset + prediction_length)
         assert (
             label_slice.stop <= entry[FieldName.TARGET].shape[-1]
-        ), "Date is too early to generate windows"
+        ), "Date is too late to generate windows"
         return (
             slice_data_entry(
                 entry, input_slice, prediction_length=prediction_length

--- a/src/gluonts/dataset/split.py
+++ b/src/gluonts/dataset/split.py
@@ -306,10 +306,10 @@ class OffsetSplitter(AbstractBaseSplitter):
         self, entry: DataEntry, prediction_length: int, offset: int = 0
     ) -> Tuple[DataEntry, DataEntry]:
         offset_ = self.offset + offset
-
-        assert (-offset_ >= prediction_length and self.offset < 0) or (
+        if self.offset < 0:
+            offset_ += entry[FieldName.TARGET].shape[-1]
+        assert (
             offset_ + prediction_length <= entry[FieldName.TARGET].shape[-1]
-            and self.offset >= 0
         ), "Offset too short to generate windows"
 
         if offset_ + prediction_length:

--- a/src/gluonts/dataset/split.py
+++ b/src/gluonts/dataset/split.py
@@ -310,7 +310,7 @@ class OffsetSplitter(AbstractBaseSplitter):
             offset_ += entry[FieldName.TARGET].shape[-1]
         assert (
             offset_ + prediction_length <= entry[FieldName.TARGET].shape[-1]
-        ), "Offset too short to generate windows"
+        ), "Not enough data to generate some of the windows; try splitting data at an earlier offset"
 
         if offset_ + prediction_length:
             input_slice = slice(None, offset_)
@@ -356,7 +356,7 @@ class DateSplitter(AbstractBaseSplitter):
         label_slice = slice(base + offset, base + offset + prediction_length)
         assert (
             label_slice.stop <= entry[FieldName.TARGET].shape[-1]
-        ), "Date is too late to generate windows"
+        ), "Not enough data to generate some of the windows; try splitting data at an earlier date"
         return (
             slice_data_entry(
                 entry, input_slice, prediction_length=prediction_length

--- a/src/gluonts/dataset/split.py
+++ b/src/gluonts/dataset/split.py
@@ -355,9 +355,8 @@ class DateSplitter(AbstractBaseSplitter):
         input_slice = slice(None, base + offset)
         label_slice = slice(base + offset, base + offset + prediction_length)
         assert (
-            base + offset + prediction_length
-            <= entry[FieldName.TARGET].shape[-1]
-        ), "Offset too short to generate windows"
+            label_slice.stop <= entry[FieldName.TARGET].shape[-1]
+        ), "Date is too late to generate windows"
         return (
             slice_data_entry(
                 entry, input_slice, prediction_length=prediction_length

--- a/src/gluonts/dataset/split.py
+++ b/src/gluonts/dataset/split.py
@@ -355,7 +355,8 @@ class DateSplitter(AbstractBaseSplitter):
         input_slice = slice(None, base + offset)
         label_slice = slice(base + offset, base + offset + prediction_length)
         assert (
-            base + offset + prediction_length <= entry[FieldName.TARGET].shape[-1]
+            base + offset + prediction_length
+            <= entry[FieldName.TARGET].shape[-1]
         ), "Offset too short to generate windows"
         return (
             slice_data_entry(

--- a/test/dataset/test_split.py
+++ b/test/dataset/test_split.py
@@ -390,3 +390,45 @@ def test_split_date(
         test_input["target"]
     )
     assert test_label["target"].shape == (prediction_length,)
+
+
+@pytest.mark.parametrize(
+    "dataset",
+    [
+        [
+            {
+                "start": pd.Period("2021-03-01", freq="D"),
+                "target": np.ones(shape=(28,)),
+            }
+        ],
+    ],
+)
+@pytest.mark.parametrize(
+    "date, offset, windows, distance",
+    [
+        (pd.Period("2021-03-22", freq="D"), None, 1, None),
+        (pd.Period("2021-03-21", freq="D"), None, 2, 1),
+        (pd.Period("2021-03-21", freq="D"), None, 2, 7),
+        (None, 22, 1, None),
+        (None, 21, 2, 1),
+        (None, 21, 2, 7),
+        (None, -6, 1, None),
+        (None, -7, 2, 1),
+        (None, -7, 2, 7),
+    ],
+)
+def test_invalid_offset(dataset, date, offset, windows, distance):
+    assert (offset is None) != (date is None)
+    exp_msg = "Not enough data to generate some of the windows"
+    prediction_length = 7
+
+    _, test_template = split(dataset, date=date, offset=offset)
+    with pytest.raises(AssertionError) as excinfo:
+        list(
+            test_template.generate_instances(
+                prediction_length=prediction_length,
+                windows=windows,
+                distance=distance,
+            )
+        )
+    assert exp_msg in str(excinfo.value)


### PR DESCRIPTION
*Issue:* #2577

*Description of changes:*
This PR addresses issue #2577 and added assertions for `OffsetSplitter` and `DateSplitter` to ensure that the targets of the label have valid target lengths, i.e. match `prediction_length.`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup