### PR TITLE
DeepVARHierarchicalEstimator: Remove target_dim parameter.

### DIFF
--- a/docs/tutorials/forecasting/hierarchical_model_tutorial.md.template
+++ b/docs/tutorials/forecasting/hierarchical_model_tutorial.md.template
@@ -105,7 +105,6 @@ estimator = DeepVARHierarchicalEstimator(
     freq=hts.freq,
     prediction_length=prediction_length,
     trainer=Trainer(epochs=2),
-    target_dim=hts.num_ts,
     S=S,
 )
 predictor = estimator.train(dataset)
@@ -159,7 +158,6 @@ estimator = DeepVARHierarchicalEstimator(
     freq=hts.freq,
     prediction_length=prediction_length,
     trainer=Trainer(epochs=2),
-    target_dim=hts.num_ts,
     S=S,
 )
 predictor = estimator.train(dataset_train)
@@ -233,7 +231,6 @@ estimator = DeepVARHierarchicalEstimator(
     freq=hts.freq,
     prediction_length=prediction_length,
     trainer=Trainer(epochs=2),
-    target_dim=hts_train.num_ts,
     S=S,
 )
 

--- a/src/gluonts/mx/model/deepvar_hierarchical/_estimator.py
+++ b/src/gluonts/mx/model/deepvar_hierarchical/_estimator.py
@@ -226,6 +226,7 @@ class DeepVARHierarchicalEstimator(DeepVAREstimator):
         # If the method is exteneded, then these can be passed as arguments of
         # the estimator.
         rank = 0
+        target_dim = len(S)
         distr_output = LowrankMultivariateGaussianOutput(
             dim=target_dim, rank=rank
         )
@@ -239,8 +240,6 @@ class DeepVARHierarchicalEstimator(DeepVAREstimator):
                 f"since {__name__} does not work in symbolic mode."
             )
             trainer.hybridize = False
-
-        target_dim = len(S)
 
         super().__init__(
             freq=freq,

--- a/src/gluonts/mx/model/deepvar_hierarchical/_estimator.py
+++ b/src/gluonts/mx/model/deepvar_hierarchical/_estimator.py
@@ -107,9 +107,6 @@ class DeepVARHierarchicalEstimator(DeepVAREstimator):
         Frequency of the data to train on and predict
     prediction_length
         Length of the prediction horizon
-    target_dim
-        Dimensionality of the input dataset (i.e., the total number of time
-        series in the hierarchical dataset).
     S
         Summation or aggregation matrix.
     num_samples_for_loss
@@ -197,7 +194,6 @@ class DeepVARHierarchicalEstimator(DeepVAREstimator):
         self,
         freq: str,
         prediction_length: int,
-        target_dim: int,
         S: np.ndarray,
         num_samples_for_loss: int = 200,
         likelihood_weight: float = 0.0,
@@ -244,6 +240,8 @@ class DeepVARHierarchicalEstimator(DeepVAREstimator):
             )
             trainer.hybridize = False
 
+        target_dim = len(S)
+
         super().__init__(
             freq=freq,
             prediction_length=prediction_length,
@@ -270,13 +268,6 @@ class DeepVARHierarchicalEstimator(DeepVAREstimator):
             **kwargs,
         )
 
-        assert target_dim == S.shape[0], (
-            "The number of rows of `S` matrix must be equal to `target_dim`. "
-            f"Either `S` matrix is incorrectly constructed or a wrong value "
-            f"is passed for `target_dim`: shape of `S`: {S.shape} and "
-            f"`target_dim`: {target_dim}."
-        )
-
         # Assert that projection is *not* being done only during training
         assert coherent_pred_samples or (
             not coherent_train_samples
@@ -285,7 +276,8 @@ class DeepVARHierarchicalEstimator(DeepVAREstimator):
         A = constraint_mat(S.astype(self.dtype))
         M = null_space_projection_mat(A)
         ctx = self.trainer.ctx
-        self.M, self.A = mx.nd.array(M, ctx=ctx), mx.nd.array(A, ctx=ctx)
+        self.M = mx.nd.array(M, ctx=ctx)
+        self.A = mx.nd.array(A, ctx=ctx)
         self.num_samples_for_loss = num_samples_for_loss
         self.likelihood_weight = likelihood_weight
         self.CRPS_weight = CRPS_weight

--- a/test/mx/model/deepvar_hierarchical/test_deepvar_hierarchical.py
+++ b/test/mx/model/deepvar_hierarchical/test_deepvar_hierarchical.py
@@ -92,7 +92,6 @@ def test_deepvar_hierarchical(
     estimator = DeepVARHierarchicalEstimator(
         freq=train_datasets.metadata.freq,
         prediction_length=prediction_length,
-        target_dim=train_datasets.metadata.S.shape[0],
         S=train_datasets.metadata.S,
         likelihood_weight=likelihood_weight,
         CRPS_weight=CRPS_weight,

--- a/test/mx/model/deepvar_hierarchical/test_train_prediction_with_hts.py
+++ b/test/mx/model/deepvar_hierarchical/test_train_prediction_with_hts.py
@@ -79,7 +79,6 @@ def test_train_prediction(features_df: Optional[pd.DataFrame]):
         freq=hts.freq,
         prediction_length=PREDICTION_LENGTH,
         trainer=Trainer(epochs=1, num_batches_per_epoch=1, hybridize=False),
-        target_dim=hts.num_ts,
         S=hts.S,
         use_feat_dynamic_real=use_feat_dynamic_real,
     )


### PR DESCRIPTION
Since `target_dim` is the same as `S.shape[0]`, the parameter is redundant. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup