### PR TITLE
Update wiki2k tarball path

### DIFF
--- a/src/gluonts/dataset/repository/_gp_copula_2019.py
+++ b/src/gluonts/dataset/repository/_gp_copula_2019.py
@@ -99,7 +99,7 @@ datasets_info = {
     "wiki2000_nips": GPCopulaDataset(
         name="wiki2000_nips",
         # Direct link required for Github Large File Storage (LFS) file.
-        url="https://github.com/awslabs/gluonts/raw/82d3038c9dd694584e8ec855a6b6ae2461dc92ef/datasets/wiki2000_nips.tar.gz",
+        url="https://github.com/awslabs/gluonts/raw/b89f203595183340651411a41eeb0ee60570a4d9/datasets/wiki2000_nips.tar.gz",
         num_series=2000,
         prediction_length=30,
         freq="D",


### PR DESCRIPTION
Had to change the tarball because previously it was [created on MacOS which added copyfiles](https://stackoverflow.com/questions/8766730/tar-command-in-mac-os-x-adding-hidden-files-why) which breaks data loading on other OSs. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup