### PR TITLE
Remove `.to_timestamp()` to fix interval plotting

### DIFF
--- a/src/gluonts/model/forecast.py
+++ b/src/gluonts/model/forecast.py
@@ -338,12 +338,12 @@ class Forecast:
         i_p50 = len(percentiles_sorted) // 2
 
         p50_data = ps_data[i_p50]
-        p50_series = pd.Series(data=p50_data, index=self.index.to_timestamp())
+        p50_series = pd.Series(data=p50_data, index=self.index)
         p50_series.plot(color=color, ls="-", label=f"{label_prefix}median")
 
         if show_mean:
             mean_data = np.mean(self._sorted_samples, axis=0)
-            pd.Series(data=mean_data, index=self.index.to_timestamp()).plot(
+            pd.Series(data=mean_data, index=self.index).plot(
                 color=color,
                 ls=":",
                 label=f"{label_prefix}mean",
@@ -355,7 +355,7 @@ class Forecast:
             ptile = percentiles_sorted[i]
             alpha = alpha_for_percentile(ptile)
             plt.fill_between(
-                self.index.to_timestamp(),
+                self.index,
                 ps_data[i],
                 ps_data[-i - 1],
                 facecolor=color,
@@ -366,9 +366,7 @@ class Forecast:
             )
             # Hack to create labels for the error intervals. Doesn't actually
             # plot anything, because we only pass a single data point
-            pd.Series(
-                data=p50_data[:1], index=self.index.to_timestamp()[:1]
-            ).plot(
+            pd.Series(data=p50_data[:1], index=self.index[:1]).plot(
                 color=color,
                 alpha=alpha,
                 linewidth=10,
@@ -718,7 +716,7 @@ class QuantileForecast(Forecast):
             keys = self.forecast_keys
 
         for k, v in zip(keys, self.forecast_array):
-            pd.Series(data=v, index=self.index.to_timestamp()).plot(
+            pd.Series(data=v, index=self.index).plot(
                 label=f"{label_prefix}q{k}",
                 *args,
                 **kwargs,


### PR DESCRIPTION
*Issue #, if available:* #2795

*Description of changes:*
Plotting intervals sometimes do not work due to how pandas plotting interacts with `plt.fill_between`. Using a period index appears to solve the issue, in my experience. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup