### PR TITLE
Fix default scale in torch DeepAR

### DIFF
--- a/src/gluonts/torch/model/deepar/estimator.py
+++ b/src/gluonts/torch/model/deepar/estimator.py
@@ -166,7 +166,7 @@ class DeepAREstimator(PyTorchLightningEstimator):
         distr_output: DistributionOutput = StudentTOutput(),
         loss: DistributionLoss = NegativeLogLikelihood(),
         scaling: bool = True,
-        default_scale: float = 0.0,
+        default_scale: Optional[float] = None,
         lags_seq: Optional[List[int]] = None,
         time_features: Optional[List[TimeFeature]] = None,
         num_parallel_samples: int = 100,

--- a/src/gluonts/torch/model/deepar/module.py
+++ b/src/gluonts/torch/model/deepar/module.py
@@ -105,7 +105,7 @@ class DeepARModel(nn.Module):
         distr_output: DistributionOutput = StudentTOutput(),
         lags_seq: Optional[List[int]] = None,
         scaling: bool = True,
-        default_scale: float = 0.0,
+        default_scale: Optional[float] = None,
         num_parallel_samples: int = 100,
     ) -> None:
         super().__init__()


### PR DESCRIPTION
*Issue #, if available:* Fixes #2884

*Description of changes:* With `default_scale=0`, model training becomes highly unstable as soon as an "empty" training window is encountered, in which case the `default_scale` value is used to scale the series: this is apparent especially in case short series are in the training data, such as in the minimal README example from #2884. This PR fixes the issue by setting `default_scale=None` by default, in which case the default scale value is taken from the rest of the batch (whether this is the right thing to do is questionable, but this is a separate story). The change to `default_scale=0` in DeepAR was introduced in #2600 (later modified by #2633 and #2632), so this PR partially undoes it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup