### PR TITLE
[Hierarchical] Simplify computation of projection matrix using the standard summation matrix

### DIFF
--- a/src/gluonts/mx/model/deepvar_hierarchical/__init__.py
+++ b/src/gluonts/mx/model/deepvar_hierarchical/__init__.py
@@ -14,7 +14,7 @@
 # Relative imports
 from ._estimator import (
     constraint_mat,
-    null_space_projection_mat,
+    projection_mat,
     DeepVARHierarchicalEstimator,
 )
 from ._network import reconcile_samples, coherency_error
@@ -22,7 +22,7 @@ from ._network import reconcile_samples, coherency_error
 __all__ = [
     "DeepVARHierarchicalEstimator",
     "constraint_mat",
-    "null_space_projection_mat",
+    "projection_mat",
     "reconcile_samples",
     "coherency_error",
 ]

--- a/src/gluonts/mx/model/deepvar_hierarchical/_estimator.py
+++ b/src/gluonts/mx/model/deepvar_hierarchical/_estimator.py
@@ -73,8 +73,8 @@ def constraint_mat(S: np.ndarray) -> np.ndarray:
     return A
 
 
-def null_space_projection_mat(
-    A: np.ndarray,
+def projection_mat(
+    S: np.ndarray,
     D: Optional[np.ndarray] = None,
 ) -> np.ndarray:
     """
@@ -82,11 +82,12 @@ def null_space_projection_mat(
 
     Parameters
     ----------
-    A
-        The constraint matrix A in the equation: Ay = 0 (y being the
-        values/forecasts of all time series in the hierarchy).
+    S
+        The summation or the aggregation matrix. Shape:
+        (total_num_time_series, num_bottom_time_series)
     D
         Symmetric positive definite matrix (typically a diagonal matrix).
+        Shape: (total_num_time_series, total_num_time_series)
         Optional.
         If provided then the distance between the reconciled and unreconciled
         forecasts is calculated based on the norm induced by D. Useful for
@@ -98,9 +99,8 @@ def null_space_projection_mat(
     Numpy ND array
         Projection matrix, shape (total_num_time_series, total_num_time_series)
     """
-    num_ts = A.shape[1]
     if D is None:
-        return np.eye(num_ts) - A.T @ np.linalg.pinv(A @ A.T) @ A
+        return S @ np.linalg.pinv(S.T @ S) @ S.T
     else:
         assert np.all(D == D.T), "`D` must be symmetric."
         assert np.all(
@@ -109,7 +109,7 @@ def null_space_projection_mat(
 
         D_inv = np.linalg.inv(D)
         return (
-            np.eye(num_ts) - D_inv @ A.T @ np.linalg.pinv(A @ D_inv @ A.T) @ A
+            S @ np.linalg.pinv(S.T @ D @ S) @ S.T @ D
         )
 
 
@@ -301,7 +301,7 @@ class DeepVARHierarchicalEstimator(DeepVAREstimator):
         ), "Cannot project only during training (and not during prediction)"
 
         A = constraint_mat(S.astype(self.dtype))
-        M = null_space_projection_mat(A=A, D=D)
+        M = projection_mat(S=S, D=D)
         ctx = self.trainer.ctx
         self.M = mx.nd.array(M, ctx=ctx)
         self.A = mx.nd.array(A, ctx=ctx)

--- a/src/gluonts/mx/model/deepvar_hierarchical/_estimator.py
+++ b/src/gluonts/mx/model/deepvar_hierarchical/_estimator.py
@@ -77,8 +77,15 @@ def projection_mat(
     S: np.ndarray,
     D: Optional[np.ndarray] = None,
 ) -> np.ndarray:
-    """
-    Computes the projection matrix for projecting onto the null space of A.
+    r"""
+    Computes the projection matrix :math: P for projecting base forecasts
+    :math: \bar{y} on to the space of coherent forecasts: :math: P \bar{y}.
+
+    More precisely,
+
+    .. math::
+        P = S (S^T S)^{-1} S^T,      if D is None,\\
+        P = S (S^T D S)^{-1} S^TD,   otherwise.
 
     Parameters
     ----------

--- a/src/gluonts/mx/model/deepvar_hierarchical/_estimator.py
+++ b/src/gluonts/mx/model/deepvar_hierarchical/_estimator.py
@@ -107,10 +107,7 @@ def projection_mat(
             np.linalg.eigvals(D) > 0
         ), "`D` must be positive definite."
 
-        D_inv = np.linalg.inv(D)
-        return (
-            S @ np.linalg.pinv(S.T @ D @ S) @ S.T @ D
-        )
+        return S @ np.linalg.pinv(S.T @ D @ S) @ S.T @ D
 
 
 class DeepVARHierarchicalEstimator(DeepVAREstimator):

--- a/src/gluonts/nursery/temporal_hierarchical_forecasting/model/cop_deepar/_network.py
+++ b/src/gluonts/nursery/temporal_hierarchical_forecasting/model/cop_deepar/_network.py
@@ -22,7 +22,7 @@ from gluonts.mx.model.deepar import DeepAREstimator
 from gluonts.mx.model.deepar._network import DeepARPredictionNetwork
 from gluonts.mx.model.deepvar_hierarchical._estimator import (
     constraint_mat,
-    null_space_projection_mat,
+    projection_mat,
 )
 from gluonts.mx.model.deepvar_hierarchical._network import coherency_error
 from gluonts.mx.distribution import Distribution, EmpiricalDistribution
@@ -97,7 +97,7 @@ class COPNetwork(mx.gluon.HybridBlock):
                 self.temporal_hierarchy.agg_mat, self.temporal_hierarchy.nodes
             )
         else:
-            M = null_space_projection_mat(A)
+            M = projection_mat(S=self.temporal_hierarchy.agg_mat)
         self.M, self.A = mx.nd.array(M), mx.nd.array(A)
 
         self.estimators = estimators

--- a/test/mx/model/deepvar_hierarchical/test_projection.py
+++ b/test/mx/model/deepvar_hierarchical/test_projection.py
@@ -1,0 +1,90 @@
+from typing import Optional
+
+import numpy as np
+import pytest
+
+from gluonts.mx.model.deepvar_hierarchical._estimator import (
+    constraint_mat,
+    projection_mat,
+)
+
+
+TOL = 1e-12
+
+S = np.array(
+    [
+        [1, 1, 1, 1],
+        [1, 1, 0, 0],
+        [0, 0, 1, 1],
+        [1, 0, 0, 0],
+        [0, 1, 0, 0],
+        [0, 0, 1, 0],
+        [0, 0, 0, 1],
+    ],
+)
+
+num_bottom_ts = S.shape[1]
+A = constraint_mat(S)
+
+
+def null_space_projection_mat(
+    A: np.ndarray,
+    D: Optional[np.ndarray] = None,
+) -> np.ndarray:
+    """
+    Computes the projection matrix for projecting onto the null space of A.
+
+    Parameters
+    ----------
+    A
+        The constraint matrix A in the equation: Ay = 0 (y being the
+        values/forecasts of all time series in the hierarchy).
+    D
+        Symmetric positive definite matrix (typically a diagonal matrix).
+        Optional.
+        If provided then the distance between the reconciled and unreconciled
+        forecasts is calculated based on the norm induced by D. Useful for
+        weighing the distances differently for each level of the hierarchy.
+        By default Euclidean distance is used.
+
+    Returns
+    -------
+    Numpy ND array
+        Projection matrix, shape (total_num_time_series, total_num_time_series)
+    """
+    num_ts = A.shape[1]
+    if D is None:
+        return np.eye(num_ts) - A.T @ np.linalg.pinv(A @ A.T) @ A
+    else:
+        assert np.all(D == D.T), "`D` must be symmetric."
+        assert np.all(
+            np.linalg.eigvals(D) > 0
+        ), "`D` must be positive definite."
+
+        D_inv = np.linalg.inv(D)
+        return (
+            np.eye(num_ts) - D_inv @ A.T @ np.linalg.pinv(A @ D_inv @ A.T) @ A
+        )
+
+
+@pytest.mark.parametrize(
+    "D",
+    [
+        None,
+        # Root gets the maximum weight and the two aggregated levels get
+        # more weight than the leaf level.
+        np.diag([4, 2, 2, 1, 1, 1, 1]),
+        # Random diagonal matrix
+        np.diag(np.random.rand(S.shape[0])),
+        # Random positive definite matrix
+        np.diag(np.random.rand(S.shape[0]))
+        + np.dot(
+            np.array([[4, 2, 2, 1, 1, 1, 1]]).T,
+            np.array([[4, 2, 2, 1, 1, 1, 1]]),
+        ),
+    ],
+)
+def test_projection_mat(D):
+    p1 = null_space_projection_mat(A=A, D=D)
+    p2 = projection_mat(S=S, D=D)
+    assert (np.abs(p1 - p2)).sum() < TOL

--- a/test/mx/model/deepvar_hierarchical/test_projection.py
+++ b/test/mx/model/deepvar_hierarchical/test_projection.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
 from typing import Optional
 
 import numpy as np

--- a/test/mx/model/deepvar_hierarchical/test_reconcile_samples.py
+++ b/test/mx/model/deepvar_hierarchical/test_reconcile_samples.py
@@ -17,7 +17,7 @@ import pytest
 
 from gluonts.mx.model.deepvar_hierarchical import (
     constraint_mat,
-    null_space_projection_mat,
+    projection_mat,
     reconcile_samples,
     coherency_error,
 )
@@ -81,7 +81,7 @@ A = constraint_mat(S)
 )
 def test_reconciliation_error(samples, D, seq_axis):
     coherent_samples = reconcile_samples(
-        reconciliation_mat=mx.nd.array(null_space_projection_mat(A=A, D=D)),
+        reconciliation_mat=mx.nd.array(projection_mat(S=S, D=D)),
         samples=mx.nd.array(samples),
         seq_axis=seq_axis,
     )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We can compute the projection matrix directly using the standard summation matrix `S` instead of the  "constraint matrix" `A` proposed in the paper. 

This form of projection matrix allows one to compare it with the other projection matrices used in the literature; essentially ours encapsulates all the linear reconciliation methods via the term `D`. Moreover, it also makes it clear that the reconciled forecasts are unbiased if the base forecasts are unbiased like the standard methods.

Added a test that asserts that the two ways of computing the projection matrix are the same.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup