### PR TITLE
Remove second call to create_lightning_module on torch estimator

### DIFF
--- a/src/gluonts/torch/model/estimator.py
+++ b/src/gluonts/torch/model/estimator.py
@@ -187,8 +187,6 @@ class PyTorchLightningEstimator(Estimator):
                     training_network,
                 )
 
-        training_network = self.create_lightning_module()
-
         if from_predictor is not None:
             training_network.load_state_dict(
                 from_predictor.network.state_dict()


### PR DESCRIPTION
Issue #2833

Description of changes:

Remove redundant call to `create_lightning_module` on `train_model` inside `torch/model/estimator.py`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Please tag this pr with at least one of these labels to make our release process faster: BREAKING, new feature, bug fix, other change, dev setup
