### PR TITLE
Add `itertools.power_set`

### DIFF
--- a/src/gluonts/itertools.py
+++ b/src/gluonts/itertools.py
@@ -385,3 +385,14 @@ def pluck_attr(seq, name, default=_no_default):
         return [getattr(el, name) for el in seq]
 
     return [getattr(el, name, default) for el in seq]
+
+
+def power_set(iterable):
+    """
+    Generate all possible subsets of the given iterable, as tuples.
+
+    Adapted from https://docs.python.org/3/library/itertools.html#itertools-recipes
+    """
+    return itertools.chain.from_iterable(
+        itertools.combinations(iterable, r) for r in range(len(iterable) + 1)
+    )

--- a/src/gluonts/itertools.py
+++ b/src/gluonts/itertools.py
@@ -391,6 +391,9 @@ def power_set(iterable):
     """
     Generate all possible subsets of the given iterable, as tuples.
 
+    >>> list(power_set(["a", "b"]))
+    [(), ('a',), ('b',), ('a', 'b')]
+    
     Adapted from https://docs.python.org/3/library/itertools.html#itertools-recipes
     """
     return itertools.chain.from_iterable(

--- a/src/gluonts/itertools.py
+++ b/src/gluonts/itertools.py
@@ -393,7 +393,7 @@ def power_set(iterable):
 
     >>> list(power_set(["a", "b"]))
     [(), ('a',), ('b',), ('a', 'b')]
-    
+
     Adapted from https://docs.python.org/3/library/itertools.html#itertools-recipes
     """
     return itertools.chain.from_iterable(

--- a/test/test_itertools.py
+++ b/test/test_itertools.py
@@ -33,6 +33,7 @@ from gluonts.itertools import (
     columns_to_rows,
     select,
     pluck_attr,
+    power_set,
     Map,
     StarMap,
     Filter,
@@ -195,3 +196,33 @@ def test_pluck_attr_curry():
         assert get("c")
 
     assert get("c", 4) == [4, 4]
+
+
+def test_power_set():
+    collection = list(range(4))
+    subsets = list(power_set(collection))
+
+    expected_subsets = [
+        (),
+        (0,),
+        (1,),
+        (2,),
+        (3,),
+        (0, 1),
+        (0, 2),
+        (0, 3),
+        (1, 2),
+        (1, 3),
+        (2, 3),
+        (0, 1, 2),
+        (0, 1, 3),
+        (0, 2, 3),
+        (1, 2, 3),
+        (0, 1, 2, 3),
+    ]
+
+    assert len(subsets) == 2 ** len(collection)
+    assert len(expected_subsets) == 2 ** len(collection)
+
+    for es in expected_subsets:
+        assert es in subsets


### PR DESCRIPTION
*Description of changes:* Adding `power_set` to generate all subsets of a collection. Adapted from the recipe in https://docs.python.org/3/library/itertools.html#itertools-recipes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup