### PR TITLE
Update `setuptools` and `wheel` in test workflow

### DIFF
--- a/.github/workflows/tests-xgboost.yaml
+++ b/.github/workflows/tests-xgboost.yaml
@@ -21,7 +21,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install other dependencies
       run: |
-        python -m pip install -U pip
+        python -m pip install -U pip setuptools wheel
         pip install .
         pip install -r requirements/requirements-test.txt
         pip install -r requirements/requirements-rotbaum.txt


### PR DESCRIPTION
*Issue #, if available:* Some test workflow was failing when installing dependencies. See eg https://github.com/awslabs/gluonts/actions/runs/4718825468/jobs/8369409495

*Description of changes:* Update `setuptools` and `wheel` as part of the workflow


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup