### PR TITLE
Fix torch DeepAREstimator in case `context_length=1`

### DIFF
--- a/src/gluonts/torch/model/deepar/module.py
+++ b/src/gluonts/torch/model/deepar/module.py
@@ -236,7 +236,7 @@ class DeepARModel(nn.Module):
 
         time_feat = torch.cat(
             (
-                take_last(past_time_feat, dim=-2, qty=self.context_length - 1),
+                take_last(past_time_feat, dim=-2, num=self.context_length - 1),
                 future_time_feat,
             ),
             dim=-2,
@@ -536,14 +536,14 @@ class DeepARModel(nn.Module):
         else:
             distr = self.output_distribution(params, scale)
             context_target = take_last(
-                past_target, dim=-1, qty=self.context_length - 1
+                past_target, dim=-1, num=self.context_length - 1
             )
             target = torch.cat(
                 (context_target, future_target_reshaped),
                 dim=1,
             )
             context_observed = take_last(
-                past_observed_values, dim=-1, qty=self.context_length - 1
+                past_observed_values, dim=-1, num=self.context_length - 1
             )
             observed_values = torch.cat(
                 (context_observed, future_observed_reshaped), dim=1

--- a/src/gluonts/torch/model/deepar/module.py
+++ b/src/gluonts/torch/model/deepar/module.py
@@ -28,6 +28,7 @@ from gluonts.torch.modules.loss import DistributionLoss, NegativeLogLikelihood
 from gluonts.torch.util import (
     lagged_sequence_values,
     repeat_along_dim,
+    take_last,
     unsqueeze_expand,
 )
 from gluonts.itertools import prod
@@ -235,7 +236,7 @@ class DeepARModel(nn.Module):
 
         time_feat = torch.cat(
             (
-                past_time_feat[..., -self.context_length + 1 :, :],
+                take_last(past_time_feat, dim=-2, qty=self.context_length - 1),
                 future_time_feat,
             ),
             dim=-2,
@@ -534,14 +535,16 @@ class DeepARModel(nn.Module):
             )
         else:
             distr = self.output_distribution(params, scale)
-            context_target = past_target[:, -self.context_length + 1 :]
+            context_target = take_last(
+                past_target, dim=-1, qty=self.context_length - 1
+            )
             target = torch.cat(
                 (context_target, future_target_reshaped),
                 dim=1,
             )
-            context_observed = past_observed_values[
-                :, -self.context_length + 1 :
-            ]
+            context_observed = take_last(
+                past_observed_values, dim=-1, qty=self.context_length - 1
+            )
             observed_values = torch.cat(
                 (context_observed, future_observed_reshaped), dim=1
             )

--- a/src/gluonts/torch/util.py
+++ b/src/gluonts/torch/util.py
@@ -188,6 +188,29 @@ def slice_along_dim(a: torch.Tensor, dim: int, slice_: slice) -> torch.Tensor:
     return a[idx]
 
 
+def take_last(a: torch.Tensor, dim: int, qty: int) -> torch.Tensor:
+    """
+    Take last elements from a given tensor along a given dimension.
+
+    Parameters
+    ----------
+    a
+        Original tensor to slice.
+    dim
+        Dimension to slice over.
+    qty
+        Quantity of trailing elements to retain (non-negative).
+
+    Returns
+    -------
+    torch.Tensor
+        A tensor with the same size as the input one, except dimension
+        ``dim`` which has length equal to ``qty``.
+    """
+    assert qty >= 0
+    return slice_along_dim(a, dim, slice(a.shape[dim] - qty, None))
+
+
 def unsqueeze_expand(a: torch.Tensor, dim: int, size: int) -> torch.Tensor:
     """
     Unsqueeze a dimension and expand over it in one go.

--- a/src/gluonts/torch/util.py
+++ b/src/gluonts/torch/util.py
@@ -188,7 +188,7 @@ def slice_along_dim(a: torch.Tensor, dim: int, slice_: slice) -> torch.Tensor:
     return a[idx]
 
 
-def take_last(a: torch.Tensor, dim: int, qty: int) -> torch.Tensor:
+def take_last(a: torch.Tensor, dim: int, num: int) -> torch.Tensor:
     """
     Take last elements from a given tensor along a given dimension.
 
@@ -198,17 +198,17 @@ def take_last(a: torch.Tensor, dim: int, qty: int) -> torch.Tensor:
         Original tensor to slice.
     dim
         Dimension to slice over.
-    qty
-        Quantity of trailing elements to retain (non-negative).
+    num
+        Number of trailing elements to retain (non-negative).
 
     Returns
     -------
     torch.Tensor
         A tensor with the same size as the input one, except dimension
-        ``dim`` which has length equal to ``qty``.
+        ``dim`` which has length equal to ``num``.
     """
-    assert qty >= 0
-    return slice_along_dim(a, dim, slice(a.shape[dim] - qty, None))
+    assert num >= 0
+    return slice_along_dim(a, dim, slice(a.shape[dim] - num, None))
 
 
 def unsqueeze_expand(a: torch.Tensor, dim: int, size: int) -> torch.Tensor:

--- a/test/torch/model/test_estimators.py
+++ b/test/torch/model/test_estimators.py
@@ -47,6 +47,15 @@ from gluonts.torch.distributions import ImplicitQuantileNetworkOutput
             loss=NegativeLogLikelihood(beta=0.1),
             scaling=False,
         ),
+        lambda dataset: DeepAREstimator(
+            freq=dataset.metadata.freq,
+            prediction_length=dataset.metadata.prediction_length,
+            context_length=1,
+            batch_size=4,
+            num_batches_per_epoch=3,
+            trainer_kwargs=dict(max_epochs=2),
+            scaling=False,
+        ),
         lambda dataset: MQF2MultiHorizonEstimator(
             freq=dataset.metadata.freq,
             prediction_length=dataset.metadata.prediction_length,


### PR DESCRIPTION
Fixes: #2838

*Description of changes:* When `context_length = 1` the torch DeepAREstimator resulted in a `-0` indexing that was causing some tensor having unexpected size.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup