### PR TITLE
Define `__repr__` instead of `__str__` for `PandasDataset`

### DIFF
--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -220,7 +220,7 @@ class PandasDataset:
     def __len__(self) -> int:
         return len(self._data_entries)
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         info = ", ".join(
             [
                 f"size={len(self)}",


### PR DESCRIPTION
*Description of changes:* This makes showing `PandasDataset` objects nicer, for example in notebooks when using

```
dataset
```

instead of

```
print(dataset)
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup