### PR TITLE
Avoid zero scale in StudentTOutput

### DIFF
--- a/src/gluonts/torch/distributions/studentT.py
+++ b/src/gluonts/torch/distributions/studentT.py
@@ -68,7 +68,7 @@ class StudentTOutput(DistributionOutput):
     def domain_map(
         cls, df: torch.Tensor, loc: torch.Tensor, scale: torch.Tensor
     ):
-        epsilon = np.finfo(cls._dtype).eps  # machine epsilon
+        epsilon = torch.finfo(scale.dtype).eps
         scale = F.softplus(scale).clamp_min(epsilon)
         df = 2.0 + F.softplus(df)
         return df.squeeze(-1), loc.squeeze(-1), scale.squeeze(-1)

--- a/src/gluonts/torch/distributions/studentT.py
+++ b/src/gluonts/torch/distributions/studentT.py
@@ -13,6 +13,7 @@
 
 from typing import Dict, Tuple, Union
 
+import numpy as np
 import torch
 import torch.nn.functional as F
 from scipy.stats import t as ScipyStudentT
@@ -67,7 +68,8 @@ class StudentTOutput(DistributionOutput):
     def domain_map(
         cls, df: torch.Tensor, loc: torch.Tensor, scale: torch.Tensor
     ):
-        scale = F.softplus(scale)
+        epsilon = np.finfo(cls._dtype).eps  # machine epsilon
+        scale = F.softplus(scale).clamp_min(epsilon)
         df = 2.0 + F.softplus(df)
         return df.squeeze(-1), loc.squeeze(-1), scale.squeeze(-1)
 

--- a/src/gluonts/torch/distributions/studentT.py
+++ b/src/gluonts/torch/distributions/studentT.py
@@ -13,7 +13,6 @@
 
 from typing import Dict, Tuple, Union
 
-import numpy as np
 import torch
 import torch.nn.functional as F
 from scipy.stats import t as ScipyStudentT


### PR DESCRIPTION
*Issue #, if available:* #2790

*Description of changes:*
- Avoid zero scale in `StudentTOutput `. Similar to the fix in #1893.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup