### PR TITLE
add num_evaluations to metrics

### DIFF
--- a/src/gluonts/ev/__init__.py
+++ b/src/gluonts/ev/__init__.py
@@ -62,6 +62,7 @@ from .metrics import (
     OWA,
     owa,
     SumNumMaskedTargetValues,
+    sum_num_masked_target_values,
 )
 from .aggregations import Aggregation, Sum, Mean
 
@@ -117,7 +118,7 @@ __all__ = [
     "Sum",
     "Mean",
     "SumNumMaskedTargetValues",
-    "num_masked_target_values"
+    "num_masked_target_values",
 ]
 
 

--- a/src/gluonts/ev/__init__.py
+++ b/src/gluonts/ev/__init__.py
@@ -24,6 +24,7 @@ from .stats import (
     scaled_interval_score,
     absolute_scaled_error,
     scaled_quantile_loss,
+    num_masked_target_values,
 )
 from .metrics import (
     Metric,
@@ -60,6 +61,7 @@ from .metrics import (
     MeanWeightedSumQuantileLoss,
     OWA,
     owa,
+    SumNumMaskedTargetValues,
 )
 from .aggregations import Aggregation, Sum, Mean
 
@@ -114,6 +116,8 @@ __all__ = [
     "Aggregation",
     "Sum",
     "Mean",
+    "SumNumMaskedTargetValues",
+    "num_masked_target_values"
 ]
 
 

--- a/src/gluonts/ev/__init__.py
+++ b/src/gluonts/ev/__init__.py
@@ -118,7 +118,7 @@ __all__ = [
     "Sum",
     "Mean",
     "SumNumMaskedTargetValues",
-    "num_masked_target_values",
+    "sum_num_masked_target_values",
 ]
 
 

--- a/src/gluonts/ev/__init__.py
+++ b/src/gluonts/ev/__init__.py
@@ -80,6 +80,7 @@ __all__ = [
     "scaled_interval_score",
     "absolute_scaled_error",
     "scaled_quantile_loss",
+    "num_masked_target_values",
     "Metric",
     "MetricDefinition",
     "MeanAbsoluteLabel",

--- a/src/gluonts/ev/metrics.py
+++ b/src/gluonts/ev/metrics.py
@@ -41,6 +41,7 @@ from .stats import (
     scaled_quantile_loss,
     squared_error,
     symmetric_absolute_percentage_error,
+    num_masked_target_values,
 )
 
 
@@ -187,6 +188,18 @@ class SumAbsoluteLabel(BaseMetricDefinition):
 
 
 sum_absolute_label = SumAbsoluteLabel()
+
+
+class SumNumMaskedTargetValues(BaseMetricDefinition):
+    def __call__(self, axis: Optional[int] = None) -> DirectMetric:
+        return DirectMetric(
+            name="sum_num_masked_target_values",
+            stat=num_masked_target_values,
+            aggregate=Sum(axis=axis),
+        )
+
+
+sum_num_masked_target_values = SumNumMaskedTargetValues()
 
 
 @dataclass

--- a/src/gluonts/ev/stats.py
+++ b/src/gluonts/ev/stats.py
@@ -16,6 +16,13 @@ from typing import Dict
 import numpy as np
 
 
+def num_masked_target_values(data: Dict[str, np.ndarray]) -> np.ndarray:
+    if np.ma.isMaskedArray(data["label"]):
+        return data["label"].mask.astype(float)
+    else:
+        return np.zeros(data["label"].shape)
+
+
 def absolute_label(data: Dict[str, np.ndarray]) -> np.ndarray:
     return np.abs(data["label"])
 

--- a/src/gluonts/evaluation/_base.py
+++ b/src/gluonts/evaluation/_base.py
@@ -48,6 +48,7 @@ from .metrics import (
     msis,
     quantile_loss,
     smape,
+    num_masked_values,
 )
 
 
@@ -386,7 +387,7 @@ class Evaluator:
             "MASE": mase(pred_target, median_fcst, seasonal_error),
             "MAPE": mape(pred_target, median_fcst),
             "sMAPE": smape(pred_target, median_fcst),
-            "num_evaluations": pred_target.count(),
+            "num_masked_target_values": num_masked_values(pred_target),
         }
 
     def get_metrics_per_ts(
@@ -499,7 +500,7 @@ class Evaluator:
             "MAPE": "mean",
             "sMAPE": "mean",
             "MSIS": "mean",
-            "num_evaluations": "sum",
+            "num_masked_target_values": "sum",
         }
         if self.calculate_owa:
             agg_funs["sMAPE_naive2"] = "mean"

--- a/src/gluonts/evaluation/_base.py
+++ b/src/gluonts/evaluation/_base.py
@@ -386,6 +386,7 @@ class Evaluator:
             "MASE": mase(pred_target, median_fcst, seasonal_error),
             "MAPE": mape(pred_target, median_fcst),
             "sMAPE": smape(pred_target, median_fcst),
+            "num_evaluations": pred_target.count(),
         }
 
     def get_metrics_per_ts(
@@ -498,6 +499,7 @@ class Evaluator:
             "MAPE": "mean",
             "sMAPE": "mean",
             "MSIS": "mean",
+            "num_evaluations": "sum",
         }
         if self.calculate_owa:
             agg_funs["sMAPE_naive2"] = "mean"

--- a/src/gluonts/evaluation/metrics.py
+++ b/src/gluonts/evaluation/metrics.py
@@ -170,3 +170,13 @@ def abs_target_mean(target) -> float:
         abs\_target\_mean = mean(|Y|)
     """
     return np.mean(np.abs(target))
+
+
+def num_masked_values(target) -> float:
+    """
+    Count number of masked values in target
+    """
+    if np.ma.isMaskedArray(target):
+        return np.ma.count_masked(target)
+    else:
+        return 0


### PR DESCRIPTION
*Description of changes:*

We add `num_evaluations` as a metric to know how many timestamps are evaluated. This helps to identify the amount of missing values when evaluating the given forecasts.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup