### PR TITLE
Add interface to `gluonts.ev`

### DIFF
--- a/src/gluonts/model/__init__.py
+++ b/src/gluonts/model/__init__.py
@@ -20,9 +20,12 @@ __all__ = [
     "QuantileForecast",
     "Input",
     "InputSpec",
+    "evaluate_forecasts",
+    "evaluate_model",
 ]
 
 from .estimator import Estimator, IncrementallyTrainable
 from .predictor import Predictor
 from .forecast import Forecast, SampleForecast, QuantileForecast
 from .inputs import Input, InputSpec
+from .evaluation import evaluate_forecasts, evaluate_model

--- a/src/gluonts/model/evaluation.py
+++ b/src/gluonts/model/evaluation.py
@@ -1,0 +1,246 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import logging
+from collections import ChainMap
+from typing import Iterable, Optional, Union
+from dataclasses import dataclass
+from toolz import first, valmap
+
+import numpy as np
+import pandas as pd
+from tqdm import tqdm
+
+from gluonts.dataset import DataEntry
+from gluonts.dataset.split import TestData
+from gluonts.time_feature.seasonality import get_seasonality
+from gluonts.model import Forecast, Predictor
+from gluonts.ev import seasonal_error
+from gluonts.itertools import prod
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BatchForecast:
+    """
+    Wrapper around ``Forecast`` objects, that adds a batch dimension
+    to arrays returned by ``__getitem__``, for compatibility with
+    ``gluonts.ev``.
+    """
+
+    forecast: Forecast
+    allow_nan: bool = False
+
+    def __getitem__(self, name):
+        value = self.forecast[name]
+        if np.isnan(value).any():
+            if not self.allow_nan:
+                raise ValueError("Forecast contains NaN values")
+
+            logger.warning(
+                "Forecast contains NaN values. Metrics may be incorrect."
+            )
+
+        return np.expand_dims(value.T, axis=0)
+
+
+def _get_data_batch(
+    input_: DataEntry,
+    label: DataEntry,
+    forecast: Forecast,
+    seasonality: Optional[int] = None,
+    mask_invalid_label: bool = True,
+    allow_nan_forecast: bool = False,
+) -> dict:
+    forecast_dict = BatchForecast(forecast, allow_nan=allow_nan_forecast)
+
+    freq = forecast.start_date.freqstr
+    if seasonality is None:
+        seasonality = get_seasonality(freq=freq)
+
+    label_target = label["target"]
+    if mask_invalid_label:
+        label_target = np.ma.masked_invalid(label_target)
+
+    other_data = {
+        "label": np.expand_dims(label_target, axis=0),
+        "seasonal_error": np.expand_dims(
+            seasonal_error(
+                input_["target"], seasonality=seasonality, time_axis=-1
+            ),
+            axis=0,
+        ),
+    }
+
+    return ChainMap(other_data, forecast_dict)
+
+
+def evaluate_forecasts_raw(
+    forecasts: Iterable[Forecast],
+    *,
+    test_data: TestData,
+    metrics,
+    axis: Optional[Union[int, tuple]] = None,
+    mask_invalid_label: bool = True,
+    allow_nan_forecast: bool = False,
+    seasonality: Optional[int] = None
+) -> dict:
+    """
+    Evaluate ``forecasts`` by comparing them with ``test_data``, according
+    to ``metrics``.
+
+    .. note:: This feature is experimental and may be subject to changes.
+
+    The optional ``axis`` arguments controls aggregation of the metrics:
+    - ``None`` (default) aggregates across all dimensions
+    - ``0`` aggregates across the dataset
+    - ``1`` aggregates across the first data dimension (time, in the univariate setting)
+    - ``2`` aggregates across the target dimension (time, in the multivariate setting)
+
+    Return results as a dictionary.
+    """
+    label_ndim = first(test_data.label)["target"].ndim
+
+    assert label_ndim in [1, 2]
+
+    if axis is None:
+        axis = tuple(range(label_ndim + 1))
+    if isinstance(axis, int):
+        axis = (axis,)
+
+    assert all(ax in range(3) for ax in axis)
+
+    evaluators = {}
+    for metric in metrics:
+        evaluator = metric(axis=axis)
+        evaluators[evaluator.name] = evaluator
+
+    index_data = []
+
+    for input_, label, forecast in tqdm(
+        zip(test_data.input, test_data.label, forecasts)
+    ):
+        if 0 not in axis:
+            index_data.append((forecast.item_id, forecast.start_date))
+
+        data_batch = _get_data_batch(
+            input_,
+            label,
+            forecast,
+            seasonality=seasonality,
+            mask_invalid_label=mask_invalid_label,
+            allow_nan_forecast=allow_nan_forecast,
+        )
+
+        for evaluator in evaluators.values():
+            evaluator.update(data_batch)
+
+    metrics_values = {
+        metric_name: evaluator.get()
+        for metric_name, evaluator in evaluators.items()
+    }
+
+    if index_data:
+        metrics_values["__index_0"] = index_data
+
+    return metrics_values
+
+
+def evaluate_forecasts(
+    forecasts: Iterable[Forecast],
+    *,
+    test_data: TestData,
+    metrics,
+    axis: Optional[Union[int, tuple]] = None,
+    mask_invalid_label: bool = True,
+    allow_nan_forecast: bool = False,
+    seasonality: Optional[int] = None
+) -> pd.DataFrame:
+    """
+    Evaluate ``forecasts`` by comparing them with ``test_data``, according
+    to ``metrics``.
+
+    .. note:: This feature is experimental and may be subject to changes.
+
+    The optional ``axis`` arguments controls aggregation of the metrics:
+    - ``None`` (default) aggregates across all dimensions
+    - ``0`` aggregates across the dataset
+    - ``1`` aggregates across the first data dimension (time, in the univariate setting)
+    - ``2`` aggregates across the target dimension (time, in the multivariate setting)
+
+    Return results as a Pandas ``DataFrame``.
+    """
+    metrics_values = evaluate_forecasts_raw(
+        forecasts=forecasts,
+        test_data=test_data,
+        metrics=metrics,
+        axis=axis,
+        mask_invalid_label=mask_invalid_label,
+        allow_nan_forecast=allow_nan_forecast,
+        seasonality=seasonality,
+    )
+    index0 = metrics_values.pop("__index_0", None)
+
+    metric_shape = metrics_values[first(metrics_values)].shape
+    if metric_shape == ():
+        index = [None]
+    else:
+        index_arrays = np.unravel_index(
+            range(prod(metric_shape)), metric_shape
+        )
+        if index0 is not None:
+            index0_repeated = np.take(index0, indices=index_arrays[0], axis=0)
+            index_arrays = (*zip(*index0_repeated), *index_arrays[1:])
+        index = pd.MultiIndex.from_arrays(index_arrays)
+
+    flattened_metrics = valmap(np.ravel, metrics_values)
+
+    return pd.DataFrame(flattened_metrics, index=index)
+
+
+def evaluate_model(
+    model: Predictor,
+    *,
+    test_data: TestData,
+    metrics,
+    axis: Optional[Union[int, tuple]] = None,
+    mask_invalid_label: bool = True,
+    allow_nan_forecast: bool = False,
+    seasonality: Optional[int] = None
+) -> pd.DataFrame:
+    """
+    Evaluate ``model`` when applied to ``test_data``, according
+    to ``metrics``.
+
+    .. note:: This feature is experimental and may be subject to changes.
+
+    The optional ``axis`` arguments controls aggregation of the metrics:
+    - ``None`` (default) aggregates across all dimensions
+    - ``0`` aggregates across the dataset
+    - ``1`` aggregates across the first data dimension (time, in the univariate setting)
+    - ``2`` aggregates across the target dimension (time, in the multivariate setting)
+
+    Return results as a Pandas ``DataFrame``.
+    """
+    forecasts = model.predict(test_data.input)
+
+    return evaluate_forecasts(
+        forecasts=forecasts,
+        test_data=test_data,
+        metrics=metrics,
+        axis=axis,
+        mask_invalid_label=mask_invalid_label,
+        allow_nan_forecast=allow_nan_forecast,
+        seasonality=seasonality,
+    )

--- a/src/gluonts/model/evaluation.py
+++ b/src/gluonts/model/evaluation.py
@@ -106,7 +106,7 @@ def evaluate_forecasts_raw(
     - ``None`` (default) aggregates across all dimensions
     - ``0`` aggregates across the dataset
     - ``1`` aggregates across the first data dimension (time, in the univariate setting)
-    - ``2`` aggregates across the target dimension (time, in the multivariate setting)
+    - ``2`` aggregates across the second data dimension (time, in the multivariate setting)
 
     Return results as a dictionary.
     """
@@ -177,7 +177,7 @@ def evaluate_forecasts(
     - ``None`` (default) aggregates across all dimensions
     - ``0`` aggregates across the dataset
     - ``1`` aggregates across the first data dimension (time, in the univariate setting)
-    - ``2`` aggregates across the target dimension (time, in the multivariate setting)
+    - ``2`` aggregates across the second data dimension (time, in the multivariate setting)
 
     Return results as a Pandas ``DataFrame``.
     """
@@ -229,7 +229,7 @@ def evaluate_model(
     - ``None`` (default) aggregates across all dimensions
     - ``0`` aggregates across the dataset
     - ``1`` aggregates across the first data dimension (time, in the univariate setting)
-    - ``2`` aggregates across the target dimension (time, in the multivariate setting)
+    - ``2`` aggregates across the second data dimension (time, in the multivariate setting)
 
     Return results as a Pandas ``DataFrame``.
     """

--- a/test/model/test_evaluation.py
+++ b/test/model/test_evaluation.py
@@ -1,0 +1,222 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from typing import Union, Tuple
+
+import numpy as np
+import pytest
+import pandas as pd
+
+from gluonts.dataset.split import split, TestData
+from gluonts.itertools import prod
+from gluonts.model.seasonal_naive import SeasonalNaivePredictor
+from gluonts.model import (
+    SampleForecast,
+    evaluate_forecasts,
+    evaluate_model,
+)
+from gluonts.ev import (
+    MSE,
+    RMSE,
+    NRMSE,
+    MAPE,
+    SMAPE,
+    MASE,
+    MSIS,
+    ND,
+    MeanWeightedSumQuantileLoss,
+)
+
+
+_test_univariate_dataset = [
+    {
+        "item_id": k,
+        "start": pd.Period("2022-06-12", freq="D"),
+        "target": np.ones((100)),
+    }
+    for k in range(5)
+]
+
+_test_multivariate_dataset = [
+    {
+        "item_id": k,
+        "start": pd.Period("2022-06-12", freq="D"),
+        "target": np.ones((7, 100)),
+    }
+    for k in range(5)
+]
+
+_test_metrics = [
+    MSE(),
+    RMSE(),
+    NRMSE(),
+    MAPE(),
+    SMAPE(),
+    MASE(),
+    MSIS(),
+    ND(),
+    MeanWeightedSumQuantileLoss(quantile_levels=[0.1, 0.5, 0.9]),
+]
+
+
+def infer_metrics_df_shape(
+    metrics,
+    test_data: TestData,
+    axis: Union[int, Tuple[int]],
+) -> Tuple[int]:
+    """
+    Infer expected shape of metrics data frame.
+    """
+    labels = list(test_data.label)
+    test_data_shape = (len(labels), *labels[0]["target"].shape)
+
+    if axis is None:
+        axis = tuple(range(len(test_data_shape)))
+    if isinstance(axis, int):
+        axis = (axis,)
+
+    return (
+        prod(
+            test_data_shape[d]
+            for d in range(len(test_data_shape))
+            if d not in axis
+        ),
+        len(metrics),
+    )
+
+
+@pytest.mark.parametrize(
+    "metrics, test_data, axis",
+    [
+        (
+            _test_metrics,
+            split(_test_univariate_dataset, offset=-12)[1].generate_instances(
+                prediction_length=3, windows=4
+            ),
+            None,
+        ),
+        (
+            _test_metrics,
+            split(_test_univariate_dataset, offset=-12)[1].generate_instances(
+                prediction_length=3, windows=4
+            ),
+            (0, 1),
+        ),
+        (
+            _test_metrics,
+            split(_test_univariate_dataset, offset=-12)[1].generate_instances(
+                prediction_length=3, windows=4
+            ),
+            0,
+        ),
+        (
+            _test_metrics,
+            split(_test_univariate_dataset, offset=-12)[1].generate_instances(
+                prediction_length=3, windows=4
+            ),
+            1,
+        ),
+        (
+            _test_metrics,
+            split(_test_multivariate_dataset, offset=-12)[
+                1
+            ].generate_instances(prediction_length=3, windows=4),
+            None,
+        ),
+        (
+            _test_metrics,
+            split(_test_multivariate_dataset, offset=-12)[
+                1
+            ].generate_instances(prediction_length=3, windows=4),
+            (0, 1, 2),
+        ),
+        (
+            _test_metrics,
+            split(_test_multivariate_dataset, offset=-12)[
+                1
+            ].generate_instances(prediction_length=3, windows=4),
+            (0, 2),
+        ),
+        (
+            _test_metrics,
+            split(_test_multivariate_dataset, offset=-12)[
+                1
+            ].generate_instances(prediction_length=3, windows=4),
+            (0, 1),
+        ),
+        (
+            _test_metrics,
+            split(_test_multivariate_dataset, offset=-12)[
+                1
+            ].generate_instances(prediction_length=3, windows=4),
+            (1, 2),
+        ),
+    ],
+)
+def test_evaluation_shape(
+    metrics,
+    test_data: TestData,
+    axis: Union[int, Tuple[int]],
+):
+    num_samples = 31
+
+    sample_forecasts = [
+        SampleForecast(
+            samples=np.zeros((num_samples, *label["target"].T.shape)),
+            start_date=label["start"],
+            item_id=label["item_id"],
+        )
+        for label in test_data.label
+    ]
+
+    metrics_df = evaluate_forecasts(
+        sample_forecasts,
+        test_data=test_data,
+        metrics=metrics,
+        axis=axis,
+    )
+
+    assert metrics_df.shape == infer_metrics_df_shape(metrics, test_data, axis)
+
+
+def test_evaluate_model_vs_forecasts():
+    dataset = [
+        {
+            "item_id": k,
+            "start": pd.Period("2022-06-12", freq="D"),
+            "target": np.random.normal(size=50),
+        }
+        for k in range(2)
+    ]
+
+    test_data = split(dataset, offset=-12)[1].generate_instances(
+        prediction_length=3, windows=4
+    )
+
+    model = SeasonalNaivePredictor(
+        freq="D", prediction_length=3, season_length=1
+    )
+
+    forecasts = list(model.predict(test_data.input))
+
+    for axis in [None, 0, 1, (0, 1)]:
+        df1 = evaluate_forecasts(
+            forecasts=forecasts,
+            test_data=test_data,
+            metrics=_test_metrics,
+            axis=axis,
+        )
+        df2 = evaluate_model(
+            model=model, test_data=test_data, metrics=_test_metrics, axis=axis
+        )
+        assert (df1 == df2).all().all()


### PR DESCRIPTION
*Description of changes:* This adds a higher-level interface to the metrics and evaluators API in `gluonts.ev`. See the example below for a feeling of how it works. In short, one calls

```python
evaluate_forecasts(forecasts, test_data=data, metrics=metrics)
```

to evaluate `metrics` to compare `forecasts` to `data`. Here `data` is a `TestData` object that contains both the "input" and "label" slices of each test series. This wraps the metric values into a `DataFrame` with appropriate index based on the aggregation dimension.

Example:

```python
from pathlib import Path
import pandas as pd
from gluonts.dataset.pandas import PandasDataset
from gluonts.dataset.split import split
from gluonts.model import Predictor, evaluate_forecasts
from gluonts.torch.model.deepar import DeepAREstimator
from gluonts.ev import (
    SMAPE,
    NRMSE,
    MeanWeightedSumQuantileLoss,
)
import torch

torch.manual_seed(0)

# Load data from a CSV file into a PandasDataset
df = pd.read_csv(
    "https://raw.githubusercontent.com/AileenNielsen/"
    "TimeSeriesAnalysisWithPython/master/data/AirPassengers.csv",
    index_col=0,
    parse_dates=True,
)
dataset = PandasDataset(df, target="#Passengers")

# Split train/test data
training_data, test_gen = split(dataset, offset=-36)
test_data = test_gen.generate_instances(prediction_length=12, windows=3)

# Train model, or load serialized model
model_path = Path("some_deepar_model")
model_path.mkdir(exist_ok=True, parents=True)
train = True
if not train:
    model = Predictor.deserialize(model_path)
else:
    model = DeepAREstimator(
        freq="M",
        prediction_length=12,
        trainer_kwargs=dict(max_epochs=20),
    ).train(training_data=training_data)
    model.serialize(model_path)

forecasts = list(model.predict(test_data.input))

metrics = [
    SMAPE(),
    NRMSE(),
    MeanWeightedSumQuantileLoss(quantile_levels=[0.1, 0.5, 0.9]),
]
```

Then,

```python
res = evaluate_forecasts(forecasts, test_data=test_data, metrics=metrics)
print(res)

# prints
#          sMAPE     NRMSE  mean_weighted_sum_quantile_loss
# None  0.055886  0.066318                         0.035829
```

```python
res = evaluate_forecasts(forecasts, test_data=test_data, metrics=metrics, axis=1)
print(res)

# prints
#                           sMAPE     NRMSE  mean_weighted_sum_quantile_loss
# 
# NaN     1958-01        0.099674  0.109566                         0.072287
#         1959-01        0.030778  0.035876                         0.018940
#         1960-01        0.037205  0.044245                         0.021850
```

```python
res = evaluate_forecasts(forecasts, test_data=test_data, metrics=metrics, axis=0)
print(res)

# prints
#                        sMAPE     NRMSE  mean_weighted_sum_quantile_loss
# 
# 0                   0.040189  0.044771                         0.021694
# 1                   0.083287  0.082183                         0.051847
# 2                   0.056241  0.067684                         0.039326
# 3                   0.046029  0.074129                         0.037520
# 4                   0.040745  0.059825                         0.030936
# [...]
# 11                  0.096292  0.110979                         0.067913
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup