### PR TITLE
Fix dataset file discovery.

### DIFF
--- a/src/gluonts/dataset/common.py
+++ b/src/gluonts/dataset/common.py
@@ -129,16 +129,18 @@ def infer_file_type(path):
     return None
 
 
-def _glob(path: Path, pattern="*", levels=1):
+def _glob(path: Path, pattern="*", levels=None):
+    if levels == 0:
+        return
+
+    yield from path.glob(pattern)
+
     if levels is not None:
         levels -= 1
 
-    for subpath in path.glob(pattern):
+    for subpath in path.iterdir():
         if subpath.is_dir():
-            if levels != 0:
-                yield from _glob(subpath, pattern, levels)
-        else:
-            yield subpath
+            yield from _glob(subpath, pattern, levels)
 
 
 def FileDataset(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR allows for the discovery of datasets that have a nested directory structure. Before this PR, dataset files would not be identified, and it would basically return an empty dataset.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup