### PR TITLE
Add scaled quantile loss

### DIFF
--- a/src/gluonts/ev/__init__.py
+++ b/src/gluonts/ev/__init__.py
@@ -26,6 +26,7 @@ from .stats import (
 )
 from .metrics import (
     Metric,
+    MetricDefinition,
     MeanAbsoluteLabel,
     mean_absolute_label,
     SumAbsoluteLabel,
@@ -53,6 +54,7 @@ from .metrics import (
     WeightedSumQuantileLoss,
     MAECoverage,
     MeanScaledQuantileLoss,
+    AverageMeanScaledQuantileLoss,
     MeanSumQuantileLoss,
     MeanWeightedSumQuantileLoss,
     OWA,
@@ -74,6 +76,7 @@ __all__ = [
     "scaled_interval_score",
     "absolute_scaled_error",
     "Metric",
+    "MetricDefinition",
     "MeanAbsoluteLabel",
     "mean_absolute_label",
     "SumAbsoluteLabel",
@@ -101,6 +104,7 @@ __all__ = [
     "WeightedSumQuantileLoss",
     "MAECoverage",
     "MeanScaledQuantileLoss",
+    "AverageMeanScaledQuantileLoss",
     "MeanSumQuantileLoss",
     "MeanWeightedSumQuantileLoss",
     "OWA",

--- a/src/gluonts/ev/__init__.py
+++ b/src/gluonts/ev/__init__.py
@@ -100,6 +100,7 @@ __all__ = [
     "nrmse",
     "WeightedSumQuantileLoss",
     "MAECoverage",
+    "MeanScaledQuantileLoss",
     "MeanSumQuantileLoss",
     "MeanWeightedSumQuantileLoss",
     "OWA",

--- a/src/gluonts/ev/__init__.py
+++ b/src/gluonts/ev/__init__.py
@@ -52,6 +52,7 @@ from .metrics import (
     nrmse,
     WeightedSumQuantileLoss,
     MAECoverage,
+    MeanScaledQuantileLoss,
     MeanSumQuantileLoss,
     MeanWeightedSumQuantileLoss,
     OWA,

--- a/src/gluonts/ev/__init__.py
+++ b/src/gluonts/ev/__init__.py
@@ -23,6 +23,7 @@ from .stats import (
     symmetric_absolute_percentage_error,
     scaled_interval_score,
     absolute_scaled_error,
+    scaled_quantile_loss,
 )
 from .metrics import (
     Metric,
@@ -75,6 +76,7 @@ __all__ = [
     "symmetric_absolute_percentage_error",
     "scaled_interval_score",
     "absolute_scaled_error",
+    "scaled_quantile_loss",
     "Metric",
     "MetricDefinition",
     "MeanAbsoluteLabel",

--- a/src/gluonts/ev/metrics.py
+++ b/src/gluonts/ev/metrics.py
@@ -38,6 +38,7 @@ from .stats import (
     coverage,
     quantile_loss,
     scaled_interval_score,
+    scaled_quantile_loss,
     squared_error,
     symmetric_absolute_percentage_error,
 )
@@ -332,6 +333,20 @@ class MASE(BaseMetricDefinition):
 
 
 mase = MASE()
+
+
+@dataclass
+class MeanScaledQuantileLoss(BaseMetricDefinition):
+    q: float
+
+    def __call__(self, axis: Optional[int] = None) -> DirectMetric:
+        return DirectMetric(
+            name=f"mean_scaled_quantile_loss[{self.q}]",
+            stat=partial(
+                scaled_quantile_loss, forecast_type=self.forecast_type
+            ),
+            aggregate=Mean(axis=axis),
+        )
 
 
 @dataclass

--- a/src/gluonts/ev/metrics.py
+++ b/src/gluonts/ev/metrics.py
@@ -509,7 +509,7 @@ class AverageMeanScaledQuantileLoss(BaseMetricDefinition):
 
     def __call__(self, axis: Optional[int] = None) -> DerivedMetric:
         return DerivedMetric(
-            name=f"average_mean_scaled_quantile_loss",
+            name="average_mean_scaled_quantile_loss",
             metrics={
                 f"mean_scaled_quantile_loss[{q}]": MeanScaledQuantileLoss(q=q)(
                     axis=axis

--- a/src/gluonts/ev/metrics.py
+++ b/src/gluonts/ev/metrics.py
@@ -342,9 +342,7 @@ class MeanScaledQuantileLoss(BaseMetricDefinition):
     def __call__(self, axis: Optional[int] = None) -> DirectMetric:
         return DirectMetric(
             name=f"mean_scaled_quantile_loss[{self.q}]",
-            stat=partial(
-                scaled_quantile_loss, forecast_type=self.forecast_type
-            ),
+            stat=partial(scaled_quantile_loss, q=self.q),
             aggregate=Mean(axis=axis),
         )
 

--- a/src/gluonts/ev/metrics.py
+++ b/src/gluonts/ev/metrics.py
@@ -496,6 +496,31 @@ class MeanWeightedSumQuantileLoss(BaseMetricDefinition):
 
 
 @dataclass
+class AverageMeanScaledQuantileLoss(BaseMetricDefinition):
+    quantile_levels: Collection[float]
+
+    @staticmethod
+    def mean(**quantile_losses: np.ndarray) -> np.ndarray:
+        stacked_quantile_losses = np.stack(
+            [quantile_loss for quantile_loss in quantile_losses.values()],
+            axis=0,
+        )
+        return np.ma.mean(stacked_quantile_losses, axis=0)
+
+    def __call__(self, axis: Optional[int] = None) -> DerivedMetric:
+        return DerivedMetric(
+            name=f"average_mean_scaled_quantile_loss",
+            metrics={
+                f"mean_scaled_quantile_loss[{q}]": MeanScaledQuantileLoss(q=q)(
+                    axis=axis
+                )
+                for q in self.quantile_levels
+            },
+            post_process=self.mean,
+        )
+
+
+@dataclass
 class MAECoverage(BaseMetricDefinition):
     quantile_levels: Collection[float]
 

--- a/src/gluonts/ev/stats.py
+++ b/src/gluonts/ev/stats.py
@@ -87,3 +87,7 @@ def absolute_scaled_error(
     data: Dict[str, np.ndarray], forecast_type: str
 ) -> np.ndarray:
     return absolute_error(data, forecast_type) / data["seasonal_error"]
+
+
+def scaled_quantile_loss(data: Dict[str, np.ndarray], q: float) -> np.ndarray:
+    return quantile_loss(data, q) / data["seasonal_error"]

--- a/test/ev/test_stats.py
+++ b/test/ev/test_stats.py
@@ -24,6 +24,7 @@ from gluonts.ev import (
     symmetric_absolute_percentage_error,
     scaled_interval_score,
     absolute_scaled_error,
+    scaled_quantile_loss,
     seasonal_error,
 )
 
@@ -190,5 +191,28 @@ def test_absolute_scaled_error():
 
             actual = absolute_scaled_error(data, forecast_type="0.5")
             expected = np.abs(label - forecast) / seasonal_err
+
+            np.testing.assert_almost_equal(actual, expected)
+
+
+def test_scaled_quantile_loss():
+    for label in TIME_SERIES:
+        for forecast in TIME_SERIES:
+            # applying `seasonal_error` on the label is not realistic but
+            # at least, the seasonal error function gets used this way
+            seasonal_err = seasonal_error(label, seasonality=2)
+            data = {
+                "label": label,
+                "0.9": forecast,
+                "seasonal_error": seasonal_err,
+            }
+
+            actual = scaled_quantile_loss(data, 0.9)
+            expected = (
+                2
+                * (label - forecast)
+                * (0.9 - (label < forecast))
+                / seasonal_err
+            )
 
             np.testing.assert_almost_equal(actual, expected)

--- a/test/model/test_evaluation.py
+++ b/test/model/test_evaluation.py
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from typing import Union, Tuple
+from typing import List, Tuple, Union
 
 import numpy as np
 import pytest
@@ -26,6 +26,7 @@ from gluonts.model import (
     evaluate_model,
 )
 from gluonts.ev import (
+    MetricDefinition,
     MSE,
     RMSE,
     NRMSE,
@@ -34,7 +35,10 @@ from gluonts.ev import (
     MASE,
     MSIS,
     ND,
+    WeightedSumQuantileLoss,
     MeanWeightedSumQuantileLoss,
+    MeanScaledQuantileLoss,
+    AverageMeanScaledQuantileLoss,
 )
 
 
@@ -65,12 +69,15 @@ _test_metrics = [
     MASE(),
     MSIS(),
     ND(),
+    WeightedSumQuantileLoss(0.5),
     MeanWeightedSumQuantileLoss(quantile_levels=[0.1, 0.5, 0.9]),
+    MeanScaledQuantileLoss(0.5),
+    AverageMeanScaledQuantileLoss(quantile_levels=[0.1, 0.5, 0.9]),
 ]
 
 
 def infer_metrics_df_shape(
-    metrics,
+    metrics: List[MetricDefinition],
     test_data: TestData,
     axis: Union[int, Tuple[int]],
 ) -> Tuple[int]:
@@ -164,7 +171,7 @@ def infer_metrics_df_shape(
     ],
 )
 def test_evaluation_shape(
-    metrics,
+    metrics: List[MetricDefinition],
     test_data: TestData,
     axis: Union[int, Tuple[int]],
 ):


### PR DESCRIPTION
*Description of changes:* Add scaled quantile loss, also known as scaled pinball loss, which is used for example in the M5 competition https://mofc.unic.ac.cy/m5-competition/. This just scales the quantile loss by the average naive error, similar to MASE.

$$
sQL_\alpha(\hat y, y, x) = \frac{
    QL_\alpha(\hat y, y)
}{
    \tfrac{1}{T-S} \sum_{S < t \leq T} |x_{t} - x_{t-S}|
}
$$

where $S$ is the number of seasons ($S=1$ gives the MAE of the naive forecaster in the denominator). This is aggregated via mean over the prediction length and/or dataset dimension. Reduces to MASE when the quantile level is 0.5.

I went for "quantile" instead of "pinball" for consistency with other metrics we have. Naming is not ideal, especially when we want to average over multiple quantile levels (`AverageMeanScaledQuantileLoss`), I'm open to suggestions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup