### PR TITLE
Fix bug with static features in `PandasDataset`

### DIFF
--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -268,7 +268,7 @@ class PandasDataset:
                 .drop_duplicates()
                 .set_index(item_id)
             )
-            assert len(static_features) == len(dataframe[item_id].unique())
+            assert len(other_static_features) == len(dataframe[item_id].unique())
         else:
             other_static_features = pd.DataFrame()
         static_features = pd.concat(

--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -268,7 +268,9 @@ class PandasDataset:
                 .drop_duplicates()
                 .set_index(item_id)
             )
-            assert len(other_static_features) == len(dataframe[item_id].unique())
+            assert len(other_static_features) == len(
+                dataframe[item_id].unique()
+            )
         else:
             other_static_features = pd.DataFrame()
         static_features = pd.concat(


### PR DESCRIPTION
*Description of changes:* A typo prevented the `static_feature_columns` option of `from_long_dataframe` from working. Updated a test that would now catch it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup