### PR TITLE
Reduce depth of `get_dataset` import

### DIFF
--- a/src/gluonts/dataset/repository/__init__.py
+++ b/src/gluonts/dataset/repository/__init__.py
@@ -11,6 +11,10 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from gluonts.dataset.repository.datasets import get_dataset, get_download_path
+from gluonts.dataset.repository.datasets import (
+    get_dataset,
+    get_download_path,
+    dataset_names,
+)
 
-__all__ = ["get_dataset", "get_download_path"]
+__all__ = ["get_dataset", "get_download_path", "dataset_names"]

--- a/src/gluonts/dataset/repository/__init__.py
+++ b/src/gluonts/dataset/repository/__init__.py
@@ -12,3 +12,5 @@
 # permissions and limitations under the License.
 
 from gluonts.dataset.repository.datasets import get_dataset, get_download_path
+
+__all__ = ["get_dataset", "get_download_path"]

--- a/src/gluonts/dataset/repository/__init__.py
+++ b/src/gluonts/dataset/repository/__init__.py
@@ -10,3 +10,5 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
+
+from gluonts.dataset.repository.datasets import get_dataset, get_download_path


### PR DESCRIPTION
*Description of changes:*
This PR reduces the depth of `get_dataset` utility import.
```python
from gluonts.dataset.repository.datasets import get_dataset # Previously
from gluonts.dataset.repository import get_dataset # Now
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup