### PR TITLE
Allow ReduceLROnPlateau to track val_loss when validation set is available

### DIFF
--- a/src/gluonts/torch/model/deepar/lightning_module.py
+++ b/src/gluonts/torch/model/deepar/lightning_module.py
@@ -118,6 +118,11 @@ class DeepARLightningModule(pl.LightningModule):
             lr=self.lr,
             weight_decay=self.weight_decay,
         )
+        monitor = (
+            "val_loss"
+            if self.trainer._data_connector._val_dataloader_source.is_defined()
+            else "train_loss"
+        )
 
         return {
             "optimizer": optimizer,
@@ -128,6 +133,6 @@ class DeepARLightningModule(pl.LightningModule):
                     factor=0.5,
                     patience=self.patience,
                 ),
-                "monitor": "train_loss",
+                "monitor": monitor,
             },
         }

--- a/src/gluonts/torch/model/tft/lightning_module.py
+++ b/src/gluonts/torch/model/tft/lightning_module.py
@@ -113,7 +113,11 @@ class TemporalFusionTransformerLightningModule(pl.LightningModule):
             lr=self.lr,
             weight_decay=self.weight_decay,
         )
-        monitor = "val_loss" if self.trainer._data_connector._val_dataloader_source.is_defined() else "train_loss"
+        monitor = (
+            "val_loss"
+            if self.trainer._data_connector._val_dataloader_source.is_defined()
+            else "train_loss"
+        )
 
         return {
             "optimizer": optimizer,

--- a/src/gluonts/torch/model/tft/lightning_module.py
+++ b/src/gluonts/torch/model/tft/lightning_module.py
@@ -113,6 +113,7 @@ class TemporalFusionTransformerLightningModule(pl.LightningModule):
             lr=self.lr,
             weight_decay=self.weight_decay,
         )
+        monitor = "val_loss" if self.trainer._data_connector._val_dataloader_source.is_defined() else "train_loss"
 
         return {
             "optimizer": optimizer,
@@ -123,6 +124,6 @@ class TemporalFusionTransformerLightningModule(pl.LightningModule):
                     factor=0.5,
                     patience=self.patience,
                 ),
-                "monitor": "train_loss",
+                "monitor": monitor,
             },
         }


### PR DESCRIPTION
*Description of changes:*
Allow ReduceLROnPlateau to track val_loss when validation set is available. This makes the torch training process to be more in line with the current mxnet training process.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup