### PR TITLE
Docs: Fix black formatting of % instructions.

### DIFF
--- a/docs/md2ipynb.py
+++ b/docs/md2ipynb.py
@@ -43,7 +43,7 @@ def run_notebook(text, kernel_name, timeout) -> str:
 def black_cells(text):
     CODE_RE = r"```py(?:thon)?\s*\n(.*?)```"
 
-    text = re.sub(r"^%", r"#%#", text, flags=re.M)
+    text = re.sub(r"^%", r"# %-% #", text, flags=re.M)
 
     def apply_black(match):
         code = match.group(1)
@@ -53,7 +53,7 @@ def black_cells(text):
         return "\n".join(["```", formatted.rstrip(), "```"])
 
     formatted = re.sub(CODE_RE, apply_black, text, flags=re.S)
-    return re.sub(r"^#%#", r"%", formatted, flags=re.M)
+    return re.sub(r"^# %-% #", r"%", formatted, flags=re.M)
 
 
 def convert(path, mode, kernel_name=None, timeout=40 * 60):


### PR DESCRIPTION
Fixes:

```
# %#matplotlib inline
import mxnet as mx
from mxnet import gluon
import numpy as np
import pandas as pd
import matplotlib.pyplot as plt
import json
```

https://ts.gluon.ai/stable/tutorials/forecasting/quick_start_tutorial.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup