### PR TITLE
Improvement of parallel work

### DIFF
--- a/src/gluonts/torch/util.py
+++ b/src/gluonts/torch/util.py
@@ -151,7 +151,9 @@ class IterableDataset(torch.utils.data.IterableDataset):
         worker_total_num = torch.utils.data.get_worker_info().num_workers
         worker_id = torch.utils.data.get_worker_info().id
 
-        yield from itertools.islice(self.iterable, worker_id, None, worker_total_num)
+        yield from itertools.islice(
+            self.iterable, worker_id, None, worker_total_num
+        )
 
 
 def repeat_along_dim(a: torch.Tensor, dim: int, repeats: int) -> torch.Tensor:

--- a/src/gluonts/torch/util.py
+++ b/src/gluonts/torch/util.py
@@ -151,9 +151,7 @@ class IterableDataset(torch.utils.data.IterableDataset):
         worker_total_num = torch.utils.data.get_worker_info().num_workers
         worker_id = torch.utils.data.get_worker_info().id
 
-        yield from itertools.islice(
-            self.iterable, worker_id, None, worker_total_num
-        )
+        yield from itertools.islice(self.iterable, worker_id, None, worker_total_num)
 
 
 def repeat_along_dim(a: torch.Tensor, dim: int, repeats: int) -> torch.Tensor:

--- a/src/gluonts/torch/util.py
+++ b/src/gluonts/torch/util.py
@@ -13,6 +13,7 @@
 
 from typing import List, Optional, Type
 import inspect
+import itertools
 
 import torch
 

--- a/src/gluonts/torch/util.py
+++ b/src/gluonts/torch/util.py
@@ -143,7 +143,14 @@ class IterableDataset(torch.utils.data.IterableDataset):
         self.iterable = iterable
 
     def __iter__(self):
-        yield from self.iterable
+        worker_info = torch.utils.data.get_worker_info()
+        if worker_info is None:
+            yield from self.iterable
+
+        worker_total_num = torch.utils.data.get_worker_info().num_workers
+        worker_id = torch.utils.data.get_worker_info().id
+
+        yield from itertools.islice(self.iterable, worker_id, None, worker_total_num)
 
 
 def repeat_along_dim(a: torch.Tensor, dim: int, repeats: int) -> torch.Tensor:

--- a/src/gluonts/torch/util.py
+++ b/src/gluonts/torch/util.py
@@ -147,13 +147,13 @@ class IterableDataset(torch.utils.data.IterableDataset):
         worker_info = torch.utils.data.get_worker_info()
         if worker_info is None:
             yield from self.iterable
+        else:
+            worker_total_num = torch.utils.data.get_worker_info().num_workers
+            worker_id = torch.utils.data.get_worker_info().id
 
-        worker_total_num = torch.utils.data.get_worker_info().num_workers
-        worker_id = torch.utils.data.get_worker_info().id
-
-        yield from itertools.islice(
-            self.iterable, worker_id, None, worker_total_num
-        )
+            yield from itertools.islice(
+                self.iterable, worker_id, None, worker_total_num
+            )
 
 
 def repeat_along_dim(a: torch.Tensor, dim: int, repeats: int) -> torch.Tensor:

--- a/src/gluonts/torch/util.py
+++ b/src/gluonts/torch/util.py
@@ -148,8 +148,8 @@ class IterableDataset(torch.utils.data.IterableDataset):
         if worker_info is None:
             yield from self.iterable
         else:
-            worker_total_num = torch.utils.data.get_worker_info().num_workers
-            worker_id = torch.utils.data.get_worker_info().id
+            worker_total_num = worker_info.num_workers
+            worker_id = worker_info.id
 
             yield from itertools.islice(
                 self.iterable, worker_id, None, worker_total_num


### PR DESCRIPTION
Improvement of duplicates in parallel work. Previous realization did duplicates in parallel work.

*Issue #, if available:*
In parallel work function duplicates output if you use DataLoader with num_workers > 1

*Description of changes:*
Added functionality to check on parallel work. If solution works in parallel than we take number of workers and each worker returns unique sequence.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup