### PR TITLE
Nonnegative predictions for deepar-pytorch

### DIFF
--- a/src/gluonts/torch/model/deepar/estimator.py
+++ b/src/gluonts/torch/model/deepar/estimator.py
@@ -144,6 +144,10 @@ class DeepAREstimator(PyTorchLightningEstimator):
         Controls the sampling of windows during training.
     validation_sampler
         Controls the sampling of windows during validation.
+    nonnegative_pred_samples
+        Should final prediction samples be non-negative? If yes, an activation
+        function is applied to ensure non-negative. Observe that this is applied
+        only to the final samples and this is not applied during training.
     """
 
     @validated()
@@ -176,6 +180,7 @@ class DeepAREstimator(PyTorchLightningEstimator):
         trainer_kwargs: Optional[Dict[str, Any]] = None,
         train_sampler: Optional[InstanceSampler] = None,
         validation_sampler: Optional[InstanceSampler] = None,
+        nonnegative_pred_samples: bool = False,
     ) -> None:
         default_trainer_kwargs = {
             "max_epochs": 100,
@@ -230,6 +235,7 @@ class DeepAREstimator(PyTorchLightningEstimator):
         self.validation_sampler = validation_sampler or ValidationSplitSampler(
             min_future=prediction_length
         )
+        self.nonnegative_pred_samples = nonnegative_pred_samples
 
     @classmethod
     def derive_auto_fields(cls, train_iter):
@@ -397,6 +403,7 @@ class DeepAREstimator(PyTorchLightningEstimator):
                 "scaling": self.scaling,
                 "default_scale": self.default_scale,
                 "num_parallel_samples": self.num_parallel_samples,
+                "nonnegative_pred_samples": self.nonnegative_pred_samples,
             },
         )
 

--- a/src/gluonts/torch/model/deepar/module.py
+++ b/src/gluonts/torch/model/deepar/module.py
@@ -363,10 +363,10 @@ class DeepARModel(nn.Module):
         Parameters
         ----------
         samples
-            Tensor of shape (batch_size * num_samples, 1)
+            Tensor of samples
         Returns
         -------
-            Tensor of samples with the same shape.
+            Tensor of processed samples with the same shape.
         """
 
         if self.nonnegative_pred_samples:
@@ -478,12 +478,6 @@ class DeepARModel(nn.Module):
         future_samples_concat = self.post_process_samples(
             future_samples_concat
         )
-        print(1)
-
-        print(f"self.training: {self.training}")
-
-        if not self.training:
-            print(1)
 
         return future_samples_concat.reshape(
             (-1, num_parallel_samples, self.prediction_length)

--- a/test/torch/model/test_deepar_nonnegative_pred_samples.py
+++ b/test/torch/model/test_deepar_nonnegative_pred_samples.py
@@ -1,0 +1,42 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import pytest
+
+from gluonts.torch import DeepAREstimator
+from gluonts.torch.distributions import StudentTOutput, NormalOutput
+from gluonts.testutil.dummy_datasets import make_dummy_datasets_with_features
+
+
+@pytest.mark.parametrize("datasets", [make_dummy_datasets_with_features()])
+@pytest.mark.parametrize("distr_output", [StudentTOutput(), NormalOutput()])
+def test_deepar_nonnegative_pred_samples(
+    distr_output,
+    datasets,
+):
+    estimator = DeepAREstimator(
+        distr_output=distr_output,
+        nonnegative_pred_samples=True,
+        freq="D",
+        prediction_length=3,
+        trainer_kwargs={"max_epochs": 1},
+    )
+
+    dataset_train, dataset_test = datasets
+    predictor = estimator.train(dataset_train)
+    forecasts = list(predictor.predict(dataset_test))
+
+    assert len(forecasts) == len(dataset_test)
+
+    for forecast in forecasts:
+        assert (forecast.samples >= 0).all()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add functionality to generate nonnegative prediction samples for DeepAR-pytorch. This is applied only to final samples for prediction.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup