### PR TITLE
Export torch models in `torch` module directly.

### DIFF
--- a/src/gluonts/torch/__init__.py
+++ b/src/gluonts/torch/__init__.py
@@ -11,12 +11,23 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# !!! DO NOT MODIFY !!! (pkgutil-style namespace package)
+__all__ = [
+    "PyTorchLightningEstimator",
+    "DeepNPTSEstimator",
+    "DeepAREstimator",
+    "MQF2MultiHorizonEstimator",
+    "SimpleFeedForwardEstimator",
+    "TemporalFusionTransformerEstimator",
+]
 
 
-from pkgutil import extend_path
+from .estimator import PyTorchLightningEstimator
 
-__path__ = extend_path(__path__, __name__)  # type: ignore
+from .model.deep_npts import DeepNPTSEstimator
+from .model.deepar import DeepAREstimator
+from .model.mqf2 import MQF2MultiHorizonEstimator
+from .model.simple_feedforward import SimpleFeedForwardEstimator
+from .model.tft import TemporalFusionTransformerEstimator
 
 
 from . import prelude as _  # noqa

--- a/src/gluonts/torch/__init__.py
+++ b/src/gluonts/torch/__init__.py
@@ -13,6 +13,7 @@
 
 __all__ = [
     "PyTorchLightningEstimator",
+    "PyTorchPredictor",
     "DeepNPTSEstimator",
     "DeepAREstimator",
     "MQF2MultiHorizonEstimator",
@@ -21,7 +22,8 @@ __all__ = [
 ]
 
 
-from .estimator import PyTorchLightningEstimator
+from .model.estimator import PyTorchLightningEstimator
+from .model.predictor import PyTorchPredictor
 
 from .model.deep_npts import DeepNPTSEstimator
 from .model.deepar import DeepAREstimator

--- a/src/gluonts/torch/model/__init__.py
+++ b/src/gluonts/torch/model/__init__.py
@@ -10,22 +10,3 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-
-
-__all__ = [
-    "PyTorchLightningEstimator",
-    "DeepNPTSEstimator",
-    "DeepAREstimator",
-    "MQF2MultiHorizonEstimator",
-    "SimpleFeedForwardEstimator",
-    "TemporalFusionTransformerEstimator",
-]
-
-
-from .estimator import PyTorchLightningEstimator
-
-from .model.deep_npts import DeepNPTSEstimator
-from .model.deepar import DeepAREstimator
-from .model.mqf2 import MQF2MultiHorizonEstimator
-from .model.simple_feedforward import SimpleFeedForwardEstimator
-from .model.tft import TemporalFusionTransformerEstimator

--- a/src/gluonts/torch/model/__init__.py
+++ b/src/gluonts/torch/model/__init__.py
@@ -11,8 +11,21 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# !!! DO NOT MODIFY !!! (pkgutil-style namespace package)
 
-from pkgutil import extend_path
+__all__ = [
+    "PyTorchLightningEstimator",
+    "DeepNPTSEstimator",
+    "DeepAREstimator",
+    "MQF2MultiHorizonEstimator",
+    "SimpleFeedForwardEstimator",
+    "TemporalFusionTransformerEstimator",
+]
 
-__path__ = extend_path(__path__, __name__)  # type: ignore
+
+from .estimator import PyTorchLightningEstimator
+
+from .model.deep_npts import DeepNPTSEstimator
+from .model.deepar import DeepAREstimator
+from .model.mqf2 import MQF2MultiHorizonEstimator
+from .model.simple_feedforward import SimpleFeedForwardEstimator
+from .model.tft import TemporalFusionTransformerEstimator


### PR DESCRIPTION
Allow to imports model more easily, e.g.:

```py
from gluonts.torch import DeepAREstimator

# vs

from gluonts.torch.model.deepar import DeepAREstimator

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup