### PR TITLE
0.13 backports

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,7 @@ jobs:
 
     - name: Configure AWS Credentials
       if: ${{ github.event_name == 'push' && ( github.ref_name == 'dev' || startsWith(github.ref_name, 'v0.')) }}
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
         role-to-assume: arn:aws:iam::671929771060:role/WebsitePublisher
         role-session-name: docs-push

--- a/README.md
+++ b/README.md
@@ -14,33 +14,34 @@ based on [PyTorch](https://pytorch.org) and [MXNet](https://mxnet.apache.org).
 
 ## Installation
 
-GluonTS requires Python 3.7 or newer, and the easiest way to install it is via `pip`:
+GluonTS requires Python 3.7 or newer, and the easiest way to install it is via
+`pip`:
 
 ```bash
-# support for mxnet models, faster datasets
-pip install "gluonts[mxnet,pro]"
+# install with support for torch models
+pip install "gluonts[torch]"
 
-# support for torch models, faster datasets
-pip install "gluonts[torch,pro]"
+# install with support for mxnet models
+pip install "gluonts[mxnet]"
 ```
+
+See the [documentation](https://ts.gluon.ai/stable/getting_started/install.html)
+for more info on how GluonTS can be installed.
 
 ## Simple Example
 
 To illustrate how to use GluonTS, we train a DeepAR-model and make predictions
-using the simple "airpassengers" dataset. The dataset consists of a single
-time series, containing monthly international passengers between the years
-1949 and 1960, a total of 144 values (12 years * 12 months). We split the
-dataset into train and test parts, by removing the last three years (36 month)
-from the train data. Thus, we will train a model on just the first nine years
-of data.
-
+using the airpassengers dataset. The dataset consists of a single time
+series of monthly passenger numbers between 1949 and 1960. We train the model
+on the first nine years and make predictions for the remaining three years.
 
 ```py
 import pandas as pd
 import matplotlib.pyplot as plt
+
 from gluonts.dataset.pandas import PandasDataset
 from gluonts.dataset.split import split
-from gluonts.mx import DeepAREstimator, Trainer
+from gluonts.torch import DeepAREstimator
 
 # Load data from a CSV file into a PandasDataset
 df = pd.read_csv(
@@ -51,14 +52,15 @@ df = pd.read_csv(
 )
 dataset = PandasDataset(df, target="#Passengers")
 
-# Train a DeepAR model on all data but the last 36 months
+# Split the data for training and testing
 training_data, test_gen = split(dataset, offset=-36)
+test_data = test_gen.generate_instances(prediction_length=12, windows=3)
+
+# Train the model and make predictions
 model = DeepAREstimator(
-    prediction_length=12, freq="M", trainer=Trainer(epochs=5)
+    prediction_length=12, freq="M", trainer_kwargs={"max_epochs": 5}
 ).train(training_data)
 
-# Generate test instances and predictions for them
-test_data = test_gen.generate_instances(prediction_length=12, windows=3)
 forecasts = list(model.predict(test_data.input))
 
 # Plot predictions
@@ -70,10 +72,9 @@ plt.legend(["True values"], loc="upper left", fontsize="xx-large")
 
 ![[train-test]](https://ts.gluon.ai/static/README/forecasts.png)
 
+Note, the forecasts are displayed in terms of a probability distribution and
+the shaded areas represent the 50% and 90% prediction intervals.
 
-Note that the forecasts are displayed in terms of a probability distribution:
-The shaded areas represent the 50% and 90% prediction intervals, respectively,
-centered around the median.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ test_data = test_gen.generate_instances(prediction_length=12, windows=3)
 forecasts = list(model.predict(test_data.input))
 
 # Plot predictions
-df["#Passengers"].plot(color="black")
-for forecast, color in zip(forecasts, ["green", "blue", "purple"]):
-    forecast.plot(color=f"tab:{color}")
+plt.plot(df["1954":], color="black")
+for forecast in forecasts:
+  forecast.plot()
 plt.legend(["True values"], loc="upper left", fontsize="xx-large")
 ```
 
-![[train-test]](https://d2kv9n23y3w0pn.cloudfront.net/static/README/forecasts.png)
+![[train-test]](https://ts.gluon.ai/static/README/forecasts.png)
 
 
 Note that the forecasts are displayed in terms of a probability distribution:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -118,3 +118,16 @@ html_favicon = "_static/gluonts.ico"
 
 # Enable Markdown
 source_suffix = [".rst", ".md"]
+
+# We want to execute the notebooks ourselves in the md2ipynb.py
+nbsphinx_execute = "never"
+
+# Add a `Download` at top of the document.
+nbsphinx_prolog = """
+.. raw:: html
+
+    <p>
+        <a href="./{{ env.docname.rsplit("/", 1)[-1] }}.ipynb">Download this notebook</a>
+    </p>
+
+"""

--- a/docs/md2ipynb.py
+++ b/docs/md2ipynb.py
@@ -1,8 +1,6 @@
-import json
 import re
 import sys
 import time
-import os
 from pathlib import Path
 
 import black
@@ -16,23 +14,24 @@ from jinja2 import Environment
 env = Environment()
 
 
-def run_notebook(text, kernel_name, timeout) -> str:
+def run_notebook(text, kernel_name, timeout, execute) -> str:
     # We add two blank lines at the end to ensure
     # that the final cell also runs.
     text += "\n" * 2
     notebook = notedown.MarkdownReader().reads(text)
 
-    kwargs = {}
-    if kernel_name is not None:
-        kwargs["kernel_name"] = kernel_name
+    if execute:
+        kwargs = {}
+        if kernel_name is not None:
+            kwargs["kernel_name"] = kernel_name
 
-    client = NotebookClient(
-        notebook,
-        timeout=timeout,
-        resources={"metadata": {"path": "."}},
-        **kwargs,
-    )
-    client.execute()
+        client = NotebookClient(
+            notebook,
+            timeout=timeout,
+            resources={"metadata": {"path": "."}},
+            **kwargs,
+        )
+        client.execute()
 
     # need to add language info to for syntax highlight
     notebook["metadata"].update(language_info={"name": "python"})
@@ -43,7 +42,7 @@ def run_notebook(text, kernel_name, timeout) -> str:
 def black_cells(text):
     CODE_RE = r"```py(?:thon)?\s*\n(.*?)```"
 
-    text = re.sub(r"^%", r"#%#", text, flags=re.M)
+    text = re.sub(r"^%", r"# %-% #", text, flags=re.M)
 
     def apply_black(match):
         code = match.group(1)
@@ -53,7 +52,7 @@ def black_cells(text):
         return "\n".join(["```", formatted.rstrip(), "```"])
 
     formatted = re.sub(CODE_RE, apply_black, text, flags=re.S)
-    return re.sub(r"^#%#", r"%", formatted, flags=re.M)
+    return re.sub(r"^# %-% #", r"%", formatted, flags=re.M)
 
 
 def convert(path, mode, kernel_name=None, timeout=40 * 60):
@@ -66,21 +65,20 @@ def convert(path, mode, kernel_name=None, timeout=40 * 60):
     markdown = template.render(mode=mode)
     markdown = black_cells(markdown)
 
-    if mode != "skip":
-        suffix = ".ipynb"
-        start = time.time()
-        output = run_notebook(markdown, kernel_name, timeout)
-        print(f"finished evaluation in {time.time() - start} sec")
-    else:
-        suffix = ".md"
-        print(f"convert to {suffix}")
-        output = markdown
+    start = time.time()
+    output = run_notebook(
+        markdown,
+        kernel_name,
+        timeout,
+        execute=mode != "skip",
+    )
+    print(f"finished evaluation in {time.time() - start} sec")
 
     # XXX.md.input -> XXX.ipynb
     # `with_suffix` only operates on last suffix, so we need some more involved
     # logic.
     stem = path.name.split(".", 1)[0]
-    with path.with_name(stem).with_suffix(suffix).open("w") as outfile:
+    with path.with_name(stem).with_suffix(".ipynb").open("w") as outfile:
         outfile.write(output)
 
 

--- a/docs/tutorials/advanced_topics/howto_pytorch_lightning.md.template
+++ b/docs/tutorials/advanced_topics/howto_pytorch_lightning.md.template
@@ -259,7 +259,7 @@ We can now train the model using the tooling that PyTorch Lightning provides:
 
 
 ```python
-trainer = pl.Trainer(max_epochs=10, gpus=-1 if torch.cuda.is_available() else None)
+trainer = pl.Trainer(max_epochs=10)
 trainer.fit(net, data_loader)
 ```
 
@@ -313,10 +313,7 @@ plt.rcParams.update({'font.size': 15})
 
 for idx, (forecast, ts) in islice(enumerate(zip(forecasts_pytorch, tss_pytorch)), 9):
     ax = plt.subplot(3, 3, idx+1)
-    ts = ts.copy()
-    ts.index = ts.index.to_timestamp()
-
-    plt.plot(ts[-5 * prediction_length:], label="target")
+    plt.plot(ts[-5 * prediction_length:].to_timestamp(), label="target")
     forecast.plot()
     plt.xticks(rotation=60)
     ax.xaxis.set_major_formatter(date_formater)

--- a/docs/tutorials/advanced_topics/hp_tuning_with_optuna.md.template
+++ b/docs/tutorials/advanced_topics/hp_tuning_with_optuna.md.template
@@ -12,21 +12,10 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 import json
-```
 
-### Provided datasets
-
-
-```python
-from gluonts.dataset.repository import get_dataset, dataset_names
+from gluonts.dataset.repository import get_dataset
 from gluonts.dataset.util import to_pandas
 ```
-
-
-```python
-print(f"Available datasets: {dataset_names}")
-```
-
 
 ```python
 dataset = get_dataset("m4_hourly")
@@ -222,22 +211,9 @@ tss = list(ts_it)
 
 
 ```python
-def plot_prob_forecasts(ts_entry, forecast_entry):
-    plot_length = 150
-    prediction_intervals = (50.0, 90.0)
-    legend = ["observations", "median prediction"] + [f"{k}% prediction interval" for k in prediction_intervals][::-1]
-
-    fig, ax = plt.subplots(1, 1, figsize=(10, 7))
-    ts_entry[-plot_length:].plot(ax=ax)  # plot the time series
-    forecast_entry.plot(prediction_intervals=prediction_intervals, color='g')
-    plt.grid(which="both")
-    plt.legend(legend, loc="upper left")
-    plt.show()
-```
-
-
-```python
-plot_prob_forecasts(tss[0], forecasts[0])
+plt.plot(tss[0][-150:].to_timestamp())
+forecasts[0].plot(show_label=True)
+plt.legend()
 ```
 
 We can also evaluate the quality of our forecasts numerically. In GluonTS, the `Evaluator` class can compute aggregate performance metrics, as well as metrics per time series (which can be useful for analyzing performance across heterogeneous time series).

--- a/docs/tutorials/data_manipulation/pandasdataframes.md.template
+++ b/docs/tutorials/data_manipulation/pandasdataframes.md.template
@@ -448,8 +448,8 @@ n_plot = 3
 indices = np.random.choice(np.arange(0, N), size=n_plot, replace=False)
 fig, axes = plt.subplots(n_plot, 1, figsize=(10, n_plot*5))
 for index, ax in zip(indices, axes):
-    tests[index][-4*prediction_length:].plot(ax=ax)
+    ax.plot(tests[index][-4 * prediction_length :].to_timestamp())
     plt.sca(ax)
-    forecasts[index].plot(prediction_intervals=[90.], color='g')
-    plt.legend(["observed", "predicted median", "predicted 90% quantile"])
+    forecasts[index].plot(intervals=(0.9,), color='g')
+    plt.legend(["observed", "predicted median", "90% prediction interval"])
 ```

--- a/docs/tutorials/forecasting/extended_tutorial.md.template
+++ b/docs/tutorials/forecasting/extended_tutorial.md.template
@@ -709,22 +709,9 @@ print(f"0.5-quantile (median) of the future window:\n {forecast_entry.quantile(0
 
 
 ```python
-def plot_prob_forecasts(ts_entry, forecast_entry):
-    plot_length = 150 
-    prediction_intervals = (50.0, 90.0)
-    legend = ["observations", "median prediction"] + [f"{k}% prediction interval" for k in prediction_intervals][::-1]
-
-    fig, ax = plt.subplots(1, 1, figsize=(10, 7))
-    ts_entry[-plot_length:].plot(ax=ax)  # plot the time series
-    forecast_entry.plot(prediction_intervals=prediction_intervals, color='g')
-    plt.grid(which="both")
-    plt.legend(legend, loc="upper left")
-    plt.show()
-```
-
-
-```python
-plot_prob_forecasts(ts_entry, forecast_entry)
+plt.plot(ts_entry[-150:].to_timestamp())
+forecast_entry.plot(show_label=True)
+plt.legend()
 ```
 
 ### Compute metrics
@@ -980,7 +967,9 @@ tss = list(ts_it)
 
 
 ```python
-plot_prob_forecasts(tss[0], forecasts[0])
+plt.plot(tss[0][-150:].to_timestamp())
+forecasts[0].plot(show_label=True)
+plt.legend()
 ```
 
 Observe that we cannot actually see any prediction intervals in the predictions. This is expected since the model that we defined does not do probabilistic forecasting but it just gives point estimates. By requiring 100 sample paths (defined in `make_evaluation_predictions`) in such a network, we get 100 times the same output.
@@ -1214,7 +1203,9 @@ tss = list(ts_it)
 
 
 ```python
-plot_prob_forecasts(tss[0], forecasts[0])
+plt.plot(tss[0][-150:].to_timestamp())
+forecasts[0].plot(show_label=True)
+plt.legend()
 ```
 
 ### Add features and scaling
@@ -1493,7 +1484,9 @@ tss = list(ts_it)
 
 
 ```python
-plot_prob_forecasts(tss[0], forecasts[0])
+plt.plot(tss[0][-150:].to_timestamp())
+forecasts[0].plot(show_label=True)
+plt.legend()
 ```
 
 ### From feedforward to RNN
@@ -1871,5 +1864,7 @@ tss = list(ts_it)
 
 
 ```python
-plot_prob_forecasts(tss[0], forecasts[0])
+plt.plot(tss[0][-150:].to_timestamp())
+forecasts[0].plot(show_label=True)
+plt.legend()
 ```

--- a/docs/tutorials/forecasting/quick_start_tutorial.md.template
+++ b/docs/tutorials/forecasting/quick_start_tutorial.md.template
@@ -11,8 +11,6 @@ GluonTS contains:
 
 ```python
 %matplotlib inline
-import mxnet as mx
-from mxnet import gluon
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
@@ -237,22 +235,9 @@ print(f"0.5-quantile (median) of the future window:\n {forecast_entry.quantile(0
 
 
 ```python
-def plot_prob_forecasts(ts_entry, forecast_entry):
-    plot_length = 150 
-    prediction_intervals = (50.0, 90.0)
-    legend = ["observations", "median prediction"] + [f"{k}% prediction interval" for k in prediction_intervals][::-1]
-
-    fig, ax = plt.subplots(1, 1, figsize=(10, 7))
-    ts_entry[-plot_length:].plot(ax=ax)  # plot the time series
-    forecast_entry.plot(prediction_intervals=prediction_intervals, color='g')
-    plt.grid(which="both")
-    plt.legend(legend, loc="upper left")
-    plt.show()
-```
-
-
-```python
-plot_prob_forecasts(ts_entry, forecast_entry)
+plt.plot(ts_entry[-150:].to_timestamp())
+forecast_entry.plot(show_label=True)
+plt.legend()
 ```
 
 We can also evaluate the quality of our forecasts numerically. In GluonTS, the `Evaluator` class can compute aggregate performance metrics, as well as metrics per time series (which can be useful for analyzing performance across heterogeneous time series).

--- a/src/gluonts/dataset/repository/_tsf_datasets.py
+++ b/src/gluonts/dataset/repository/_tsf_datasets.py
@@ -208,6 +208,7 @@ def convert_data(
                     data_entry.get("start_timestamp", default_start_timestamp)
                 ),
                 "item_id": data_entry.get("series_name", i),
+                "feat_static_cat": [i],
             }
         )
 
@@ -218,6 +219,7 @@ def convert_data(
                     data_entry.get("start_timestamp", default_start_timestamp)
                 ),
                 "item_id": data_entry.get("series_name", i),
+                "feat_static_cat": [i],
             }
         )
 

--- a/src/gluonts/itertools.py
+++ b/src/gluonts/itertools.py
@@ -452,3 +452,39 @@ def power_set(iterable):
     return itertools.chain.from_iterable(
         itertools.combinations(iterable, r) for r in range(len(iterable) + 1)
     )
+
+
+def join_items(left, right, how="outer", default=None):
+    """
+    Iterate over joined dictionary items.
+
+    Yields triples of `key`, `left_value`, `right_value`.
+
+    Similar to SQL join statements the join behaviour is controlled by ``how``:
+
+    * ``outer`` (default): use keys from left and right
+    * ``inner``: only use keys which appear in both left and right
+    * ``strict``: like ``inner``, but throws error if keys mismatch
+    * ``left``: use only keys from ``left``
+    * ``right``: use only keys from ``right``
+
+    If a key is not present in either input, ``default`` is chosen instead.
+
+    """
+
+    if how == "outer":
+        keys = {**left, **right}
+    elif how == "strict":
+        assert left.keys() == right.keys()
+        keys = left.keys()
+    elif how == "inner":
+        keys = left.keys() & right.keys()
+    elif how == "left":
+        keys = left.keys()
+    elif how == "right":
+        keys = right.keys()
+    else:
+        raise ValueError(f"Unknown how={how}.")
+
+    for key in keys:
+        yield key, left.get(key, default), right.get(key, default)

--- a/src/gluonts/zebras/_base.py
+++ b/src/gluonts/zebras/_base.py
@@ -142,7 +142,7 @@ class TimeBase:
         else:
             return self.iloc[: length - len(self)]
 
-    def index_of(self, period: Period) -> int:
+    def index_of(self, period: Union[Period, str]) -> int:
         assert self.index is not None
 
         return self.index.index_of(period)
@@ -154,16 +154,20 @@ class TimeBase:
             subtype = idx
         else:
             assert isinstance(idx, slice)
-            subtype = maybe.or_(idx.start, idx.stop)
 
-        if subtype is None:
-            return self
+            start = idx.start
+            if start is not None or not isinstance(start, int):
+                if isinstance(start, (Period, str)):
+                    start = self.index_of(start)
 
-        elif isinstance(subtype, int):
-            return self.iloc[idx]
+            stop = idx.stop
+            if stop is not None or not isinstance(stop, int):
+                if isinstance(stop, (Period, str)):
+                    stop = self.index_of(stop)
 
-        elif isinstance(subtype, Period):
-            return self.loc[idx]
+            idx = slice(start, stop, idx.step)
+
+        return self.iloc[idx]
 
         raise RuntimeError(f"Unsupported type {subtype}.")
 

--- a/src/gluonts/zebras/_period.py
+++ b/src/gluonts/zebras/_period.py
@@ -355,9 +355,7 @@ class Periods(_BasePeriod):
         if not isinstance(other, Periods):
             return False
 
-        return self.freq.n == other.freq.n and np.array_equal(
-            self.data, other.data
-        )
+        return len(self) == len(other) and self.start == other.start
 
     def to_numpy(self) -> np.ndarray:
         return self.data

--- a/src/gluonts/zebras/_time_series.py
+++ b/src/gluonts/zebras/_time_series.py
@@ -49,6 +49,9 @@ class TimeSeries(TimeBase):
     def __array__(self):
         return self.values
 
+    def to_numpy(self):
+        return self.values
+
     def __len__(self):
         return self.values.shape[self.tdim]
 

--- a/test/mx/model/deepstate/test_using_tsf_dataset.py
+++ b/test/mx/model/deepstate/test_using_tsf_dataset.py
@@ -1,0 +1,34 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from gluonts.dataset.repository.datasets import get_dataset
+from gluonts.mx.model.deepstate import DeepStateEstimator
+from gluonts.mx.trainer import Trainer
+
+
+def test_deepstate_on_tsf_dataset():
+    dataset = get_dataset("covid_deaths")
+
+    estimator = DeepStateEstimator(
+        cardinality=[len(dataset)],
+        freq=dataset.metadata.freq,
+        prediction_length=dataset.metadata.prediction_length,
+        trainer=Trainer(
+            ctx="cpu",
+            epochs=1,
+            learning_rate=1e-3,
+            num_batches_per_epoch=1,
+            hybridize=False,
+        ),
+    )
+    estimator.train(dataset.train)

--- a/test/test_itertools.py
+++ b/test/test_itertools.py
@@ -39,6 +39,7 @@ from gluonts.itertools import (
     Map,
     StarMap,
     Filter,
+    join_items,
 )
 
 
@@ -248,3 +249,31 @@ def test_power_set():
 
     for es in expected_subsets:
         assert es in subsets
+
+
+def test_join_items():
+    left = {"a": 1, "b": 2}
+    right = {"a": 3, "c": 4}
+
+    assert list(join_items(left, right)) == [
+        ("a", 1, 3),
+        ("b", 2, None),
+        ("c", None, 4),
+    ]
+
+    assert list(join_items(left, right, "inner")) == [
+        ("a", 1, 3),
+    ]
+
+    assert list(join_items(left, right, "left")) == [
+        ("a", 1, 3),
+        ("b", 2, None),
+    ]
+
+    assert list(join_items(left, right, "right")) == [
+        ("a", 1, 3),
+        ("c", None, 4),
+    ]
+
+    with pytest.raises(Exception):
+        oin_items(left, right, "strict")

--- a/test/zebras/test_timeframe.py
+++ b/test/zebras/test_timeframe.py
@@ -45,6 +45,7 @@ def test_time_series():
 
 
 def test_time_frame():
+    assert tf.eq_to(tf)
     assert len(tf) == 10
     assert len(tf[:4]) == 4
     assert len(tf[-4:]) == 4
@@ -57,6 +58,7 @@ def test_time_frame():
     assert tf.metadata == {"x": 42}
 
     tf2 = tf.stack(["target", "feat"], "stacked")
+    assert not tf.eq_to(tf2)
     assert tf2.columns["stacked"].shape == (3, 10)
     assert tf2.columns["stacked"].shape == (3, 10)
     assert "target" not in tf2.columns


### PR DESCRIPTION
Zebras: Improve equality for Periods. (#2857)

Add ``join_items`` to itertools. (#2859)

Zebras: Add `eq_to` to TimeFrame. (#2858)

Zebras: Add eq_shape to TimeFrame. (#2863)

Zebras: Allow to slice TimeFrame using plain strings for time info. (#2865)

Simplify plotting of forecasts. (#2864)

Zebras: Add TimeSeries.to_numpy. (#2866)

Update plotting in readme example. (#2867)

Cache groupby result in `PandasDataset` (#2860)

Docs: Fix and simplify tutorials. (#2869)
    
Docs: Fix black formatting of % instructions. (#2870)
    
Add feat_static_cat for TSF datasets (#2871)
    
Docs: Add download link to notebooks. (#2872)
    
Update action to configure AWS credentials (#2873)

Docs: Use torch DeepAR in README. (#2874)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup