### PR TITLE
Fix docstrings in torch lightning modules

### DIFF
--- a/src/gluonts/torch/model/d_linear/lightning_module.py
+++ b/src/gluonts/torch/model/d_linear/lightning_module.py
@@ -30,15 +30,14 @@ class DLinearLightningModule(pl.LightningModule):
 
     Parameters
     ----------
-    model
-        ``DLinearModel`` to be trained.
+    model_kwargs
+        Keyword arguments to construct the ``DLinearModel`` to be trained.
     loss
-        Loss function to be used for training,
-        default: ``NegativeLogLikelihood()``.
+        Loss function to be used for training.
     lr
-        Learning rate, default: ``1e-3``.
+        Learning rate.
     weight_decay
-        Weight decay regularization parameter, default: ``1e-8``.
+        Weight decay regularization parameter.
     """
 
     @validated()

--- a/src/gluonts/torch/model/deepar/lightning_module.py
+++ b/src/gluonts/torch/model/deepar/lightning_module.py
@@ -33,17 +33,16 @@ class DeepARLightningModule(pl.LightningModule):
 
     Parameters
     ----------
-    model
-        ``DeepARModel`` to be trained.
+    model_kwargs
+        Keyword arguments to construct the ``DeepARModel`` to be trained.
     loss
-        Loss function to be used for training,
-        default: ``NegativeLogLikelihood()``.
+        Loss function to be used for training.
     lr
-        Learning rate, default: ``1e-3``.
+        Learning rate.
     weight_decay
-        Weight decay regularization parameter, default: ``1e-8``.
+        Weight decay regularization parameter.
     patience
-        Patience parameter for learning rate scheduler, default: ``10``.
+        Patience parameter for learning rate scheduler.
     """
 
     @validated()

--- a/src/gluonts/torch/model/lag_tst/lightning_module.py
+++ b/src/gluonts/torch/model/lag_tst/lightning_module.py
@@ -30,15 +30,14 @@ class LagTSTLightningModule(pl.LightningModule):
 
     Parameters
     ----------
-    model
-        ``LagTSTModel`` to be trained.
+    model_kwargs
+        Keyword arguments to construct the ``LagTSTModel`` to be trained.
     loss
-        Loss function to be used for training,
-        default: ``NegativeLogLikelihood()``.
+        Loss function to be used for training.
     lr
-        Learning rate, default: ``1e-3``.
+        Learning rate.
     weight_decay
-        Weight decay regularization parameter, default: ``1e-8``.
+        Weight decay regularization parameter.
     """
 
     @validated()

--- a/src/gluonts/torch/model/mqf2/lightning_module.py
+++ b/src/gluonts/torch/model/mqf2/lightning_module.py
@@ -35,14 +35,14 @@ class MQF2MultiHorizonLightningModule(pl.LightningModule):
 
     Parameters
     ----------
-    model
-        An MQF2MultiHorizonModel instance
+    model_kwargs
+        Keyword arguments to construct the ``MQF2MultiHorizonModel`` to be trained.
     loss
-        Distribution loss
+        Distribution loss.
     lr
-        Learning rate
+        Learning rate.
     weight_decay
-        Weight decay during training
+        Weight decay during training.
     patience
         Patience parameter for learning rate scheduler, default: ``10``.
     """

--- a/src/gluonts/torch/model/patch_tst/lightning_module.py
+++ b/src/gluonts/torch/model/patch_tst/lightning_module.py
@@ -30,15 +30,14 @@ class PatchTSTLightningModule(pl.LightningModule):
 
     Parameters
     ----------
-    model
-        ``PatchTSTModel`` to be trained.
+    model_kwargs
+        Keyword arguments to construct the ``PatchTSTModel`` to be trained.
     loss
-        Loss function to be used for training,
-        default: ``NegativeLogLikelihood()``.
+        Loss function to be used for training.
     lr
-        Learning rate, default: ``1e-3``.
+        Learning rate.
     weight_decay
-        Weight decay regularization parameter, default: ``1e-8``.
+        Weight decay regularization parameter.
     """
 
     @validated()

--- a/src/gluonts/torch/model/simple_feedforward/lightning_module.py
+++ b/src/gluonts/torch/model/simple_feedforward/lightning_module.py
@@ -30,15 +30,14 @@ class SimpleFeedForwardLightningModule(pl.LightningModule):
 
     Parameters
     ----------
-    model
-        ``SimpleFeedForwardModel`` to be trained.
+    model_kwargs
+        Keyword arguments to construct the ``SimpleFeedForwardModel`` to be trained.
     loss
-        Loss function to be used for training,
-        default: ``NegativeLogLikelihood()``.
+        Loss function to be used for training.
     lr
-        Learning rate, default: ``1e-3``.
+        Learning rate.
     weight_decay
-        Weight decay regularization parameter, default: ``1e-8``.
+        Weight decay regularization parameter.
     """
 
     @validated()

--- a/src/gluonts/torch/model/tft/lightning_module.py
+++ b/src/gluonts/torch/model/tft/lightning_module.py
@@ -31,14 +31,14 @@ class TemporalFusionTransformerLightningModule(pl.LightningModule):
 
     Parameters
     ----------
-    model
-        ``TemporalFusionTransformerModel`` to be trained.
+    model_kwargs
+        Keyword arguments to construct the ``TemporalFusionTransformerModel`` to be trained.
     lr
-        Learning rate, default: ``1e-3``.
+        Learning rate.
     weight_decay
-        Weight decay regularization parameter, default: ``1e-8``.
+        Weight decay regularization parameter.
     patience
-        Patience parameter for learning rate scheduler, default: ``10``.
+        Patience parameter for learning rate scheduler.
     """
 
     @validated()


### PR DESCRIPTION
*Description of changes:* Some docstrings are outdated
- constructor gets kwargs for the model, not the model itself
- some default was wrong, removing defaults from docstrings (they are just redundant)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup