### PR TITLE
Add `SizedIterableSlice`, an `IterableSlice` that supports `len()`

### DIFF
--- a/src/gluonts/itertools.py
+++ b/src/gluonts/itertools.py
@@ -240,6 +240,11 @@ class IterableSlice:
     def __iter__(self):
         yield from itertools.islice(self.iterable, self.length)
 
+    def __len__(self):
+        # NOTE: This works correctly only when self.iterable supports `len()`.
+        total_len = len(self.iterable)
+        return min(total_len, self.length)
+
 
 @dataclass
 class Map:

--- a/src/gluonts/itertools.py
+++ b/src/gluonts/itertools.py
@@ -240,6 +240,16 @@ class IterableSlice:
     def __iter__(self):
         yield from itertools.islice(self.iterable, self.length)
 
+
+class SizedIterableSlice(IterableSlice):
+    """
+    Same as ``IterableSlice`` but also supports `len()`:
+
+        >>> isl = SizedIterableSlice([1, 2, 3, 4, 5], 3)
+        >>> len(isl)
+        3
+    """
+
     def __len__(self):
         # NOTE: This works correctly only when self.iterable supports `len()`.
         total_len = len(self.iterable)

--- a/test/test_itertools.py
+++ b/test/test_itertools.py
@@ -128,6 +128,25 @@ def test_rows_to_columns(given, expected, wrapper):
     assert columns_to_rows(output) == given
 
 
+def test_iterable_slice():
+    def generator():
+        for i in range(10):
+            yield i
+
+    unsized_iter = generator()
+    sized_iter = list(range(10))
+
+    unsized_iter_slice = IterableSlice(unsized_iter, 5)
+    with pytest.raises(TypeError):
+        len(unsized_iter_slice)
+
+    sized_iter_slice = IterableSlice(sized_iter, 5)
+    assert len(sized_iter_slice) == 5
+
+    sized_iter_slice = IterableSlice(sized_iter, 15)
+    assert len(sized_iter_slice) == 10
+
+
 def test_select():
     d = {"a": 1, "b": 2, "c": 3}
 

--- a/test/test_itertools.py
+++ b/test/test_itertools.py
@@ -29,6 +29,7 @@ from gluonts.itertools import (
     PickleCached,
     Cyclic,
     IterableSlice,
+    SizedIterableSlice,
     PseudoShuffled,
     rows_to_columns,
     columns_to_rows,
@@ -128,7 +129,7 @@ def test_rows_to_columns(given, expected, wrapper):
     assert columns_to_rows(output) == given
 
 
-def test_iterable_slice():
+def test_sized_iterable_slice():
     def generator():
         for i in range(10):
             yield i
@@ -136,14 +137,14 @@ def test_iterable_slice():
     unsized_iter = generator()
     sized_iter = list(range(10))
 
-    unsized_iter_slice = IterableSlice(unsized_iter, 5)
+    unsized_iter_slice = SizedIterableSlice(unsized_iter, 5)
     with pytest.raises(TypeError):
         len(unsized_iter_slice)
 
-    sized_iter_slice = IterableSlice(sized_iter, 5)
+    sized_iter_slice = SizedIterableSlice(sized_iter, 5)
     assert len(sized_iter_slice) == 5
 
-    sized_iter_slice = IterableSlice(sized_iter, 15)
+    sized_iter_slice = SizedIterableSlice(sized_iter, 15)
     assert len(sized_iter_slice) == 10
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add `SizedIterableSlice`, an `IterableSlice` that supports `len()`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup