### PR TITLE
Zebras: Add batching.

### DIFF
--- a/src/zebras/__init__.py
+++ b/src/zebras/__init__.py
@@ -18,22 +18,40 @@ __all__ = [
     "Periods",
     "period",
     "periods",
+    "BatchTimeFrame",
     "TimeFrame",
     "time_frame",
+    "BatchSplitFrame",
     "SplitFrame",
     "split_frame",
     "time_series",
+    "BatchTimeSeries",
     "TimeSeries",
 ]
 
+from typing import TypeVar
+
 from ._freq import Freq, freq
 from ._period import period, Period, periods, Periods
-from ._split_frame import split_frame, SplitFrame
-from ._timeframe import time_frame, TimeFrame
-from ._time_series import time_series, TimeSeries
+from ._split_frame import split_frame, SplitFrame, BatchSplitFrame
+from ._timeframe import time_frame, TimeFrame, BatchTimeFrame
+from ._time_series import time_series, TimeSeries, BatchTimeSeries
+
+
+Batchable = TypeVar("Batchable", TimeSeries, TimeFrame, SplitFrame)
 
 
 def batch(xs: list):
-    assert xs
+    assert xs, "Passed data cannot be empty."
+    types = set(map(type, xs))
+    assert (
+        len(types) == 1
+    ), "All values need to be of same type, got: " + ", ".join(
+        f"'{ty.__name__}'" for ty in types
+    )
+    ty = types.pop()
+    assert ty in set(
+        Batchable.__constraints__
+    ), f"Unsupported type: '{ty.__name__}'"
 
-    return xs[0]._batch(xs)
+    return ty._batch(xs)

--- a/src/zebras/__init__.py
+++ b/src/zebras/__init__.py
@@ -31,3 +31,9 @@ from ._period import period, Period, periods, Periods
 from ._split_frame import split_frame, SplitFrame
 from ._timeframe import time_frame, TimeFrame
 from ._time_series import time_series, TimeSeries
+
+
+def batch(xs: list):
+    assert xs
+
+    return xs[0]._batch(xs)

--- a/src/zebras/_split_frame.py
+++ b/src/zebras/_split_frame.py
@@ -191,9 +191,10 @@ class SplitFrame:
     def with_index(self, index):
         return _replace(self, index=index)
 
-    def _batch(self, xs):
-        ref = xs[0]
-        pluck = pluck_attr(xs)
+    @staticmethod
+    def _batch(split_frames: List[SplitFrame]) -> BatchSplitFrame:
+        ref = split_frames[0]
+        pluck = pluck_attr(split_frames)
 
         return BatchSplitFrame(
             _past=rows_to_columns(pluck("_past"), np.stack),
@@ -223,6 +224,9 @@ class BatchSplitFrame:
     @property
     def batch_size(self):
         return len(self.index)
+
+    def __len__(self):
+        return self.past_length + self.future_length
 
     @property
     def past(self):
@@ -378,6 +382,6 @@ def split_frame(
     return sf
 
 
-# We defer importing `TimeSeries` to avoid circular imports.
+# We defer these imports to avoid circular imports.
 from ._time_series import TimeSeries  # noqa
 from ._timeframe import BatchTimeFrame, TimeFrame  # noqa

--- a/src/zebras/_time_series.py
+++ b/src/zebras/_time_series.py
@@ -89,7 +89,7 @@ class TimeSeries(TimeBase):
         )
 
     @classmethod
-    def batch(cls, xs: List[TimeSeries], into=None):
+    def _batch(cls, xs: List[TimeSeries]):
         for series in xs:
             assert type(series) == TimeSeries
 
@@ -104,8 +104,6 @@ class TimeSeries(TimeBase):
             tdim += 1
 
         values = np.stack(pluck("values"))
-        if into is not None:
-            values = into(values)
 
         return BatchTimeSeries(
             values=values,

--- a/src/zebras/_time_series.py
+++ b/src/zebras/_time_series.py
@@ -88,8 +88,8 @@ class TimeSeries(TimeBase):
             _pad=self._pad.extend(left, right),
         )
 
-    @classmethod
-    def _batch(cls, xs: List[TimeSeries]):
+    @staticmethod
+    def _batch(xs: List[TimeSeries]) -> BatchTimeSeries:
         for series in xs:
             assert type(series) == TimeSeries
 

--- a/src/zebras/_time_series.py
+++ b/src/zebras/_time_series.py
@@ -159,7 +159,6 @@ class BatchTimeSeries(TimeBase):
     def __array__(self):
         return self.values
 
-    @property
     def items(self):
         return TimeSeriesItems(self)
 

--- a/src/zebras/_timeframe.py
+++ b/src/zebras/_timeframe.py
@@ -372,6 +372,9 @@ class BatchTimeFrame:
     def batch_size(self):
         return len(self.index)
 
+    def __len__(self):
+        return self.length
+
     def like(self, columns=None, static=None, tdims=None):
         columns = maybe.unwrap_or(columns, {})
         static = maybe.unwrap_or(static, {})

--- a/src/zebras/_timeframe.py
+++ b/src/zebras/_timeframe.py
@@ -309,7 +309,7 @@ class TimeFrame(TimeBase):
             name, data = item
 
             tdim = self.tdims[name]
-            past, future = np.split(data, [index], axis=tdim)
+            past, future = np.split(data, [index], tdim)
             past = AxisView(past, tdim)[-past_length:]
             future = AxisView(future, tdim)[:future_length]
             return name, (past, future)
@@ -337,7 +337,8 @@ class TimeFrame(TimeBase):
     def __len__(self) -> int:
         return self.length
 
-    def _batch(self, xs):
+    @staticmethod
+    def _batch(xs: List[TimeFrame]) -> BatchTimeFrame:
         # TODO: Check
         ref = xs[0]
         pluck = pluck_attr(xs)
@@ -516,6 +517,6 @@ def time_frame(
     return tf
 
 
-# We defer importing `TimeSeries` to avoid circular imports.
+# We defer these imports to avoid circular imports.
 from ._time_series import BatchTimeSeries, TimeSeries  # noqa
 from ._split_frame import SplitFrame  # noqa

--- a/test/zebras/test_batch.py
+++ b/test/zebras/test_batch.py
@@ -59,3 +59,22 @@ def test_batch_time_frame():
     assert batched.batch_size == 2
 
     tf0x, tf1x = batched.items()
+
+
+def test_batch_split_frame():
+    sf0 = zb.time_frame(
+        {"x": [1, 2, 3]},
+        start="2020",
+        freq="D",
+        metadata={"item_id": 0},
+    ).split(1, past_length=4, future_length=3)
+    sf1 = zb.time_frame({"x": [4, 5, 6]}).split(
+        1, past_length=4, future_length=3
+    )
+
+    batched = zb.batch([sf0, sf1])
+
+    assert len(batched) == 7
+    assert batched.batch_size == 2
+
+    sf0x, sf1x = batched.items()

--- a/test/zebras/test_batch.py
+++ b/test/zebras/test_batch.py
@@ -1,0 +1,61 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import pytest
+
+import numpy as np
+
+import zebras as zb
+
+
+def test_batch_time_series():
+    ts0 = zb.time_series(
+        [1, 2, 3], start="2020", freq="D", metadata={"item_id": 0}, name="x"
+    )
+    ts1 = zb.time_series([4, 5, 6])
+
+    batched = zb.batch([ts0, ts1])
+
+    assert len(batched) == 3
+    assert batched.batch_size == 2
+
+    ts0x, ts1x = batched.items()
+
+    np.testing.assert_array_equal(ts0, ts0x)
+    assert ts0.metadata == ts0x.metadata
+    assert ts0.tdim == ts0x.tdim
+    assert ts0.name == ts0x.name
+    assert ts0._pad == ts0x._pad
+
+    np.testing.assert_array_equal(ts1, ts1x)
+    assert ts1.metadata == ts1x.metadata
+    assert ts1.tdim == ts1x.tdim
+    assert ts1.name == ts1x.name
+    assert ts1._pad == ts1x._pad
+
+
+def test_batch_time_frame():
+    tf0 = zb.time_frame(
+        {"x": [1, 2, 3]},
+        start="2020",
+        freq="D",
+        metadata={"item_id": 0},
+    )
+    tf1 = zb.time_frame({"x": [4, 5, 6]})
+
+    batched = zb.batch([tf0, tf1])
+
+    assert len(batched) == 3
+    assert batched.batch_size == 2
+
+    tf0x, tf1x = batched.items()


### PR DESCRIPTION
Allows batching of `TimeSeries`, `TimeFrame` and `SplitFrame`.

The batched versions stack the underlying data into a single `array`, while other information (such as metadata) is merged into lists.

```py
ts0 = zb.time_series([1, 2, 3])
ts1 = zb.time_series([4, 5, 6])

b = zb.batch([ts0, ts1])
assert b.batch_size == 2

np.testing.assert_array_equal(
    b.values,
    [[1, 2, 3], [4, 5, 6]],
)
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup