### PR TITLE
Fix _version location for sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,7 +9,6 @@ graft docs
 graft requirements
 graft test
 
-includes *.md
 include NOTICE
 
 prune .devtools
@@ -21,3 +20,6 @@ prune evaluations
 exclude .dockerignore
 exclude .gitignore
 exclude dev_setup.sh
+
+global-exclude */__pycache__/*
+global-exclude *.pyc

--- a/src/gluonts/meta/_version.py
+++ b/src/gluonts/meta/_version.py
@@ -243,7 +243,8 @@ def cmdclass():
             super().make_release_tree(base_dir, files)
 
             write_version(
-                Path(base_dir) / package_root.relative_to(dist_root())
+                Path(base_dir)
+                / Path(__file__).parent.resolve().relative_to(dist_root())
             )
 
     return {"sdist": sdist, "build_py": build_py}


### PR DESCRIPTION
Previously the version was written to `src/gluonts/` instead of `src/gluonts/meta` where it belongs.

This PR also ensures there are no `__pycache__` or `.pyc` files in the distribution.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup