### PR TITLE
Add data_path to env.

### DIFF
--- a/src/gluonts/env.py
+++ b/src/gluonts/env.py
@@ -13,8 +13,19 @@
 
 
 import os
+from pathlib import Path
 
 from .core.settings import Settings
+
+
+# see: https://wiki.archlinux.org/title/XDG_Base_Directory
+if "GLUONTS_DATA" in os.environ:
+    data_path = Path(os.environ["GLUONTS_DATA"]).expanduser()
+else:
+    data_path = (
+        Path(os.environ.get("XDG_DATA_HOME", "~/.local/share")).expanduser()
+        / "gluonts"
+    )
 
 
 class Environment(Settings):
@@ -28,6 +39,15 @@ class Environment(Settings):
 
     # we want to be able to disable TQDM, for example when running in sagemaker
     use_tqdm: bool = True
+
+    data_path: Path = data_path
+
+    def get_data_path(self, create: bool = True) -> Path:
+        path = self.data_path
+        if not path.exists():
+            path.mkdir(parents=True, exist_ok=True)
+
+        return path
 
 
 env = Environment()


### PR DESCRIPTION
Add a standard location to store data related to GluonTS. Add `GLUONTS_DATA` as an environment variable to set the location directly, but this defaults to `$XDG_DATA_HOME/gluonts` and if that not exists, `~/.local/share/gluonts`.

This ensures that we store data in a (somewhat) standardized location.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup