### PR TITLE
Simplify PyTorchPredictor serde

### DIFF
--- a/src/gluonts/model/predictor.py
+++ b/src/gluonts/model/predictor.py
@@ -162,7 +162,6 @@ class RepresentablePredictor(Predictor):
         return equals(self, that)
 
     def serialize(self, path: Path) -> None:
-        # call Predictor.serialize() in order to serialize the class name
         super().serialize(path)
         with (path / "predictor.json").open("w") as fp:
             print(dump_json(self), file=fp)

--- a/src/gluonts/torch/model/d_linear/estimator.py
+++ b/src/gluonts/torch/model/d_linear/estimator.py
@@ -247,7 +247,5 @@ class DLinearEstimator(PyTorchLightningEstimator):
             ),
             batch_size=self.batch_size,
             prediction_length=self.prediction_length,
-            device=torch.device(
-                "cuda" if torch.cuda.is_available() else "cpu"
-            ),
+            device="cuda" if torch.cuda.is_available() else "cpu",
         )

--- a/src/gluonts/torch/model/deep_npts/_estimator.py
+++ b/src/gluonts/torch/model/deep_npts/_estimator.py
@@ -399,7 +399,7 @@ class DeepNPTSEstimator(Estimator):
         return best_net
 
     def get_predictor(
-        self, net: torch.nn.Module, device=torch.device("cpu")
+        self, net: torch.nn.Module, device="cpu"
     ) -> PyTorchPredictor:
         pred_net_multi_step = DeepNPTSMultiStepNetwork(
             net=net, prediction_length=self.prediction_length

--- a/src/gluonts/torch/model/deepar/estimator.py
+++ b/src/gluonts/torch/model/deepar/estimator.py
@@ -420,7 +420,5 @@ class DeepAREstimator(PyTorchLightningEstimator):
             prediction_net=module,
             batch_size=self.batch_size,
             prediction_length=self.prediction_length,
-            device=torch.device(
-                "cuda" if torch.cuda.is_available() else "cpu"
-            ),
+            device="cuda" if torch.cuda.is_available() else "cpu",
         )

--- a/src/gluonts/torch/model/lag_tst/estimator.py
+++ b/src/gluonts/torch/model/lag_tst/estimator.py
@@ -275,7 +275,5 @@ class LagTSTEstimator(PyTorchLightningEstimator):
             ),
             batch_size=self.batch_size,
             prediction_length=self.prediction_length,
-            device=torch.device(
-                "cuda" if torch.cuda.is_available() else "cpu"
-            ),
+            device="cuda" if torch.cuda.is_available() else "cpu",
         )

--- a/src/gluonts/torch/model/patch_tst/estimator.py
+++ b/src/gluonts/torch/model/patch_tst/estimator.py
@@ -279,7 +279,5 @@ class PatchTSTEstimator(PyTorchLightningEstimator):
             ),
             batch_size=self.batch_size,
             prediction_length=self.prediction_length,
-            device=torch.device(
-                "cuda" if torch.cuda.is_available() else "cpu"
-            ),
+            device="cuda" if torch.cuda.is_available() else "cpu",
         )

--- a/src/gluonts/torch/model/predictor.py
+++ b/src/gluonts/torch/model/predictor.py
@@ -98,6 +98,13 @@ class PyTorchPredictor(Predictor):
         if type(self) != type(that):
             return False
 
+        if (
+            self.prediction_length != that.prediction_length
+            or self.lead_time != that.lead_time
+            or self.input_names != that.input_names
+        ):
+            return False
+
         if not equals(self.input_transform, that.input_transform):
             return False
 

--- a/src/gluonts/torch/model/simple_feedforward/estimator.py
+++ b/src/gluonts/torch/model/simple_feedforward/estimator.py
@@ -247,7 +247,5 @@ class SimpleFeedForwardEstimator(PyTorchLightningEstimator):
             ),
             batch_size=self.batch_size,
             prediction_length=self.prediction_length,
-            device=torch.device(
-                "cuda" if torch.cuda.is_available() else "cpu"
-            ),
+            device="cuda" if torch.cuda.is_available() else "cpu",
         )

--- a/src/gluonts/torch/model/tft/estimator.py
+++ b/src/gluonts/torch/model/tft/estimator.py
@@ -400,9 +400,7 @@ class TemporalFusionTransformerEstimator(PyTorchLightningEstimator):
             prediction_net=module,
             batch_size=self.batch_size,
             prediction_length=self.prediction_length,
-            device=torch.device(
-                "cuda" if torch.cuda.is_available() else "cpu"
-            ),
+            device="cuda" if torch.cuda.is_available() else "cpu",
             forecast_generator=QuantileForecastGenerator(
                 quantiles=[str(q) for q in self.quantiles]
             ),

--- a/src/gluonts/torch/model/wavenet/estimator.py
+++ b/src/gluonts/torch/model/wavenet/estimator.py
@@ -460,7 +460,5 @@ class WaveNetEstimator(PyTorchLightningEstimator):
             prediction_net=module,
             batch_size=self.batch_size,
             prediction_length=self.prediction_length,
-            device=torch.device(
-                "cuda" if torch.cuda.is_available() else "cpu"
-            ),
+            device="cuda" if torch.cuda.is_available() else "cpu",
         )

--- a/test/torch/model/test_estimators.py
+++ b/test/torch/model/test_estimators.py
@@ -140,6 +140,8 @@ def test_estimator_constant_dataset(
         predictor.serialize(Path(td))
         predictor_copy = Predictor.deserialize(Path(td))
 
+    assert predictor == predictor_copy
+
     forecasts = predictor_copy.predict(constant.test)
 
     for f in islice(forecasts, 5):
@@ -314,6 +316,8 @@ def test_estimator_with_features(estimator_constructor):
     with tempfile.TemporaryDirectory() as td:
         predictor.serialize(Path(td))
         predictor_copy = Predictor.deserialize(Path(td))
+
+    assert predictor == predictor_copy
 
     forecasts = predictor_copy.predict(prediction_dataset)
 

--- a/test/torch/model/test_torch_predictor.py
+++ b/test/torch/model/test_torch_predictor.py
@@ -69,7 +69,7 @@ def test_pytorch_predictor_serde():
         prediction_net=pred_net,
         batch_size=16,
         input_transform=transformation,
-        device=torch.device("cpu"),
+        device="cpu",
     )
 
     with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
*Description of changes:* Simplify the serialization format for `PyTorchPredictor`. Piggy-backing on the recursive definition of `encode` and `decode` [here](https://github.com/awslabs/gluonts/blob/3ae0ac464c844cddaa85f13adf35b347b66c6a3e/src/gluonts/core/serde/_base.py), this PR removes the need for dedicated file encoding the network and the input transform: these can be stored directly together with the rest of the constructor parameters.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup