### PR TITLE
Fix r-forecast doc strings

### DIFF
--- a/src/gluonts/ext/r_forecast/_hierarchical_predictor.py
+++ b/src/gluonts/ext/r_forecast/_hierarchical_predictor.py
@@ -46,9 +46,9 @@ class RHierarchicalForecastPredictor(RBasePredictor):
     Wrapper for calling the `R hts package
     <https://www.r-pkg.org/pkg/hts>`_.
 
-    In order to use it you need to install R and run
+    In order to use it you need to install R and rpy2. You also need the R `hts` package which
+    can be installed by running:
 
-        pip install rpy2
         R -e 'install.packages(c("hts"), repos="https://cloud.r-project.org")'
 
     Parameters

--- a/src/gluonts/ext/r_forecast/_predictor.py
+++ b/src/gluonts/ext/r_forecast/_predictor.py
@@ -44,21 +44,22 @@ else:
 
 USAGE_MESSAGE = """
 The RForecastPredictor is a thin wrapper for calling the R forecast package.
-In order to use it you need to install R and run
+In order to use it you need to install R and rpy2. You also need to install \
+specific R packages for univariate and/or hierarchical methods.
 
-pip install 'rpy2>=2.9.*,<3.*'
-
+For univariate methods, install:
 R -e 'install.packages(c("forecast", "nnfor"),\
 repos="https://cloud.r-project.org")'
+
+For hierarchical methods, install:
+R -e 'install.packages(c("hts"), repos="https://cloud.r-project.org")'
 """
 
 
 class RBasePredictor(RepresentablePredictor):
     """
     The `RBasePredictor` is a thin wrapper for calling R packages.
-    In order to use it you need to install R and run::
-
-        pip install 'rpy2>=2.9.*,<3.*'
+    In order to use it you need to install R and rpy2.
 
     Note that specific R packages need to be installed, depending
     on which wrapper one needs to run.

--- a/src/gluonts/ext/r_forecast/_univariate_predictor.py
+++ b/src/gluonts/ext/r_forecast/_univariate_predictor.py
@@ -39,9 +39,9 @@ class RForecastPredictor(RBasePredictor):
     Wrapper for calling the `R forecast package
     <http://pkg.robjhyndman.com/forecast/>`_.
 
-    In order to use it you need to install R and run::
+    In order to use it you need to install R and rpy2. You also need the R `forecast` package which
+    can be installed by running:
 
-        pip install 'rpy2>=2.9.*,<3.*'
         R -e 'install.packages(c("forecast", "nnfor"), repos="https://cloud.r-project.org")' # noqa
 
     Parameters


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Remove references to specific version of `rpy2` from doc strings.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup