### PR TITLE
Speedup is_uniform for PandasDataset.

### DIFF
--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -350,5 +350,4 @@ def is_uniform(index: pd.PeriodIndex) -> bool:
         >>> is_uniform(pd.DatetimeIndex(ts).to_period("2H"))
         False
     """
-    other = pd.period_range(index[0], periods=len(index), freq=index.freq)
-    return (other == index).all()
+    return np.all(np.diff(index.asi8) == index.freq.n)

--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field, InitVar
-from typing import Any, Iterable, Optional, Type, Union
+from typing import Any, Iterable, Optional, Type, Union, cast
 
 import numpy as np
 import pandas as pd
@@ -350,4 +350,5 @@ def is_uniform(index: pd.PeriodIndex) -> bool:
         >>> is_uniform(pd.DatetimeIndex(ts).to_period("2H"))
         False
     """
-    return np.all(np.diff(index.asi8) == index.freq.n)
+
+    return cast(bool, np.all(np.diff(index.asi8) == index.freq.n))


### PR DESCRIPTION
Constructing a second index is very slow. The new version is 9x faster locally when using an index of size 365.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup