### PR TITLE
Add test workflow for R based models

### DIFF
--- a/.github/workflows/tests-r.yml
+++ b/.github/workflows/tests-r.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: R Tests
 
 on: [push, pull_request]
 

--- a/.github/workflows/tests-r.yml
+++ b/.github/workflows/tests-r.yml
@@ -31,7 +31,7 @@ jobs:
         pip install -r requirements/requirements-extras-r.txt
     - name: Install R dependencies
       run: |
-        sudo apt-get install libcurl-dev
+        sudo apt-get install libcurl4-openssl-dev
         Rscript -e 'install.packages(c("forecast", "nnfor"), repos="https://cloud.r-project.org")'
     - name: Test with pytest
       run: |

--- a/.github/workflows/tests-r.yml
+++ b/.github/workflows/tests-r.yml
@@ -30,7 +30,9 @@ jobs:
         pip install -r requirements/requirements-test.txt
         pip install -r requirements/requirements-extras-r.txt
     - name: Install R dependencies
-      run: Rscript -e 'install.packages(c("forecast", "nnfor"), repos="https://cloud.r-project.org")'
+      run: |
+        sudo apt-get install libcurl-dev
+        Rscript -e 'install.packages(c("forecast", "nnfor"), repos="https://cloud.r-project.org")'
     - name: Test with pytest
       run: |
         pytest --ignore test/ext/r_forecast/test_r_hierarchical_predictor.py test/ext/r_forecast

--- a/.github/workflows/tests-r.yml
+++ b/.github/workflows/tests-r.yml
@@ -21,7 +21,6 @@ jobs:
         r-version: '3.5.3'
     - name: Install R dependencies
       run: |
-        sudo wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
         sudo add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
         sudo apt-get install -y \
           libcairo-dev \

--- a/.github/workflows/tests-r.yml
+++ b/.github/workflows/tests-r.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up R
       uses: r-lib/actions/setup-r@v2
       with:
-        r-version: '3.5.3'
+        r-version: '4.2.3'
     - name: Install R dependencies
       run: |
         wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | sudo tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc

--- a/.github/workflows/tests-r.yml
+++ b/.github/workflows/tests-r.yml
@@ -13,6 +13,8 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
 
+    if: contains(github.event.pull_request.labels.*.name, 'pr:test-r')
+
     steps:
     - uses: actions/checkout@v3
     - name: Set up R

--- a/.github/workflows/tests-r.yml
+++ b/.github/workflows/tests-r.yml
@@ -28,9 +28,7 @@ jobs:
           libedit-dev \
           libnlopt-dev \
           libxml2-dev \
-          libcurl4-openssl-dev \
-          r-base \
-          r-base-dev
+          libcurl4-openssl-dev
         Rscript -e 'install.packages(c("forecast", "nnfor"), repos="https://cloud.r-project.org")'
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/.github/workflows/tests-r.yml
+++ b/.github/workflows/tests-r.yml
@@ -21,7 +21,7 @@ jobs:
         r-version: '3.5.3'
     - name: Install R dependencies
       run: |
-        wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
+        sudo wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
         sudo add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
         sudo apt-get install -y \
           libcairo-dev \

--- a/.github/workflows/tests-r.yml
+++ b/.github/workflows/tests-r.yml
@@ -30,7 +30,7 @@ jobs:
         pip install -r requirements/requirements-test.txt
         pip install -r requirements/requirements-extras-r.txt
     - name: Install R dependencies
-      run: Rscript -e 'install.packages(c("forecast", "nnfor", "hts"), repos="https://cloud.r-project.org")'
+      run: Rscript -e 'install.packages(c("forecast", "nnfor"), repos="https://cloud.r-project.org")'
     - name: Test with pytest
       run: |
-        pytest test/ext/r_forecast
+        pytest --exclude test/ext/r_forecast/test_r_hierarchical_predictor.py test/ext/r_forecast

--- a/.github/workflows/tests-r.yml
+++ b/.github/workflows/tests-r.yml
@@ -15,24 +15,33 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
     - name: Set up R
       uses: r-lib/actions/setup-r@v2
       with:
         r-version: '3.5.3'
+    - name: Install R dependencies
+      run: |
+        wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
+        sudo add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
+        sudo apt-get install -y \
+          libcairo-dev \
+          libedit-dev \
+          libnlopt-dev \
+          libxml2-dev \
+          libcurl4-openssl-dev \
+          r-base \
+          r-base-dev
+        Rscript -e 'install.packages(c("forecast", "nnfor"), repos="https://cloud.r-project.org")'
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
     - name: Install Python dependencies
       run: |
         python -m pip install -U pip
         pip install .
         pip install -r requirements/requirements-test.txt
         pip install -r requirements/requirements-extras-r.txt
-    - name: Install R dependencies
-      run: |
-        sudo apt-get install libcurl4-openssl-dev
-        Rscript -e 'install.packages(c("forecast", "nnfor"), repos="https://cloud.r-project.org")'
     - name: Test with pytest
       run: |
         pytest --ignore test/ext/r_forecast/test_r_hierarchical_predictor.py test/ext/r_forecast

--- a/.github/workflows/tests-r.yml
+++ b/.github/workflows/tests-r.yml
@@ -33,4 +33,4 @@ jobs:
       run: Rscript -e 'install.packages(c("forecast", "nnfor"), repos="https://cloud.r-project.org")'
     - name: Test with pytest
       run: |
-        pytest --exclude test/ext/r_forecast/test_r_hierarchical_predictor.py test/ext/r_forecast
+        pytest --ignore test/ext/r_forecast/test_r_hierarchical_predictor.py test/ext/r_forecast

--- a/.github/workflows/tests-r.yml
+++ b/.github/workflows/tests-r.yml
@@ -21,8 +21,7 @@ jobs:
         r-version: '3.5.3'
     - name: Install R dependencies
       run: |
-        wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc
-        sudo apt-key add marutter_pubkey.asc
+        wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | sudo tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
         sudo add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
         sudo apt-get install -y \
           libcairo-dev \

--- a/.github/workflows/tests-r.yml
+++ b/.github/workflows/tests-r.yml
@@ -21,6 +21,8 @@ jobs:
         r-version: '3.5.3'
     - name: Install R dependencies
       run: |
+        wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc
+        sudo apt-key add marutter_pubkey.asc
         sudo add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
         sudo apt-get install -y \
           libcairo-dev \

--- a/.github/workflows/tests-r.yml
+++ b/.github/workflows/tests-r.yml
@@ -1,0 +1,36 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    strategy:
+      max-parallel: 4
+      fail-fast: false
+      matrix:
+        python-version: ['3.9']
+        platform: [ubuntu-latest]
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Set up R
+      uses: r-lib/actions/setup-r@v2
+      with:
+        r-version: '3.5.3'
+    - name: Install Python dependencies
+      run: |
+        python -m pip install -U pip
+        pip install .
+        pip install -r requirements/requirements-test.txt
+        pip install -r requirements/requirements-extras-r.txt
+    - name: Install R dependencies
+      run: Rscript -e 'install.packages(c("forecast", "nnfor", "hts"), repos="https://cloud.r-project.org")'
+    - name: Test with pytest
+      run: |
+        pytest test/ext/r_forecast


### PR DESCRIPTION
*Issue #, if available:* The tests for R model wrappers do not run on GitHub

*Description of changes:* Add test workflow for wrapped R models. There appears to be an issue with installing the `hts` package in R, so the workflow currently excludes the tests for hierarchical models.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup