### PR TITLE
Use observation mask as feature in DeepAR

### DIFF
--- a/src/gluonts/torch/model/deepar/module.py
+++ b/src/gluonts/torch/model/deepar/module.py
@@ -227,7 +227,10 @@ class DeepARModel(nn.Module):
         observed_input = observed_context
         future_length = future_time_feat.shape[-2]
         if future_length > 1:
-            assert future_target is not None
+            assert (
+                future_target is not None
+                and future_observed_values is not None
+            )
             input = torch.cat(
                 (input, future_target[..., : future_length - 1] / scale),
                 dim=-1,

--- a/src/gluonts/torch/model/mqf2/lightning_module.py
+++ b/src/gluonts/torch/model/mqf2/lightning_module.py
@@ -96,6 +96,7 @@ class MQF2MultiHorizonLightningModule(pl.LightningModule):
         future_time_feat = batch["future_time_feat"]
         future_target = batch["future_target"]
         past_observed_values = batch["past_observed_values"]
+        future_observed_values = batch["future_observed_values"]
 
         picnn = self.model.picnn
 
@@ -107,6 +108,7 @@ class MQF2MultiHorizonLightningModule(pl.LightningModule):
             past_observed_values,
             future_time_feat,
             future_target,
+            future_observed_values,
         )
 
         hidden_state = hidden_state[:, : self.model.context_length]

--- a/test/torch/model/test_deepar_modules.py
+++ b/test/torch/model/test_deepar_modules.py
@@ -79,6 +79,7 @@ def test_deepar_modules(
         past_observed_values,
         future_time_feat,
         future_target,
+        future_observed_values,
     )
 
     assert scale.shape == (batch_size, 1)
@@ -230,6 +231,11 @@ def test_rnn_input(
         history_length + prediction_length,
         dtype=torch.float32,
     ).view(1, prediction_length)
+
+    batch["future_observed_values"] = torch.ones(
+        (1, prediction_length),
+        dtype=torch.float32,
+    )
 
     rnn_input, scale, _ = model.prepare_rnn_input(**batch)
 

--- a/test/torch/model/test_mqf2_modules.py
+++ b/test/torch/model/test_mqf2_modules.py
@@ -78,6 +78,7 @@ def test_mqf2_modules(
         past_observed_values,
         future_time_feat,
         future_target,
+        future_observed_values,
     )
 
     hidden_state = hidden_state[:, :context_length]


### PR DESCRIPTION
*Description of changes:*
This PR adds the observation mask as an input feature to DeepAR. Previously lags were fed into the model but the model had no information on whether the lag value is observed or missing/padded.

I ran a small experiment to gauge the performance with and without (previous version) the mask feature. Here are the results on the **solar** dataset averaged over 10 runs. Each model was trained for 10 epochs.

| model        |   NRMSE |     ND |   mean_wQuantileLoss |   sMAPE |   MASE |
|:-------------|--------:|-------:|---------------------:|--------:|-------:|
| with_mask (now)   |  1.0553 | 0.4896 |               0.4054 |  1.3745 | 1.1503 |
| without_mask (previous) |  1.0551 | 0.4892 |               0.4074 |  1.3741 | 1.1495 |


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup