### PR TITLE
Pass prediction inputs as dict.

### DIFF
--- a/src/gluonts/model/forecast_generator.py
+++ b/src/gluonts/model/forecast_generator.py
@@ -199,7 +199,7 @@ class DistributionForecastGenerator(ForecastGenerator):
     ) -> Iterator[Forecast]:
         for batch in inference_data_loader:
             inputs = select(input_names, batch, ignore_missing=True)
-            outputs = predict_to_numpy(prediction_net, inputs)
+            outputs = prediction_net(*inputs.values())
 
             if output_transform:
                 log_once(OUTPUT_TRANSFORM_NOT_SUPPORTED_MSG)

--- a/src/gluonts/model/forecast_generator.py
+++ b/src/gluonts/model/forecast_generator.py
@@ -199,7 +199,7 @@ class DistributionForecastGenerator(ForecastGenerator):
     ) -> Iterator[Forecast]:
         for batch in inference_data_loader:
             inputs = select(input_names, batch)
-            outputs = prediction_net(inputs)
+            outputs = predict_to_numpy(prediction_net, inputs)
 
             if output_transform:
                 log_once(OUTPUT_TRANSFORM_NOT_SUPPORTED_MSG)

--- a/src/gluonts/model/forecast_generator.py
+++ b/src/gluonts/model/forecast_generator.py
@@ -20,6 +20,7 @@ import numpy as np
 from gluonts.core.component import validated
 from gluonts.dataset.common import DataEntry
 from gluonts.dataset.field_names import FieldName
+from gluonts.itertools import select
 from gluonts.dataset.loader import DataLoader
 from gluonts.model.forecast import Forecast, QuantileForecast, SampleForecast
 
@@ -48,7 +49,7 @@ def log_once(msg):
 # numpy conversion differently, use a dispatching function to prevent needing
 # a ForecastGenerators for each framework
 @singledispatch
-def predict_to_numpy(prediction_net, args) -> np.ndarray:
+def predict_to_numpy(prediction_net, kwargs) -> np.ndarray:
     raise NotImplementedError
 
 
@@ -114,8 +115,7 @@ class QuantileForecastGenerator(ForecastGenerator):
         **kwargs
     ) -> Iterator[Forecast]:
         for batch in inference_data_loader:
-            # TODO: Change inputs to dict to avoid assuming matching order in input_names / model signature?
-            inputs = [batch.get(k) for k in input_names]
+            inputs = select(input_names, batch)
             outputs = predict_to_numpy(prediction_net, inputs)
             if output_transform is not None:
                 outputs = output_transform(batch, outputs)
@@ -152,7 +152,7 @@ class SampleForecastGenerator(ForecastGenerator):
         **kwargs
     ) -> Iterator[Forecast]:
         for batch in inference_data_loader:
-            inputs = [batch[k] for k in input_names]
+            inputs = select(input_names, batch)
             outputs = predict_to_numpy(prediction_net, inputs)
             if output_transform is not None:
                 outputs = output_transform(batch, outputs)
@@ -198,8 +198,8 @@ class DistributionForecastGenerator(ForecastGenerator):
         **kwargs
     ) -> Iterator[Forecast]:
         for batch in inference_data_loader:
-            inputs = [batch[k] for k in input_names]
-            outputs = prediction_net(*inputs)
+            inputs = select(input_names, batch)
+            outputs = prediction_net(inputs)
 
             if output_transform:
                 log_once(OUTPUT_TRANSFORM_NOT_SUPPORTED_MSG)

--- a/src/gluonts/model/forecast_generator.py
+++ b/src/gluonts/model/forecast_generator.py
@@ -115,7 +115,7 @@ class QuantileForecastGenerator(ForecastGenerator):
         **kwargs
     ) -> Iterator[Forecast]:
         for batch in inference_data_loader:
-            inputs = select(input_names, batch)
+            inputs = select(input_names, batch, ignore_missing=True)
             outputs = predict_to_numpy(prediction_net, inputs)
             if output_transform is not None:
                 outputs = output_transform(batch, outputs)
@@ -152,7 +152,7 @@ class SampleForecastGenerator(ForecastGenerator):
         **kwargs
     ) -> Iterator[Forecast]:
         for batch in inference_data_loader:
-            inputs = select(input_names, batch)
+            inputs = select(input_names, batch, ignore_missing=True)
             outputs = predict_to_numpy(prediction_net, inputs)
             if output_transform is not None:
                 outputs = output_transform(batch, outputs)
@@ -198,7 +198,7 @@ class DistributionForecastGenerator(ForecastGenerator):
         **kwargs
     ) -> Iterator[Forecast]:
         for batch in inference_data_loader:
-            inputs = select(input_names, batch)
+            inputs = select(input_names, batch, ignore_missing=True)
             outputs = predict_to_numpy(prediction_net, inputs)
 
             if output_transform:

--- a/src/gluonts/mx/model/predictor.py
+++ b/src/gluonts/mx/model/predictor.py
@@ -44,8 +44,8 @@ from gluonts.transform import Transformation
 
 
 @predict_to_numpy.register(mx.gluon.Block)
-def _(prediction_net: mx.gluon.Block, args) -> np.ndarray:
-    return prediction_net(*args).asnumpy()
+def _(prediction_net: mx.gluon.Block, kwargs) -> np.ndarray:
+    return prediction_net(kwargs.values()).asnumpy()
 
 
 class GluonPredictor(Predictor):

--- a/src/gluonts/mx/model/predictor.py
+++ b/src/gluonts/mx/model/predictor.py
@@ -45,7 +45,7 @@ from gluonts.transform import Transformation
 
 @predict_to_numpy.register(mx.gluon.Block)
 def _(prediction_net: mx.gluon.Block, kwargs) -> np.ndarray:
-    return prediction_net(kwargs.values()).asnumpy()
+    return prediction_net(*kwargs.values()).asnumpy()
 
 
 class GluonPredictor(Predictor):

--- a/src/gluonts/torch/model/predictor.py
+++ b/src/gluonts/torch/model/predictor.py
@@ -34,8 +34,8 @@ from gluonts.transform import Transformation
 
 
 @predict_to_numpy.register(nn.Module)
-def _(prediction_net: nn.Module, args) -> np.ndarray:
-    return prediction_net(*args).cpu().numpy()
+def _(prediction_net: nn.Module, kwargs) -> np.ndarray:
+    return prediction_net(**args).cpu().numpy()
 
 
 class PyTorchPredictor(Predictor):

--- a/src/gluonts/torch/model/predictor.py
+++ b/src/gluonts/torch/model/predictor.py
@@ -35,7 +35,7 @@ from gluonts.transform import Transformation
 
 @predict_to_numpy.register(nn.Module)
 def _(prediction_net: nn.Module, kwargs) -> np.ndarray:
-    return prediction_net(**args).cpu().numpy()
+    return prediction_net(**kwargs).cpu().numpy()
 
 
 class PyTorchPredictor(Predictor):


### PR DESCRIPTION
Fixes: #2624

We have a central function that is used to create predictions called ``predict_to_numpy``.

Previously, the prediction inputs were passed as positional arguments. Now, we pass ``kwargs`` instead. Since `mxnet` expects positional arguments, we pass values via `args`, while `torch` can handle ``kwargs``.

There are some benefits to this: In `torch`, we can make use of optional arguments. ONNX models expects the inputs as `dict`, so we can now just pass these directly.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
