### PR TITLE
Fix: Loading of nested paths in FileDataset.

### DIFF
--- a/src/gluonts/dataset/common.py
+++ b/src/gluonts/dataset/common.py
@@ -129,18 +129,21 @@ def infer_file_type(path):
     return None
 
 
-def _glob(path: Path, pattern="*", levels=None):
-    if levels == 0:
-        return
+def _rglob(path: Path, pattern="*", levels=1):
+    """Like ``path.rglob(pattern)`` except this limits the number of sub
+    directories that are traversed. ``levels = 0`` is thus the same as
+    ``path.glob(pattern)``.
 
-    yield from path.glob(pattern)
-
+    """
     if levels is not None:
         levels -= 1
 
     for subpath in path.iterdir():
         if subpath.is_dir():
-            yield from _glob(subpath, pattern, levels)
+            if levels is None or levels >= 0:
+                yield from _rglob(subpath, pattern, levels)
+        else:
+            yield subpath
 
 
 def FileDataset(
@@ -150,9 +153,8 @@ def FileDataset(
     cache: bool = False,
     use_timestamp: bool = False,
     loader_class=None,
-    ignore=False,
     pattern="*",
-    levels=1,
+    levels=2,
     translate=None,
 ) -> Dataset:
     path = Path(path)
@@ -161,42 +163,39 @@ def FileDataset(
         raise FileNotFoundError(path)
 
     if path.is_dir():
-        subpaths = _glob(path, pattern, levels)
-
-        datasets = [
-            FileDataset(
-                subpath,
-                freq,
-                one_dim_target,
-                cache,
-                use_timestamp,
-                loader_class=loader_class,
-                ignore=True,
-            )
-            for subpath in subpaths
-        ]
-
-        return DatasetCollection(
-            [dataset for dataset in datasets if dataset is not None]
-        )
-
-    assert path.is_file()
-
-    if loader_class is None:
-        loader = infer_file_type(path)
-        if loader is None:
-            message = f"Cannot infer loader for {path}."
-            if ignore:
-                logging.warning(message)
-                return None  # type: ignore
-
-            raise ValueError(message)
+        paths = _rglob(path, pattern, levels)
     else:
-        loader = loader_class(path)
+        assert path.is_file()
+        paths = [path]
 
-    return _FileDataset(
-        loader, freq, one_dim_target, cache, use_timestamp, translate
+    loaders = []
+    for subpath in paths:
+        if loader_class is None:
+            loader = infer_file_type(subpath)
+            if loader is None:
+                logging.warn(f"Cannot infer loader for {subpath}.")
+                continue
+        else:
+            loader = loader_class(subpath)
+
+        loaders.append(loader)
+
+    assert (
+        loaders
+    ), f"Cannot find any loadable data in '{path}' using pattern {pattern!r}"
+
+    file_dataset = functools.partial(
+        _FileDataset,
+        freq=freq,
+        one_dim_target=one_dim_target,
+        cache=cache,
+        use_timestamp=use_timestamp,
+        translate=translate,
     )
+    if len(loaders) == 1:
+        return file_dataset(loaders[0])
+    else:
+        return DatasetCollection(list(map(file_dataset, loaders)))
 
 
 def _FileDataset(


### PR DESCRIPTION
Before this change `levels` didn't do anything, since we iterated subfolders in `FileDataset` as well. Now, `_rglob` does path discovery and `FileDataset` applies the right loader.

This also removes the `ignore` flag from `FileDataset`, which wasn't really used before.


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup