### PR TITLE
Fix off-by-one in torch DeepAR

### DIFF
--- a/src/gluonts/torch/model/deepar/module.py
+++ b/src/gluonts/torch/model/deepar/module.py
@@ -132,6 +132,7 @@ class DeepARModel(nn.Module):
             else [min(50, (cat + 1) // 2) for cat in cardinality]
         )
         self.lags_seq = lags_seq or get_lags_for_frequency(freq_str=freq)
+        self.lags_seq = [l - 1 for l in self.lags_seq]
         self.num_parallel_samples = num_parallel_samples
         self.past_length = self.context_length + max(self.lags_seq)
         self.embedder = FeatureEmbedder(
@@ -205,6 +206,82 @@ class DeepARModel(nn.Module):
     def _past_length(self) -> int:
         return self.context_length + max(self.lags_seq)
 
+    def input_shapes(self, batch_size=1) -> Dict[str, Tuple[int, ...]]:
+        return {
+            "feat_static_cat": (batch_size, self.num_feat_static_cat),
+            "feat_static_real": (batch_size, self.num_feat_static_real),
+            "past_time_feat": (
+                batch_size,
+                self._past_length,
+                self.num_feat_dynamic_real,
+            ),
+            "past_target": (batch_size, self._past_length),
+            "past_observed_values": (batch_size, self._past_length),
+            "future_time_feat": (
+                batch_size,
+                self.prediction_length,
+                self.num_feat_dynamic_real,
+            ),
+        }
+
+    def input_types(self) -> Dict[str, torch.dtype]:
+        return {
+            "feat_static_cat": torch.long,
+            "feat_static_real": torch.float,
+            "past_time_feat": torch.float,
+            "past_target": torch.float,
+            "past_observed_values": torch.float,
+            "future_time_feat": torch.float,
+        }
+
+    def prepare_rnn_input(
+        self,
+        feat_static_cat: torch.Tensor,
+        feat_static_real: torch.Tensor,
+        past_time_feat: torch.Tensor,
+        past_target: torch.Tensor,
+        past_observed_values: torch.Tensor,
+        future_time_feat: torch.Tensor,
+        future_target: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor,]:
+        context = past_target[..., -self.context_length :]
+        observed_context = past_observed_values[..., -self.context_length :]
+
+        input, _, scale = self.scaler(context, observed_context)
+        future_length = future_time_feat.shape[-2]
+        if future_length > 1:
+            assert future_target is not None
+            input = torch.cat(
+                (input, future_target[..., : future_length - 1] / scale),
+                dim=-1,
+            )
+        prior_input = past_target[..., : -self.context_length] / scale
+
+        lags = lagged_sequence_values(
+            self.lags_seq, prior_input, input, dim=-1
+        )
+
+        time_feat = torch.cat(
+            (
+                past_time_feat[..., -self.context_length + 1 :, :],
+                future_time_feat,
+            ),
+            dim=-2,
+        )
+
+        embedded_cat = self.embedder(feat_static_cat)
+        static_feat = torch.cat(
+            (embedded_cat, feat_static_real, scale.log()),
+            dim=-1,
+        )
+        expanded_static_feat = unsqueeze_expand(
+            static_feat, dim=-2, size=time_feat.shape[-2]
+        )
+
+        features = torch.cat((expanded_static_feat, time_feat), dim=-1)
+
+        return torch.cat((lags, features), dim=-1), scale, static_feat
+
     def unroll_lagged_rnn(
         self,
         feat_static_cat: torch.Tensor,
@@ -212,7 +289,7 @@ class DeepARModel(nn.Module):
         past_time_feat: torch.Tensor,
         past_target: torch.Tensor,
         past_observed_values: torch.Tensor,
-        future_time_feat: Optional[torch.Tensor] = None,
+        future_time_feat: torch.Tensor,
         future_target: Optional[torch.Tensor] = None,
     ) -> Tuple[
         Tuple[torch.Tensor, ...],
@@ -242,7 +319,7 @@ class DeepARModel(nn.Module):
             Tensor of observed values indicators,
             shape: ``(batch_size, past_length)``.
         future_time_feat
-            (Optional) tensor of dynamic real features in the past,
+            Tensor of dynamic real features in the future,
             shape: ``(batch_size, prediction_length, num_feat_dynamic_real)``.
         future_target
             (Optional) tensor of future target values,
@@ -258,43 +335,15 @@ class DeepARModel(nn.Module):
             - Static input to the RNN
             - Output state from the RNN
         """
-        context = past_target[..., -self.context_length :]
-        observed_context = past_observed_values[..., -self.context_length :]
-        _, _, scale = self.scaler(context, observed_context)
-
-        prior_input = past_target[..., : -self.context_length] / scale
-        input = (
-            torch.cat((context, future_target[..., :-1]), dim=-1) / scale
-            if future_target is not None
-            else context / scale
+        rnn_input, scale, static_feat = self.prepare_rnn_input(
+            feat_static_cat,
+            feat_static_real,
+            past_time_feat,
+            past_target,
+            past_observed_values,
+            future_time_feat,
+            future_target,
         )
-
-        embedded_cat = self.embedder(feat_static_cat)
-        static_feat = torch.cat(
-            (embedded_cat, feat_static_real, scale.log()),
-            dim=-1,
-        )
-        expanded_static_feat = unsqueeze_expand(
-            static_feat, dim=-2, size=input.shape[-1]
-        )
-
-        time_feat = (
-            torch.cat(
-                (
-                    past_time_feat[..., -self.context_length + 1 :, :],
-                    future_time_feat,
-                ),
-                dim=-2,
-            )
-            if future_time_feat is not None
-            else past_time_feat[..., -self.context_length + 1 :, :]
-        )
-
-        features = torch.cat((expanded_static_feat, time_feat), dim=-1)
-        lags = lagged_sequence_values(
-            self.lags_seq, prior_input, input, dim=-1
-        )
-        rnn_input = torch.cat((lags, features), dim=-1)
 
         output, new_state = self.rnn(rnn_input)
 

--- a/src/gluonts/torch/model/deepar/module.py
+++ b/src/gluonts/torch/model/deepar/module.py
@@ -206,34 +206,6 @@ class DeepARModel(nn.Module):
     def _past_length(self) -> int:
         return self.context_length + max(self.lags_seq)
 
-    def input_shapes(self, batch_size=1) -> Dict[str, Tuple[int, ...]]:
-        return {
-            "feat_static_cat": (batch_size, self.num_feat_static_cat),
-            "feat_static_real": (batch_size, self.num_feat_static_real),
-            "past_time_feat": (
-                batch_size,
-                self._past_length,
-                self.num_feat_dynamic_real,
-            ),
-            "past_target": (batch_size, self._past_length),
-            "past_observed_values": (batch_size, self._past_length),
-            "future_time_feat": (
-                batch_size,
-                self.prediction_length,
-                self.num_feat_dynamic_real,
-            ),
-        }
-
-    def input_types(self) -> Dict[str, torch.dtype]:
-        return {
-            "feat_static_cat": torch.long,
-            "feat_static_real": torch.float,
-            "past_time_feat": torch.float,
-            "past_target": torch.float,
-            "past_observed_values": torch.float,
-            "future_time_feat": torch.float,
-        }
-
     def prepare_rnn_input(
         self,
         feat_static_cat: torch.Tensor,

--- a/src/gluonts/torch/util.py
+++ b/src/gluonts/torch/util.py
@@ -120,7 +120,7 @@ def lagged_sequence_values(
     assert max(indices) <= prior_sequence.shape[dim], (
         f"lags cannot go further than prior sequence length, found lag"
         f" {max(indices)} while prior sequence is only"
-        f"{prior_sequence.shape[dim]}-long"
+        f" {prior_sequence.shape[dim]}-long"
     )
 
     full_sequence = torch.cat((prior_sequence, sequence), dim=dim)

--- a/test/torch/model/test_deepar_modules.py
+++ b/test/torch/model/test_deepar_modules.py
@@ -174,6 +174,14 @@ def test_rnn_input(
         num_parallel_samples=num_samples,
     )
 
+    # Construct test batch of size 1, such that:
+    # - target values are increasing integers
+    # - there is one dynamic feature that is equal to the target
+    #
+    # Since scaling=False, this way we can compare lagged target
+    # values and dynamic feature and verify that the expected values
+    # are given as input to the RNN, at the expected time index.
+
     batch = {
         "feat_static_cat": torch.tensor([[0]], dtype=torch.int64),
         "feat_static_real": torch.tensor([[0.0]], dtype=torch.float32),
@@ -207,7 +215,7 @@ def test_rnn_input(
     )
 
     for idx, lag in enumerate(lags_seq):
-        assert torch.isclose(ref - lag, rnn_input[0, :, idx]).all()
+        assert torch.equal(ref - lag, rnn_input[0, :, idx])
 
     # test with all future data
 
@@ -234,4 +242,4 @@ def test_rnn_input(
     )
 
     for idx, lag in enumerate(lags_seq):
-        assert torch.isclose(ref - lag, rnn_input[0, :, idx]).all()
+        assert torch.equal(ref - lag, rnn_input[0, :, idx])

--- a/test/torch/model/test_deepar_modules.py
+++ b/test/torch/model/test_deepar_modules.py
@@ -146,3 +146,92 @@ def test_deepar_modules(
 
     assert lightning_module.training_step(batch, batch_idx=0).shape == ()
     assert lightning_module.validation_step(batch, batch_idx=0).shape == ()
+
+
+@pytest.mark.parametrize(
+    "prediction_length, context_length, lags_seq",
+    [
+        (1, 5, [1, 10, 15]),
+        (1, 5, [3, 6, 9, 10]),
+        (2, 5, [1, 2, 7]),
+        (2, 5, [2, 3, 4, 6]),
+        (4, 5, [1, 5, 9, 11]),
+        (4, 5, [7, 8, 13, 14]),
+    ],
+)
+def test_rnn_input(
+    prediction_length: int, context_length: int, lags_seq: List[int]
+):
+    num_samples = 10
+    history_length = max(lags_seq) + context_length - 1
+
+    model = DeepARModel(
+        freq="D",
+        prediction_length=prediction_length,
+        context_length=context_length,
+        lags_seq=lags_seq,
+        scaling=False,
+        num_parallel_samples=num_samples,
+    )
+
+    batch = {
+        "feat_static_cat": torch.tensor([[0]], dtype=torch.int64),
+        "feat_static_real": torch.tensor([[0.0]], dtype=torch.float32),
+        "past_time_feat": torch.arange(
+            history_length, dtype=torch.float32
+        ).view(1, history_length, 1),
+        "past_target": torch.arange(history_length, dtype=torch.float32).view(
+            1, history_length
+        ),
+        "past_observed_values": torch.arange(
+            history_length, dtype=torch.float32
+        ).view(1, history_length),
+    }
+
+    # test with no future_target (only one step prediction)
+
+    batch["future_time_feat"] = torch.arange(
+        history_length,
+        history_length + 1,
+        dtype=torch.float32,
+    ).view(1, 1, 1)
+
+    rnn_input, scale, _ = model.prepare_rnn_input(**batch)
+
+    assert (scale == 1.0).all()
+
+    ref = torch.arange(
+        history_length - context_length + 1,
+        history_length + 1,
+        dtype=torch.float32,
+    )
+
+    for idx, lag in enumerate(lags_seq):
+        assert torch.isclose(ref - lag, rnn_input[0, :, idx]).all()
+
+    # test with all future data
+
+    batch["future_time_feat"] = torch.arange(
+        history_length,
+        history_length + prediction_length,
+        dtype=torch.float32,
+    ).view(1, prediction_length, 1)
+
+    batch["future_target"] = torch.arange(
+        history_length,
+        history_length + prediction_length,
+        dtype=torch.float32,
+    ).view(1, prediction_length)
+
+    rnn_input, scale, _ = model.prepare_rnn_input(**batch)
+
+    assert (scale == 1.0).all()
+
+    ref = torch.arange(
+        history_length - context_length + 1,
+        history_length + prediction_length,
+        dtype=torch.float32,
+    )
+
+    for idx, lag in enumerate(lags_seq):
+        assert torch.isclose(ref - lag, rnn_input[0, :, idx]).all()

--- a/test/torch/model/test_estimators.py
+++ b/test/torch/model/test_estimators.py
@@ -67,14 +67,14 @@ from gluonts.torch.distributions import ImplicitQuantileNetworkOutput
             num_batches_per_epoch=3,
             trainer_kwargs=dict(max_epochs=2),
         ),
-        lambda dataset: DeepNPTSEstimator(
-            freq=dataset.metadata.freq,
-            prediction_length=dataset.metadata.prediction_length,
-            context_length=2 * dataset.metadata.prediction_length,
-            batch_size=4,
-            num_batches_per_epoch=3,
-            epochs=2,
-        ),
+        # lambda dataset: DeepNPTSEstimator(
+        #     freq=dataset.metadata.freq,
+        #     prediction_length=dataset.metadata.prediction_length,
+        #     context_length=2 * dataset.metadata.prediction_length,
+        #     batch_size=4,
+        #     num_batches_per_epoch=3,
+        #     epochs=2,
+        # ),
     ],
 )
 def test_estimator_constant_dataset(estimator_constructor):

--- a/test/torch/model/test_estimators.py
+++ b/test/torch/model/test_estimators.py
@@ -67,14 +67,14 @@ from gluonts.torch.distributions import ImplicitQuantileNetworkOutput
             num_batches_per_epoch=3,
             trainer_kwargs=dict(max_epochs=2),
         ),
-        # lambda dataset: DeepNPTSEstimator(
-        #     freq=dataset.metadata.freq,
-        #     prediction_length=dataset.metadata.prediction_length,
-        #     context_length=2 * dataset.metadata.prediction_length,
-        #     batch_size=4,
-        #     num_batches_per_epoch=3,
-        #     epochs=2,
-        # ),
+        lambda dataset: DeepNPTSEstimator(
+            freq=dataset.metadata.freq,
+            prediction_length=dataset.metadata.prediction_length,
+            context_length=2 * dataset.metadata.prediction_length,
+            batch_size=4,
+            num_batches_per_epoch=3,
+            epochs=2,
+        ),
     ],
 )
 def test_estimator_constant_dataset(estimator_constructor):


### PR DESCRIPTION
*Issue #, if available:* Fixes #2616

*Description of changes:* The RNN in torch DeepAR was getting dynamic features shifted by one as input.
- Split `prepare_rnn_input` out of `unroll_lagged_rnn`
- Add test to verify alignment of RNN inputs (target values vs dynamic features, test is failing prior to fix)
- Change is breaking in that previously serialized models will not work as before (network changes)

Todo:
- [x] Take the opportunity to improve the code
- [x] Test effect of bug/fix (e.g. simple indicator that zeroes-out a series, model should not get it right prior to fix)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup