### PR TITLE
Docs: fix missing values use-case in tutorial for `PandasDataset`

### DIFF
--- a/docs/tutorials/data_manipulation/pandasdataframes.md.template
+++ b/docs/tutorials/data_manipulation/pandasdataframes.md.template
@@ -124,7 +124,7 @@ from gluonts.dataset.pandas import PandasDataset
 max_end = max(df.groupby("item_id").apply(lambda _df: _df.index[-1]))
 dfs_dict = {}
 for item_id, gdf in df_missing_val.groupby("item_id"):
-    new_index = pd.date_range(gdf.index[0], end=max_end, freq="1D")
+    new_index = pd.date_range(gdf.index[0], end=max_end, freq="1H")
     dfs_dict[item_id] = gdf.reindex(new_index).drop("item_id", axis=1)
 
 ds = PandasDataset(dfs_dict, target="target")

--- a/docs/tutorials/data_manipulation/pandasdataframes.md.template
+++ b/docs/tutorials/data_manipulation/pandasdataframes.md.template
@@ -123,7 +123,7 @@ from gluonts.dataset.pandas import PandasDataset
 
 max_end = max(df.groupby("item_id").apply(lambda _df: _df.index[-1]))
 dfs_dict = {}
-for item_id, gdf in df.groupby("item_id"):
+for item_id, gdf in df_missing_val.groupby("item_id"):
     new_index = pd.date_range(gdf.index[0], end=max_end, freq="1D")
     dfs_dict[item_id] = gdf.reindex(new_index).drop("item_id", axis=1)
 


### PR DESCRIPTION
The reindexing of the grouped dataframes is being performed on the original dataframe. It should be preformed on the dataframe where rows were removed, df_missing_val.


The freq of pd.date_range on line 127 is also set to "1D" instead of "1H" as in the original dataframe.

*Description of changes: Update pandasdataframes.md.template

