### PR TITLE
Fix: torch `PoissonOutput` scaling

### DIFF
--- a/src/gluonts/torch/distributions/distribution_output.py
+++ b/src/gluonts/torch/distributions/distribution_output.py
@@ -239,6 +239,22 @@ class PoissonOutput(DistributionOutput):
     def domain_map(cls, rate: torch.Tensor):
         rate_pos = F.softplus(rate).clone()
         return (rate_pos.squeeze(-1),)
+    
+    # Overwrites the parent class method. We cannot scale using the affine
+    # transformation since Poisson should return integers. Instead we scale
+    # the parameters.
+    def distribution(
+        self,
+        distr_args,
+        loc: Optional[torch.Tensor] = None,
+        scale: Optional[torch.Tensor] = None,
+    ) -> Distribution:
+        (rate,) = distr_args
+
+        if scale is not None:
+            rate *= scale
+
+        return Poisson(rate=rate)
 
     @property
     def event_shape(self) -> Tuple:

--- a/src/gluonts/torch/distributions/distribution_output.py
+++ b/src/gluonts/torch/distributions/distribution_output.py
@@ -239,7 +239,7 @@ class PoissonOutput(DistributionOutput):
     def domain_map(cls, rate: torch.Tensor):
         rate_pos = F.softplus(rate).clone()
         return (rate_pos.squeeze(-1),)
-    
+
     # Overwrites the parent class method. We cannot scale using the affine
     # transformation since Poisson should return integers. Instead we scale
     # the parameters.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

overwrite poison distribution when scale is not none.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup