### PR TITLE
Fix ```DateSplitter``` when split date is before start

### DIFF
--- a/src/gluonts/dataset/split.py
+++ b/src/gluonts/dataset/split.py
@@ -101,6 +101,8 @@ def periods_between(
         >>> periods_between(start, end)
         9
     """
+    if start > end:
+        return 0
     return ((end - start).n // start.freq.n) + 1
 
 

--- a/test/dataset/test_split.py
+++ b/test/dataset/test_split.py
@@ -95,6 +95,21 @@ def test_time_series_slice():
             pd.Period("2021-01-01 11", "2H"),
             6,
         ),
+        (
+            pd.Period("2021-03-04", freq="2D"),
+            pd.Period("2021-03-02", freq="2D"),
+            0,
+        ),
+        (
+            pd.Period("2021-03-04", freq="2D"),
+            pd.Period("2021-03-04", freq="2D"),
+            1,
+        ),
+        (
+            pd.Period("2021-03-03 23:00", freq="30T"),
+            pd.Period("2021-03-03 03:29", freq="30T"),
+            0,
+        ),
     ],
 )
 def test_periods_between(start, end, count):


### PR DESCRIPTION
*Description of changes:*
DateSplitter aims to split time series such that "Training entries obtained from this class will be limited to observations up to (including) the given ``date``." However, its current behaviour is similar to OffsetSplitter, when the split date is before the start date, i.e. ```start > end```, ```periods_between``` returns a negative value, and slicing the array via negative indexing. This is not the expected behaviour, and instead should return an empty array.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** bug fix