### PR TITLE
[Hierarchical] Allow computing projection based on a non-Euclidean norm

### DIFF
--- a/src/gluonts/mx/model/deepvar_hierarchical/_estimator.py
+++ b/src/gluonts/mx/model/deepvar_hierarchical/_estimator.py
@@ -86,7 +86,8 @@ def null_space_projection_mat(
         The constraint matrix A in the equation: Ay = 0 (y being the
         values/forecasts of all time series in the hierarchy).
     D
-        Positive definite matrix (typically a diagonal matrix). Optional.
+        Symmetric positive definite matrix (typically a diagonal matrix).
+        Optional.
         If provided then the distance between the reconciled and unreconciled
         forecasts is calculated based on the norm induced by D. Useful for
         weighing the distances differently for each level of the hierarchy.
@@ -101,9 +102,11 @@ def null_space_projection_mat(
     if D is None:
         return np.eye(num_ts) - A.T @ np.linalg.pinv(A @ A.T) @ A
     else:
+        assert np.all(D == D.T), "`D` must be symmetric."
         assert np.all(
             np.linalg.eigvals(D) > 0
         ), "`D` must be positive definite."
+
         D_inv = np.linalg.inv(D)
         return (
             np.eye(num_ts) - D_inv @ A.T @ np.linalg.pinv(A @ D_inv @ A.T) @ A

--- a/src/gluonts/mx/model/deepvar_hierarchical/_estimator.py
+++ b/src/gluonts/mx/model/deepvar_hierarchical/_estimator.py
@@ -124,6 +124,12 @@ class DeepVARHierarchicalEstimator(DeepVAREstimator):
         Length of the prediction horizon
     S
         Summation or aggregation matrix.
+    D
+        Positive definite matrix (typically a diagonal matrix). Optional.
+        If provided then the distance between the reconciled and unreconciled
+        forecasts is calculated based on the norm induced by D. Useful for
+        weighing the distances differently for each level of the hierarchy.
+        By default Euclidean distance is used.
     num_samples_for_loss
         Number of samples to draw from the predicted distribution to compute
         the training loss.
@@ -210,6 +216,7 @@ class DeepVARHierarchicalEstimator(DeepVAREstimator):
         freq: str,
         prediction_length: int,
         S: np.ndarray,
+        D: Optional[np.ndarray] = None,
         num_samples_for_loss: int = 200,
         likelihood_weight: float = 0.0,
         CRPS_weight: float = 1.0,
@@ -288,7 +295,7 @@ class DeepVARHierarchicalEstimator(DeepVAREstimator):
         ), "Cannot project only during training (and not during prediction)"
 
         A = constraint_mat(S.astype(self.dtype))
-        M = null_space_projection_mat(A)
+        M = null_space_projection_mat(A=A, D=D)
         ctx = self.trainer.ctx
         self.M = mx.nd.array(M, ctx=ctx)
         self.A = mx.nd.array(A, ctx=ctx)

--- a/src/gluonts/mx/model/deepvar_hierarchical/_estimator.py
+++ b/src/gluonts/mx/model/deepvar_hierarchical/_estimator.py
@@ -101,6 +101,9 @@ def null_space_projection_mat(
     if D is None:
         return np.eye(num_ts) - A.T @ np.linalg.pinv(A @ A.T) @ A
     else:
+        assert np.all(
+            np.linalg.eigvals(D) > 0
+        ), "`D` must be positive definite."
         D_inv = np.linalg.inv(D)
         return (
             np.eye(num_ts) - D_inv @ A.T @ np.linalg.pinv(A @ D_inv @ A.T) @ A

--- a/src/gluonts/mx/model/deepvar_hierarchical/_estimator.py
+++ b/src/gluonts/mx/model/deepvar_hierarchical/_estimator.py
@@ -75,7 +75,7 @@ def constraint_mat(S: np.ndarray) -> np.ndarray:
 
 def null_space_projection_mat(
     A: np.ndarray,
-    D: Optional[np.ndarray],
+    D: Optional[np.ndarray] = None,
 ) -> np.ndarray:
     """
     Computes the projection matrix for projecting onto the null space of A.
@@ -88,9 +88,9 @@ def null_space_projection_mat(
     D
         Positive definite matrix (typically a diagonal matrix). Optional.
         If provided then the distance between the reconciled and unreconciled
-        forecasts is calculated based on the norm induced by D. Useful for 
-        weighing the distances differently for each level of the hierarchy. 
-        By default Euclidean distance is used. 
+        forecasts is calculated based on the norm induced by D. Useful for
+        weighing the distances differently for each level of the hierarchy.
+        By default Euclidean distance is used.
 
     Returns
     -------
@@ -102,7 +102,10 @@ def null_space_projection_mat(
         return np.eye(num_ts) - A.T @ np.linalg.pinv(A @ A.T) @ A
     else:
         D_inv = np.linalg.inv(D)
-        return np.eye(num_ts) - D_inv @ A.T @ np.linalg.pinv(A @ D_inv @ A.T) @ A
+        return (
+            np.eye(num_ts) - D_inv @ A.T @ np.linalg.pinv(A @ D_inv @ A.T) @ A
+        )
+
 
 class DeepVARHierarchicalEstimator(DeepVAREstimator):
     """

--- a/test/mx/model/deepvar_hierarchical/test_reconcile_samples.py
+++ b/test/mx/model/deepvar_hierarchical/test_reconcile_samples.py
@@ -58,20 +58,15 @@ A = constraint_mat(S)
         None,
         # Root gets the maximum weight and the two aggregated levels get
         # more weight than the leaf level.
-        np.diag(
-            [4, 2, 2, 1, 1, 1, 1]
-        ),
+        np.diag([4, 2, 2, 1, 1, 1, 1]),
         # Random diagonal matrix
-        np.diag(
-            np.random.rand(S.shape[0])
-        ),
+        np.diag(np.random.rand(S.shape[0])),
         # Random positive definite matrix
-        np.diag(
-            np.random.rand(S.shape[0])
-        ) + np.dot(
+        np.diag(np.random.rand(S.shape[0]))
+        + np.dot(
             np.array([[4, 2, 2, 1, 1, 1, 1]]).T,
-            np.array([[4, 2, 2, 1, 1, 1, 1]])
-        )
+            np.array([[4, 2, 2, 1, 1, 1, 1]]),
+        ),
     ],
 )
 @pytest.mark.parametrize(

--- a/test/mx/model/deepvar_hierarchical/test_reconcile_samples.py
+++ b/test/mx/model/deepvar_hierarchical/test_reconcile_samples.py
@@ -38,7 +38,6 @@ S = np.array(
 
 num_bottom_ts = S.shape[1]
 A = constraint_mat(S)
-reconciliation_mat = null_space_projection_mat(A)
 
 
 @pytest.mark.parametrize(
@@ -54,6 +53,28 @@ reconciliation_mat = null_space_projection_mat(A)
     ],
 )
 @pytest.mark.parametrize(
+    "D",
+    [
+        None,
+        # Root gets the maximum weight and the two aggregated levels get
+        # more weight than the leaf level.
+        np.diag(
+            [4, 2, 2, 1, 1, 1, 1]
+        ),
+        # Random diagonal matrix
+        np.diag(
+            np.random.rand(S.shape[0])
+        ),
+        # Random positive definite matrix
+        np.diag(
+            np.random.rand(S.shape[0])
+        ) + np.dot(
+            np.array([[4, 2, 2, 1, 1, 1, 1]]).T,
+            np.array([[4, 2, 2, 1, 1, 1, 1]])
+        )
+    ],
+)
+@pytest.mark.parametrize(
     "seq_axis",
     [
         None,
@@ -63,9 +84,9 @@ reconciliation_mat = null_space_projection_mat(A)
         [1, 0],
     ],
 )
-def test_reconciliation_error(samples, seq_axis):
+def test_reconciliation_error(samples, D, seq_axis):
     coherent_samples = reconcile_samples(
-        reconciliation_mat=mx.nd.array(reconciliation_mat),
+        reconciliation_mat=mx.nd.array(null_space_projection_mat(A=A, D=D)),
         samples=mx.nd.array(samples),
         seq_axis=seq_axis,
     )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently the forecasts are reconciled by projecting them on to the feasible set based on the Euclidean norm. Sometimes it is desirable to weigh the distances (errors) between the unreconciled and reconciled forecasts differently for each level (because there are more number of terms for the bottom level compared to the top level).

This PR adds an option to provide such weights via a diagonal matrix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup