### PR TITLE
Raise warning in `QuantileForecast.mean` when mean is not there

### DIFF
--- a/src/gluonts/model/forecast.py
+++ b/src/gluonts/model/forecast.py
@@ -12,6 +12,7 @@
 # permissions and limitations under the License.
 
 import re
+import logging
 from dataclasses import field
 from typing import Callable, Dict, List, Optional, Union, Tuple
 
@@ -21,6 +22,8 @@ from pydantic.dataclasses import dataclass
 
 from gluonts.core.component import validated
 from gluonts import maybe
+
+logger = logging.getLogger(__name__)
 
 
 def _linear_interpolation(
@@ -656,7 +659,10 @@ class QuantileForecast(Forecast):
         """
         if "mean" in self._forecast_dict:
             return self._forecast_dict["mean"]
-
+        logger.warning(
+            "The mean prediction is not stored in the forecast data; "
+            "the median is being returned instead."
+        )
         return self.quantile("p50")
 
     def dim(self) -> int:

--- a/src/gluonts/model/forecast.py
+++ b/src/gluonts/model/forecast.py
@@ -661,7 +661,8 @@ class QuantileForecast(Forecast):
             return self._forecast_dict["mean"]
         logger.warning(
             "The mean prediction is not stored in the forecast data; "
-            "the median is being returned instead."
+            "the median is being returned instead. "
+            "This behaviour may change in the future."
         )
         return self.quantile("p50")
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The `QuantileForecast` class falls back to the median when asked for the mean but the mean is not among the stored values. This is motivated by some downstream evaluation metrics using the mean of the predicted distribution, but some models only producing quantiles as forecasts.

To me this is pretty clearly not the right thing to do, and potential source of confusion: instead, it should be clear how to configure the evaluation to use the predicted median instead of the mean, if that's what the user wants.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup