### PR TITLE
Allow `axis` to be a tuple in `ev.aggregations`

### DIFF
--- a/src/gluonts/itertools.py
+++ b/src/gluonts/itertools.py
@@ -393,7 +393,7 @@ def power_set(iterable):
 
     >>> list(power_set(["a", "b"]))
     [(), ('a',), ('b',), ('a', 'b')]
-    
+
     Adapted from https://docs.python.org/3/library/itertools.html#itertools-recipes
     """
     return itertools.chain.from_iterable(

--- a/src/gluonts/itertools.py
+++ b/src/gluonts/itertools.py
@@ -393,7 +393,7 @@ def power_set(iterable):
 
     >>> list(power_set(["a", "b"]))
     [(), ('a',), ('b',), ('a', 'b')]
-
+    
     Adapted from https://docs.python.org/3/library/itertools.html#itertools-recipes
     """
     return itertools.chain.from_iterable(

--- a/test/ev/test_aggregations.py
+++ b/test/ev/test_aggregations.py
@@ -100,12 +100,8 @@ def test_Mean(value_stream, res_axis_none, res_axis_0, res_axis_1):
         np.testing.assert_almost_equal(mean.get(), expected_result)
 
 
-@pytest.mark.parametrize(
-    "shape", [(4, 9, 5, 2)]
-)
-@pytest.mark.parametrize(
-    "axis", [None] + list(power_set([0, 1, 2, 3]))
-)
+@pytest.mark.parametrize("shape", [(4, 9, 5, 2)])
+@pytest.mark.parametrize("axis", [None] + list(power_set([0, 1, 2, 3])))
 def test_high_dim(shape: tuple, axis):
     batch_count = 3
 

--- a/test/ev/test_aggregations.py
+++ b/test/ev/test_aggregations.py
@@ -16,6 +16,7 @@ import numpy as np
 import pytest
 
 from gluonts.ev import Mean, Sum
+from gluonts.itertools import power_set
 
 VALUE_STREAM = [
     [
@@ -99,26 +100,30 @@ def test_Mean(value_stream, res_axis_none, res_axis_0, res_axis_1):
         np.testing.assert_almost_equal(mean.get(), expected_result)
 
 
-def test_high_dim():
-    shape = (4, 9, 5, 2)
+@pytest.mark.parametrize(
+    "shape", [(4, 9, 5, 2)]
+)
+@pytest.mark.parametrize(
+    "axis", [None] + list(power_set([0, 1, 2, 3]))
+)
+def test_high_dim(shape: tuple, axis):
     batch_count = 3
 
     value_stream = [np.random.random(shape) for _ in range(batch_count)]
     all_values = np.concatenate(value_stream)
 
-    for axis in [None, 0, 1, 2, 3]:
-        sum = Sum(axis=axis)
-        for values in value_stream:
-            sum.step(values)
+    sum = Sum(axis=axis)
+    for values in value_stream:
+        sum.step(values)
 
-        actual_sum = sum.get()
-        expected_sum = all_values.sum(axis=axis)
-        np.testing.assert_almost_equal(actual_sum, expected_sum)
+    actual_sum = sum.get()
+    expected_sum = all_values.sum(axis=axis)
+    np.testing.assert_almost_equal(actual_sum, expected_sum)
 
-        mean = Mean(axis=axis)
-        for values in value_stream:
-            mean.step(values)
+    mean = Mean(axis=axis)
+    for values in value_stream:
+        mean.step(values)
 
-        actual_mean = mean.get()
-        expected_mean = all_values.mean(axis=axis)
-        np.testing.assert_almost_equal(actual_mean, expected_mean)
+    actual_mean = mean.get()
+    expected_mean = all_values.mean(axis=axis)
+    np.testing.assert_almost_equal(actual_mean, expected_mean)


### PR DESCRIPTION
*Description of changes:* This extends the behaviour of `gluonts.ev.aggregations.Aggregation` to the case where `axis` is a tuple, to reduce along multiple axes at once. A test is expanded by using the newly introduced `power_set` (see https://docs.python.org/3/library/itertools.html#itertools-recipes, I'm open to split this into a separate PR). This change can be useful for multivariate evaluation, where one may want to reduce across different combinations of batch/time/covariate dimensions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup