### PR TITLE
Zebras: Add update to TimeSeries.

### DIFF
--- a/src/gluonts/zebras/_time_frame.py
+++ b/src/gluonts/zebras/_time_frame.py
@@ -240,7 +240,10 @@ class TimeFrame(TimeBase):
 
             values = np.full(
                 replace(
-                    maybe.unwrap(maybe.or_(self_col, other_col)).shape,
+                    cast(
+                        TimeFrame,
+                        maybe.unwrap(maybe.or_(self_col, other_col)),
+                    ).shape,
                     tdim,
                     len(index),
                 ),

--- a/src/gluonts/zebras/_time_frame.py
+++ b/src/gluonts/zebras/_time_frame.py
@@ -169,7 +169,27 @@ class TimeFrame(TimeBase):
         )
 
     def update(self, other: TimeFrame, default=np.nan) -> TimeFrame:
+        """Create a new ``TimeFrame`` which includes values of both input
+        frames.
+
+        The new frame spans both input frames and inserts default values if
+        there is a gap between the two frames. If both frames overlap, the
+        second can overwrite the values of the first frame.
+
+        Static columns and metadata is also updated, and the second frames
+        value take precedence.
+
+        Updating a frame with itself is effectively a noop, similar to how
+        ``dict.update`` on the same dict will return an identical result.
+
+        Update requires that both frame have defined indices, since otherwise
+        its not possible to know how the values relate to each other.
+
+        Note: ``update`` will reset the padding.
+        """
+
         assert self.index is not None and other.index is not None
+        assert self.index.freq == other.index.freq
 
         start = min(self.index.start, other.index.start)
         end = max(self.index.end, other.index.end)

--- a/src/gluonts/zebras/_time_frame.py
+++ b/src/gluonts/zebras/_time_frame.py
@@ -240,7 +240,9 @@ class TimeFrame(TimeBase):
 
             values = np.full(
                 replace(
-                    maybe.or_(self_col, other_col).shape, tdim, len(index)
+                    maybe.unwrap(maybe.or_(self_col, other_col)).shape,
+                    tdim,
+                    len(index),
                 ),
                 default,
             )

--- a/src/gluonts/zebras/_time_frame.py
+++ b/src/gluonts/zebras/_time_frame.py
@@ -204,7 +204,7 @@ class TimeFrame(TimeBase):
         static = {**self.static, **other.static}
 
         if self.metadata is not None and other.metadata is not None:
-            metadata = {**self.metadata, **other.metadata}
+            metadata: Optional[dict] = {**self.metadata, **other.metadata}
         else:
             metadata = maybe.or_(self.metadata, other.metadata)
 

--- a/src/gluonts/zebras/_time_frame.py
+++ b/src/gluonts/zebras/_time_frame.py
@@ -188,7 +188,7 @@ class TimeFrame(TimeBase):
         Note: ``update`` will reset the padding.
         """
 
-        if self.index is not None or other.index is not None:
+        if self.index is None or other.index is None:
             raise ValueError("Both time frames need to have an index.")
 
         if self.index.freq != other.index.freq:

--- a/src/gluonts/zebras/_time_frame.py
+++ b/src/gluonts/zebras/_time_frame.py
@@ -27,6 +27,7 @@ from gluonts.itertools import (
     rows_to_columns,
     select,
     join_items,
+    replace,
 )
 
 from ._base import Pad, TimeBase
@@ -228,16 +229,19 @@ class TimeFrame(TimeBase):
         self_idx0 = index.index_of(self.index.start)
         other_idx0 = index.index_of(other.index.start)
 
+        tdims = {**self.tdims, **other.tdims}
         # create new columns, by first filling them with default values and
         # then writing the values of self and other to them
         columns = {}
         for name, self_col, other_col in join_items(
             self.columns, other.columns, "outer"
         ):
-            tdim = self.tdims[name]
+            tdim = tdims[name]
 
             values = np.full(
-                replace(self_col.shape, tdim, len(index)),
+                replace(
+                    maybe.or_(self_col, other_col).shape, tdim, len(index)
+                ),
                 default,
             )
             view = AxisView(values, tdim)

--- a/src/gluonts/zebras/_time_series.py
+++ b/src/gluonts/zebras/_time_series.py
@@ -119,12 +119,12 @@ class TimeSeries(TimeBase):
 
         # ensure tdims match
         if self.tdim != other.tdim:
-            raise ValueError(f"tdims mismatch.")
+            raise ValueError("tdims mismatch.")
 
         if replace(np.shape(self), self.tdim, 0) != replace(
             np.shape(other), other.tdim, 0
         ):
-            raise ValueError(f"Incompatible shapes.")
+            raise ValueError("Incompatible shapes.")
 
         start = min(self.index.start, other.index.start)
         end = max(self.index.end, other.index.end)

--- a/src/gluonts/zebras/_time_series.py
+++ b/src/gluonts/zebras/_time_series.py
@@ -113,9 +113,11 @@ class TimeSeries(TimeBase):
         values = np.full(new_shape, default)
         view = AxisView(values, self.tdim)
 
-        for part in self, other:
-            idx = index.index_of(part.index.start)
-            view[idx : idx + len(part)] = part.values
+        idx = index.index_of(self.index.start)
+        view[idx : idx + len(self)] = self.values
+
+        idx = index.index_of(other.index.start)
+        view[idx : idx + len(other)] = other.values
 
         if self.metadata is not None and other.metadata is not None:
             metadata = {**self.metadata, **other.metadata}

--- a/src/gluonts/zebras/_time_series.py
+++ b/src/gluonts/zebras/_time_series.py
@@ -140,7 +140,7 @@ class TimeSeries(TimeBase):
         view[idx : idx + len(other)] = other.values
 
         if self.metadata is not None and other.metadata is not None:
-            metadata = {**self.metadata, **other.metadata}
+            metadata: Optional[dict] = {**self.metadata, **other.metadata}
         else:
             metadata = maybe.or_(self.metadata, other.metadata)
 

--- a/src/gluonts/zebras/_time_series.py
+++ b/src/gluonts/zebras/_time_series.py
@@ -92,7 +92,27 @@ class TimeSeries(TimeBase):
         )
 
     def update(self, other: TimeSeries, default=np.nan) -> TimeSeries:
+        """Create a new ``TimeSeries`` which includes values of both input
+        series.
+
+        The new series spans both input series and inserts default values if
+        there is a gap between the two series. If both series overlap, the
+        second can overwrite the values of the first series.
+
+        Name and metadata is also updated, and the second series
+        value take precedence.
+
+        Updating a series with itself is effectively a noop, similar to how
+        ``dict.update`` on the same dict will return an identical result.
+
+        Update requires that both series have defined indices, since otherwise
+        its not possible to know how the values relate to each other.
+
+        Note: ``update`` will reset the padding.
+        """
+
         assert self.index is not None and other.index is not None
+        assert self.index.freq == other.index.freq
 
         start = min(self.index.start, other.index.start)
         end = max(self.index.end, other.index.end)
@@ -126,11 +146,14 @@ class TimeSeries(TimeBase):
 
         # TODO: Pad -- does it even make sense?
 
+        name = maybe.or_(other.name, self.name)
+
         return _replace(
             self,
             values=values,
             index=index,
             metadata=metadata,
+            name=name,
             _pad=Pad(),
         )
 

--- a/src/gluonts/zebras/_time_series.py
+++ b/src/gluonts/zebras/_time_series.py
@@ -21,7 +21,7 @@ import numpy as np
 from toolz import first
 
 from gluonts import maybe
-from gluonts.itertools import pluck_attr
+from gluonts.itertools import pluck_attr, replace
 
 from ._base import Pad, TimeBase
 from ._period import period, Period, Periods

--- a/src/gluonts/zebras/_time_series.py
+++ b/src/gluonts/zebras/_time_series.py
@@ -21,7 +21,7 @@ import numpy as np
 from toolz import first
 
 from gluonts import maybe
-from gluonts.itertools import pluck_attr, replace
+from gluonts.itertools import pluck_attr
 
 from ._base import Pad, TimeBase
 from ._period import period, Period, Periods

--- a/src/gluonts/zebras/_util.py
+++ b/src/gluonts/zebras/_util.py
@@ -30,6 +30,12 @@ class AxisView:
 
         return self.data[tuple(slices)]
 
+    def __setitem__(self, index, value):
+        slices = [slice(None)] * self.data.ndim
+        slices[self.axis] = index
+
+        self.data[tuple(slices)] = value
+
     def __len__(self):
         return self.data.shape[self.axis]
 

--- a/test/zebras/test_timeframe.py
+++ b/test/zebras/test_timeframe.py
@@ -196,3 +196,23 @@ def test_rename():
 
 def test_update():
     assert tf.update(tf).eq_to(tf)
+
+    left = tf[:3]
+    right = tf[-3:]
+
+    tf2 = left.update(right)
+    assert len(tf) == len(tf2)
+    assert tf.index == tf2.index
+
+    gap = tf2[3:-3]
+    assert np.isnan(gap["target"]).all()
+
+    xxx = zb.time_frame(
+        {"xxx": np.full(3, 99)},
+        index=right.index,
+    )
+    tf3 = left.update(xxx)
+
+    assert len(tf) == len(tf3)
+    assert tf.index == tf3.index
+    tf3.columns.keys() == tf.columns.keys() | {"xxx"}

--- a/test/zebras/test_timeframe.py
+++ b/test/zebras/test_timeframe.py
@@ -192,3 +192,7 @@ def test_rename():
 
     tf2 = tf.rename_static(x="static")
     assert tf2.static.keys() == {"x"}
+
+
+def test_update():
+    assert tf.update(tf).eq_to(tf)

--- a/test/zebras/test_timeframe.py
+++ b/test/zebras/test_timeframe.py
@@ -194,7 +194,7 @@ def test_rename():
     assert tf2.static.keys() == {"x"}
 
 
-def test_update():
+def test_update_timeframe():
     assert tf.update(tf).eq_to(tf)
 
     left = tf[:3]
@@ -216,3 +216,22 @@ def test_update():
     assert len(tf) == len(tf3)
     assert tf.index == tf3.index
     tf3.columns.keys() == tf.columns.keys() | {"xxx"}
+
+
+def test_update_timeseries():
+    ts = tf["target"]
+    assert np.all(ts.update(ts) == ts)
+
+    left = ts[:3]
+    right = ts[-3:]
+
+    ts2 = left.update(right)
+    assert len(ts) == len(ts2)
+    assert ts.index == ts2.index
+
+    gap = ts2[3:-3]
+    assert np.isnan(gap).all()
+
+    ts3 = left.update(zb.time_series(np.full(3, 99), index=right.index))
+    assert len(ts) == len(ts3)
+    assert ts.index == ts3.index


### PR DESCRIPTION
Allow merging of two time series.

With `update` it is possible to gradually build up a time series by updating the time series.

This works by creating a new series that spans both input series and is pre-filled with a default values. Then values are copied for the input series. This has some implications: If there is an overlap, the values of the second series overwrite the values of the first series in the overlapping span. Also, the values spanning between the two series remain the default value.


TODO:

- [x] Add consistency checks.
- [x] Merge static values
- [x] Merge metadata
- [x] Extend behaviour to other classes.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup