### PR TITLE
Remove `dataclasses` requirement

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,5 +6,3 @@ toolz~=0.10
 
 # used for Protocol, can be removed once Python 3.8 is required
 typing-extensions~=4.0
-
-dataclasses


### PR DESCRIPTION
*Issue #, if available:* Fixes #2622

*Description of changes:* Since Python 3.7 is required, `dataclasses` is not needed (it’s standard library).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup