### PR TITLE
Zebras: Add TimeSeries.to_numpy.

### DIFF
--- a/src/gluonts/zebras/_time_series.py
+++ b/src/gluonts/zebras/_time_series.py
@@ -49,6 +49,9 @@ class TimeSeries(TimeBase):
     def __array__(self):
         return self.values
 
+    def to_numpy(self):
+        return self.values
+
     def __len__(self):
         return self.values.shape[self.tdim]
 


### PR DESCRIPTION
`matplotlib` tries to call `to_numpy` on a given input, to plot it:


```py
def index_of(y):
    """
    A helper function to create reasonable x values for the given *y*.

    This is used for plotting (x, y) if x values are not explicitly given.

    First try ``y.index`` (assuming *y* is a `pandas.Series`), if that
    fails, use ``range(len(y))``.

    This will be extended in the future to deal with more types of
    labeled data.

    Parameters
    ----------
    y : float or array-like

    Returns
    -------
    x, y : ndarray
       The x and y values to plot.
    """
    try:
        return y.index.to_numpy(), y.to_numpy()
    except AttributeError:
        pass
...
```

https://github.com/matplotlib/matplotlib/blob/55d90d2952088a6f37eab044cfe0a00510cd7102/lib/matplotlib/cbook.py#L1597

`index.to_numpy()` already works, but `to_numpy` was missing on the series itself.

This will allows use to call ``plt.plot(zb.time_series(...)`` directly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup