### PR TITLE
Remove FallbackPredictor.

### DIFF
--- a/src/gluonts/model/predictor.py
+++ b/src/gluonts/model/predictor.py
@@ -11,7 +11,6 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-import functools
 import itertools
 import json
 import logging
@@ -21,7 +20,7 @@ import traceback
 from pathlib import Path
 from pydoc import locate
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Callable, Iterator, Optional, Type
+from typing import TYPE_CHECKING, Callable, Iterator, Optional
 
 import numpy as np
 
@@ -30,7 +29,6 @@ from gluonts.core import fqname_for
 from gluonts.core.component import equals, from_hyperparameters, validated
 from gluonts.core.serde import dump_json, load_json
 from gluonts.dataset.common import DataEntry, Dataset
-from gluonts.exceptions import GluonTSException
 from gluonts.model.forecast import Forecast
 
 if TYPE_CHECKING:  # avoid circular import

--- a/src/gluonts/model/trivial/constant.py
+++ b/src/gluonts/model/trivial/constant.py
@@ -18,7 +18,7 @@ from gluonts.dataset.common import DataEntry
 from gluonts.dataset.field_names import FieldName
 from gluonts.dataset.util import forecast_start
 from gluonts.model.forecast import SampleForecast
-from gluonts.model.predictor import FallbackPredictor, RepresentablePredictor
+from gluonts.model.predictor import RepresentablePredictor
 
 
 class ConstantPredictor(RepresentablePredictor):
@@ -45,7 +45,7 @@ class ConstantPredictor(RepresentablePredictor):
         )
 
 
-class ConstantValuePredictor(RepresentablePredictor, FallbackPredictor):
+class ConstantValuePredictor(RepresentablePredictor):
     """
     A `Predictor` that always produces the same value as forecast.
 

--- a/src/gluonts/model/trivial/mean.py
+++ b/src/gluonts/model/trivial/mean.py
@@ -22,11 +22,11 @@ from gluonts.dataset.field_names import FieldName
 from gluonts.dataset.util import forecast_start
 from gluonts.model.estimator import Estimator
 from gluonts.model.forecast import SampleForecast
-from gluonts.model.predictor import FallbackPredictor, RepresentablePredictor
+from gluonts.model.predictor import RepresentablePredictor
 from gluonts.model.trivial.constant import ConstantPredictor
 
 
-class MeanPredictor(RepresentablePredictor, FallbackPredictor):
+class MeanPredictor(RepresentablePredictor):
     """
     A :class:`Predictor` that predicts the samples based on the mean of the
     last `context_length` elements of the input target.


### PR DESCRIPTION
At some point we had the idea that a predictor can act as a fallback, if a given predictor is unable to perform predictions.

However, this can easily achieved in a few lines of code and doesn't require a dedicated super class.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup