### PR TITLE
Simplify scalers, move to `gluonts.torch.scaler`

### DIFF
--- a/src/gluonts/torch/model/deepar/module.py
+++ b/src/gluonts/torch/model/deepar/module.py
@@ -138,7 +138,9 @@ class DeepARModel(nn.Module):
             embedding_dims=self.embedding_dimension,
         )
         if scaling:
-            self.scaler: Scaler = MeanScaler(default_scale=default_scale)
+            self.scaler: Scaler = MeanScaler(
+                dim=-1, keepdim=True, default_scale=default_scale
+            )
         else:
             self.scaler = NOPScaler(dim=-1, keepdim=True)
         self.rnn_input_size = len(self.lags_seq) + self._number_of_features

--- a/src/gluonts/torch/model/deepar/module.py
+++ b/src/gluonts/torch/model/deepar/module.py
@@ -22,7 +22,7 @@ from gluonts.torch.distributions import (
     DistributionOutput,
     StudentTOutput,
 )
-from gluonts.torch.scaler import MeanScaler, NOPScaler
+from gluonts.torch.scaler import Scaler, MeanScaler, NOPScaler
 from gluonts.torch.modules.feature import FeatureEmbedder
 from gluonts.torch.modules.loss import DistributionLoss, NegativeLogLikelihood
 from gluonts.torch.util import (
@@ -138,7 +138,7 @@ class DeepARModel(nn.Module):
             embedding_dims=self.embedding_dimension,
         )
         if scaling:
-            self.scaler = MeanScaler(default_scale=default_scale)
+            self.scaler: Scaler = MeanScaler(default_scale=default_scale)
         else:
             self.scaler = NOPScaler(dim=-1, keepdim=True)
         self.rnn_input_size = len(self.lags_seq) + self._number_of_features

--- a/src/gluonts/torch/model/deepar/module.py
+++ b/src/gluonts/torch/model/deepar/module.py
@@ -22,7 +22,7 @@ from gluonts.torch.distributions import (
     DistributionOutput,
     StudentTOutput,
 )
-from gluonts.torch.modules.scaler import MeanScaler, NOPScaler
+from gluonts.torch.scaler import MeanScaler, NOPScaler
 from gluonts.torch.modules.feature import FeatureEmbedder
 from gluonts.torch.modules.loss import DistributionLoss, NegativeLogLikelihood
 from gluonts.torch.util import (

--- a/src/gluonts/torch/model/tft/module.py
+++ b/src/gluonts/torch/model/tft/module.py
@@ -17,7 +17,7 @@ import torch
 import torch.nn as nn
 from gluonts.core.component import validated
 from gluonts.torch.modules.quantile_output import QuantileOutput
-from gluonts.torch.modules.scaler import StdScaler
+from gluonts.torch.scaler import StdScaler
 from gluonts.torch.util import weighted_average
 
 from .layers import (

--- a/src/gluonts/torch/scaler.py
+++ b/src/gluonts/torch/scaler.py
@@ -16,7 +16,7 @@ from typing import Optional
 
 import torch
 
-from gluonts.core.serde import dataclass
+from gluonts.core.component import validated
 
 
 class Scaler:
@@ -26,7 +26,6 @@ class Scaler:
         raise NotImplementedError
 
 
-@dataclass
 class MeanScaler(Scaler):
     """
     Computes a scaling factor as the weighted average absolute value along
@@ -45,10 +44,18 @@ class MeanScaler(Scaler):
         minimum possible scale that is used for any item.
     """
 
-    dim: int = -1
-    keepdim: bool = True
-    default_scale: Optional[float] = None
-    minimum_scale: float = 1e-10
+    @validated()
+    def __init__(
+        self,
+        dim: int = -1,
+        keepdim: bool = False,
+        default_scale: Optional[float] = None,
+        minimum_scale: float = 1e-10,
+    ) -> None:
+        self.dim = dim
+        self.keepdim = keepdim
+        self.default_scale = default_scale
+        self.minimum_scale = minimum_scale
 
     def __call__(
         self, data: torch.Tensor, observed_indicator: torch.Tensor
@@ -88,7 +95,6 @@ class MeanScaler(Scaler):
         return scaled_data, loc, scale
 
 
-@dataclass
 class NOPScaler(Scaler):
     """
     Assigns a scaling factor equal to 1 along dimension ``dim``, and therefore
@@ -103,8 +109,14 @@ class NOPScaler(Scaler):
         scale tensor, or suppress it.
     """
 
-    dim: int = -1
-    keepdim: bool = False
+    @validated()
+    def __init__(
+        self,
+        dim: int = -1,
+        keepdim: bool = False,
+    ) -> None:
+        self.dim = dim
+        self.keepdim = keepdim
 
     def __call__(
         self, data: torch.Tensor, observed_indicator: torch.Tensor
@@ -117,7 +129,6 @@ class NOPScaler(Scaler):
         return data, loc, scale
 
 
-@dataclass
 class StdScaler(Scaler):
     """
     Computes a std scaling  value along dimension ``dim``, and scales the data accordingly.
@@ -134,9 +145,16 @@ class StdScaler(Scaler):
         along dimension ``dim``.
     """
 
-    dim: int = -1
-    keepdim: bool = False
-    minimum_scale: float = 1e-5
+    @validated()
+    def __init__(
+        self,
+        dim: int = -1,
+        keepdim: bool = False,
+        minimum_scale: float = 1e-5,
+    ) -> None:
+        self.dim = dim
+        self.keepdim = keepdim
+        self.minimum_scale = minimum_scale
 
     def __call__(
         self, data: torch.Tensor, weights: torch.Tensor

--- a/src/gluonts/torch/scaler.py
+++ b/src/gluonts/torch/scaler.py
@@ -60,12 +60,12 @@ class MeanScaler(Scaler):
 
         # If `default_scale` is provided, we use it, otherwise we use the scale
         # of the batch.
-        if self.default_scale is not None:
+        if self.default_scale is None:
             batch_sum = ts_sum.sum(dim=0)
             batch_observations = torch.clamp(num_observed.sum(0), min=1)
             default_scale = torch.squeeze(batch_sum / batch_observations)
         else:
-            default_scale = torch.Tensor(self.default_scale)
+            default_scale = self.default_scale * torch.ones_like(scale)
 
         # apply default scale where there are no observations
         scale = torch.where(

--- a/src/gluonts/torch/scaler.py
+++ b/src/gluonts/torch/scaler.py
@@ -12,10 +12,11 @@
 # permissions and limitations under the License.
 
 from __future__ import annotations
-from dataclasses import dataclass
 from typing import Optional
 
 import torch
+
+from gluonts.core.serde import dataclass
 
 
 class Scaler:

--- a/src/gluonts/torch/scaler.py
+++ b/src/gluonts/torch/scaler.py
@@ -58,13 +58,9 @@ class MeanScaler(Scaler):
 
         scale = ts_sum / torch.clamp(num_observed, min=1)
 
+        # If `default_scale` is provided, we use it, otherwise we use the scale
+        # of the batch.
         if self.default_scale is not None:
-            # Set default_scale for time-series which are all zeros.
-            # If `default_scale` is provided, we use it, otherwise we use the scale
-            # of the batch.
-            # Note: We want to support tracing and to remove branching we we always
-            # calculate the batch_scale. Also, using `where` allows us to set
-            # values conditionally.
             batch_sum = ts_sum.sum(dim=0)
             batch_observations = torch.clamp(num_observed.sum(0), min=1)
             default_scale = torch.squeeze(batch_sum / batch_observations)

--- a/test/torch/test_scaler.py
+++ b/test/torch/test_scaler.py
@@ -15,7 +15,7 @@ import torch
 import numpy as np
 import pytest
 
-from gluonts.torch.modules import scaler
+from gluonts.torch import scaler
 
 test_cases = [
     (

--- a/test/torch/test_scaler.py
+++ b/test/torch/test_scaler.py
@@ -38,7 +38,7 @@ test_cases = [
                 [0.0] * 50,
             ]
         ),
-        torch.Tensor([1.0, 3.0, 1.5, 1e-10, 1.00396824]).unsqueeze(1),
+        torch.Tensor([1.0, 3.0, 1.5, 1e-10, 1.00396824]),
     ),
     (
         scaler.MeanScaler(default_scale=0.5),
@@ -60,10 +60,10 @@ test_cases = [
                 [0.0] * 50,
             ]
         ),
-        torch.Tensor([0.5, 3.0, 1.5, 1e-10, 0.5]).unsqueeze(1),
+        torch.Tensor([0.5, 3.0, 1.5, 1e-10, 0.5]),
     ),
     (
-        scaler.MeanScaler(keepdim=False),
+        scaler.MeanScaler(keepdim=True),
         torch.Tensor(
             [
                 [1.0] * 50,
@@ -82,7 +82,7 @@ test_cases = [
                 [0.0] * 50,
             ]
         ),
-        torch.Tensor([1.0, 3.0, 1.5, 1e-10, 1.00396824]),
+        torch.Tensor([1.0, 3.0, 1.5, 1e-10, 1.00396824]).unsqueeze(1),
     ),
     (
         scaler.MeanScaler(),
@@ -102,13 +102,13 @@ test_cases = [
                 [1.0] * 10 + [0.0] * 30 + [1.0] * 10,
             ]
         ),
-        torch.Tensor([135.0, 32.0, 73.00454712, 2.5e-2]).unsqueeze(1),
+        torch.Tensor([135.0, 32.0, 73.00454712, 2.5e-2]),
     ),
     (
         scaler.MeanScaler(),
         torch.randn(size=(5, 30)),
         torch.zeros(size=(5, 30)),
-        1e-10 * torch.ones(size=(5, 1)),
+        1e-10 * torch.ones(size=(5,)),
     ),
 ]
 
@@ -165,27 +165,3 @@ def test_nopscaler(target, observed):
     assert torch.allclose(torch.zeros(target.shape[:-1]), loc)
     assert torch.allclose(target, target_scaled)
     assert torch.allclose(torch.ones(target.shape[:-1]), scale)
-
-
-if __name__ == "__main__":
-    s = scaler.MeanScaler()
-    target = torch.Tensor(
-        [
-            [1.0] * 50,
-            [0.0] * 25 + [3.0] * 25,
-            [2.0] * 49 + [1.5] * 1,
-            [0.0] * 50,
-            [1.0] * 50,
-        ]
-    )
-    observed = torch.Tensor(
-        [
-            [1.0] * 50,
-            [0.0] * 25 + [1.0] * 25,
-            [0.0] * 49 + [1.0] * 1,
-            [1.0] * 50,
-            [0.0] * 50,
-        ]
-    )
-    expected = torch.Tensor([1.0, 3.0, 1.5, 1.00396824, 1.00396824])
-    s(target, observed)


### PR DESCRIPTION
*Description of changes:* There's no need for scalers to be `torch.nn.Module` since they don't really hold parameters. Also fixes the default `keepdim` of `MeanScaler` for consistency.

cc @kashif 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup