### PR TITLE
Test: Remove -v option from pytest.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ line-length = 79
 minversion = "6.0"
 timeout = 60
 addopts = """
-    -v
     --doctest-modules
     --ignore src/gluonts/block.py
     --ignore src/gluonts/distribution.py


### PR DESCRIPTION
``-v`` makes the output more verbose. This isn't helpful, because if things are fine, we don't care about any output, and if things go wrong, we already have enough output describing the problem.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup