### PR TITLE
[Docs] fix link to NPTS implementation

### DIFF
--- a/docs/getting_started/models.md
+++ b/docs/getting_started/models.md
@@ -79,4 +79,4 @@ NPTS                                                         | Local        | Un
 [Prophet]: https://github.com/awslabs/gluonts/blob/dev/src/gluonts/ext/prophet/_predictor.py
 [NaiveSeasonal]: https://github.com/awslabs/gluonts/blob/dev/src/gluonts/model/seasonal_naive/_predictor.py
 [Naive2]: https://github.com/awslabs/gluonts/blob/dev/src/gluonts/ext/naive_2/_predictor.py
-[NPTS]: https://github.com/awslabs/gluonts/blob/dev/src/gluonts/ext/npts/_predictor.py
+[NPTS]: https://github.com/awslabs/gluonts/blob/dev/src/gluonts/model/npts/_predictor.py


### PR DESCRIPTION
*Description of changes:* Link was broken
- old link https://github.com/awslabs/gluonts/blob/dev/src/gluonts/ext/npts/_predictor.py
- new link https://github.com/awslabs/gluonts/blob/dev/src/gluonts/model/npts/_predictor.py


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup