### PR TITLE
Fix zebras period time features.

### DIFF
--- a/src/gluonts/zebras/_period.py
+++ b/src/gluonts/zebras/_period.py
@@ -74,19 +74,27 @@ class _BasePeriod:
 
     @property
     def day(self) -> np.ndarray:
-        return (self.data - self.data.astype("M8[M]")).astype(int) + 1
+        return (self.data.astype("M8[D]") - self.data.astype("M8[M]")).astype(
+            int
+        ) + 1
 
     @property
     def hour(self) -> np.ndarray:
-        return (self.data - self.data.astype("M8[D]")).astype(int)
+        return (self.data.astype("M8[h]") - self.data.astype("M8[D]")).astype(
+            int
+        )
 
     @property
     def minute(self) -> np.ndarray:
-        return (self.data - self.data.astype("M8[h]")).astype(int)
+        return (self.data.astype("M8[m]") - self.data.astype("M8[h]")).astype(
+            int
+        )
 
     @property
     def second(self) -> np.ndarray:
-        return (self.data - self.data.astype("M8[m]")).astype(int)
+        return (self.data.astype("M8[s]") - self.data.astype("M8[m]")).astype(
+            int
+        )
 
     @property
     def dayofweek(self) -> np.ndarray:

--- a/test/zebras/test_period.py
+++ b/test/zebras/test_period.py
@@ -94,3 +94,24 @@ def test_periods_serde(freq):
 
     assert ps[0] == serde.decode(serde.encode(ps[0]))
     assert ps == serde.decode(serde.encode(ps))
+
+
+@pytest.mark.parametrize("freq", FREQS)
+def test_periods_feature(freq):
+    if freq != "S" and freq.endswith("S"):
+        pytest.skip()
+
+    pr = pd.period_range(start="2020", freq=freq, periods=20)
+    ps = zb.periods("2020", freq, 20)
+
+    np.testing.assert_array_equal(pr.start_time.year, ps.year)
+    np.testing.assert_array_equal(pr.start_time.month, ps.month)
+    np.testing.assert_array_equal(pr.start_time.day, ps.day)
+
+    np.testing.assert_array_equal(pr.start_time.hour, ps.hour)
+    np.testing.assert_array_equal(pr.start_time.minute, ps.minute)
+    np.testing.assert_array_equal(pr.start_time.second, ps.second)
+
+    np.testing.assert_array_equal(pr.start_time.dayofweek, ps.dayofweek)
+    np.testing.assert_array_equal(pr.start_time.dayofyear, ps.dayofyear)
+    np.testing.assert_array_equal(pr.start_time.week, ps.week)


### PR DESCRIPTION
Features like `index.hour` did not work in all cases, this fixes it.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup