### PR TITLE
make Pytorch scaler's forward API consistent

### DIFF
--- a/src/gluonts/torch/model/deepar/module.py
+++ b/src/gluonts/torch/model/deepar/module.py
@@ -246,7 +246,7 @@ class DeepARModel(nn.Module):
         """
         context = past_target[..., -self.context_length :]
         observed_context = past_observed_values[..., -self.context_length :]
-        _, scale = self.scaler(context, observed_context)
+        _, _, scale = self.scaler(context, observed_context)
 
         prior_input = past_target[..., : -self.context_length] / scale
         input = (

--- a/src/gluonts/torch/modules/scaler.py
+++ b/src/gluonts/torch/modules/scaler.py
@@ -49,11 +49,11 @@ class MeanScaler(nn.Module):
         self.dim = dim
         self.keepdim = keepdim
         self.register_buffer("minimum_scale", torch.tensor(minimum_scale))
-        self.register_buffer("default_scale", torch.tensor(0.0))
+        self.register_buffer("default_scale", torch.tensor(default_scale))
 
     def forward(
         self, data: torch.Tensor, observed_indicator: torch.Tensor
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor,  torch.Tensor, torch.Tensor]:
         # shape: (N, [C], T=1)
         ts_sum = (data * observed_indicator).abs().sum(self.dim, keepdim=True)
         num_observed = observed_indicator.sum(self.dim, keepdim=True)
@@ -89,7 +89,9 @@ class MeanScaler(nn.Module):
         if not self.keepdim:
             scale = scale.squeeze(dim=self.dim)
 
-        return data / scale, scale
+        loc = torch.zeros_like(scale)
+
+        return data / scale, loc, scale
 
 
 class NOPScaler(nn.Module):
@@ -114,12 +116,13 @@ class NOPScaler(nn.Module):
 
     def forward(
         self, data: torch.Tensor, observed_indicator: torch.Tensor
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         scale = torch.ones_like(data).mean(
             dim=self.dim,
             keepdim=self.keepdim,
         )
-        return data, scale
+        loc = torch.zeros_like(scale)
+        return data, loc, scale
 
 
 class StdScaler(nn.Module):

--- a/src/gluonts/torch/modules/scaler.py
+++ b/src/gluonts/torch/modules/scaler.py
@@ -53,7 +53,7 @@ class MeanScaler(nn.Module):
 
     def forward(
         self, data: torch.Tensor, observed_indicator: torch.Tensor
-    ) -> tuple[torch.Tensor,  torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         # shape: (N, [C], T=1)
         ts_sum = (data * observed_indicator).abs().sum(self.dim, keepdim=True)
         num_observed = observed_indicator.sum(self.dim, keepdim=True)


### PR DESCRIPTION
*Description of changes:*

Made the API of the scalers consistent... this will allow us to use the different scalers interchangeably (which is not possible for the StdScaler)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup