### PR TITLE
Faster index building in PandasDataset

### DIFF
--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -151,7 +151,9 @@ class PandasDataset:
             df = df.to_frame(name=self.target)
 
         if self.timestamp:
-            df.index = pd.PeriodIndex(df[self.timestamp], freq=self.freq)
+            df.index = pd.DatetimeIndex(
+                df[self.timestamp], freq=self.freq
+            ).to_period()
 
         if not isinstance(df.index, pd.PeriodIndex):
             df = df.to_period(freq=self.freq)

--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -151,9 +151,9 @@ class PandasDataset:
             df = df.to_frame(name=self.target)
 
         if self.timestamp:
-            df.index = pd.DatetimeIndex(
-                df[self.timestamp], freq=self.freq
-            ).to_period()
+            df.index = pd.DatetimeIndex(df[self.timestamp]).to_period(
+                freq=self.freq
+            )
 
         if not isinstance(df.index, pd.PeriodIndex):
             df = df.to_period(freq=self.freq)


### PR DESCRIPTION
*Faster index building for PandasDataset:*
Construct `pd.PeriodIndex` from list of time stamp strings can be quite slow:
```Python
periods = pd.period_range('2006-01-01 00:00:00', periods=7000, freq='H')
timestamps_list = [str(t.start_time) for t in period]

>>> timeit.timeit(lambda: pd.PeriodIndex(timestamps_list, freq='H'), number=5)
3.156371082000078
>>> timeit.timeit(lambda: pd.DatetimeIndex(timestamps_list).to_period(freq='H'), number=5)
0.02911860299991531
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup