### PR TITLE
Add loaders for missing Monash datasets

### DIFF
--- a/src/gluonts/dataset/repository/_tsf_datasets.py
+++ b/src/gluonts/dataset/repository/_tsf_datasets.py
@@ -142,6 +142,46 @@ datasets = {
         file_name="weather_dataset.zip",
         record="4654822",
     ),
+    "australian_electricity_demand": Dataset(
+        file_name="australian_electricity_demand_dataset.zip",
+        record="4659727",
+    ),
+    "electricity_hourly": Dataset(
+        file_name="electricity_hourly_dataset.zip",
+        record="4656140",
+    ),
+    "electricity_weekly": Dataset(
+        file_name="electricity_weekly_dataset.zip",
+        record="4656141",
+    ),
+    "rideshare_without_missing": Dataset(
+        file_name="rideshare_dataset_without_missing_values.zip",
+        record="5122232",
+    ),
+    "saugeenday": Dataset(
+        file_name="saugeenday_dataset.zip",
+        record="4656058",
+    ),
+    "solar_10_minutes": Dataset(
+        file_name="solar_10_minutes_dataset.zip",
+        record="4656144",
+    ),
+    "solar_weekly": Dataset(
+        file_name="solar_weekly_dataset.zip",
+        record="4656151",
+    ),
+    "sunspot_without_missing": Dataset(
+        file_name="sunspot_dataset_without_missing_values.zip",
+        record="4654722",
+    ),
+    "temperature_rain_without_missing": Dataset(
+        file_name="temperature_rain_dataset_without_missing_values.zip",
+        record="5129091",
+    ),
+    "vehicle_trips_without_missing": Dataset(
+        file_name="vehicle_trips_dataset_without_missing_values.zip",
+        record="5122537",
+    ),
 }
 
 

--- a/src/gluonts/dataset/repository/datasets.py
+++ b/src/gluonts/dataset/repository/datasets.py
@@ -201,6 +201,46 @@ dataset_recipes = {
         generate_uber_dataset, uber_freq="Hourly", prediction_length=24
     ),
     "airpassengers": partial(generate_airpassengers_dataset),
+    "australian_electricity_demand": partial(
+        generate_forecasting_dataset,
+        dataset_name="australian_electricity_demand",
+    ),
+    "electricity_hourly": partial(
+        generate_forecasting_dataset,
+        dataset_name="electricity_hourly",
+    ),
+    "electricity_weekly": partial(
+        generate_forecasting_dataset,
+        dataset_name="electricity_weekly",
+    ),
+    "rideshare_without_missing": partial(
+        generate_forecasting_dataset,
+        dataset_name="rideshare_without_missing",
+    ),
+    "saugeenday": partial(
+        generate_forecasting_dataset,
+        dataset_name="saugeenday",
+    ),
+    "solar_10_minutes": partial(
+        generate_forecasting_dataset,
+        dataset_name="solar_10_minutes",
+    ),
+    "solar_weekly": partial(
+        generate_forecasting_dataset,
+        dataset_name="solar_weekly",
+    ),
+    "sunspot_without_missing": partial(
+        generate_forecasting_dataset,
+        dataset_name="sunspot_without_missing",
+    ),
+    "temperature_rain_without_missing": partial(
+        generate_forecasting_dataset,
+        dataset_name="temperature_rain_without_missing",
+    ),
+    "vehicle_trips_without_missing": partial(
+        generate_forecasting_dataset,
+        dataset_name="vehicle_trips_without_missing",
+    ),
 }
 
 


### PR DESCRIPTION
*Description of changes:*
- Enable loading some of the [Monash Forecasting Repository](https://forecastingdata.org/) datasets using `get_dataset`. This includes the following datasets:
   - `australian_electricity_demand`
   - `electricity_hourly`
   - `electricity_weekly`
   - `rideshare_without_missing`
   - `saugeenday`
   - `solar_10_minutes`
   - `solar_weekly`
   - `sunspot_without_missing`
   - `temperature_rain_without_missing`
   - `vehicle_trips_without_missing`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup