### PR TITLE
Fix pd.Period serialization

### DIFF
--- a/src/gluonts/core/serde/pd.py
+++ b/src/gluonts/core/serde/pd.py
@@ -40,7 +40,7 @@ def encode_pd_period(v: pd.Period) -> Any:
     """
     return {
         "__kind__": Kind.Instance,
-        "class": "pandas.Timestamp",
+        "class": "pandas.Period",
         "args": encode([str(v)]),
         "kwargs": {"freq": v.freqstr},
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix serialization of `pd.Period`. Previously it was being serialized to `pd.Timestamp` which broke serde for `SampleForecast` objects.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup