### PR TITLE
Fix Cython version in XGBoost tests

### DIFF
--- a/.github/workflows/tests-xgboost.yaml
+++ b/.github/workflows/tests-xgboost.yaml
@@ -22,6 +22,7 @@ jobs:
     - name: Install other dependencies
       run: |
         python -m pip install -U pip setuptools wheel
+        python -m pip install -U "Cython<3.0"
         pip install .
         pip install -r requirements/requirements-test.txt
         pip install -r requirements/requirements-rotbaum.txt

--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,7 @@ dev_require = (
 )
 
 setup(
+    setup_requires=["Cython<3.0"],
     install_requires=find_requirements("requirements.txt"),
     tests_require=tests_require,
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,6 @@ dev_require = (
 )
 
 setup(
-    setup_requires=["Cython<3.0"],
     install_requires=find_requirements("requirements.txt"),
     tests_require=tests_require,
     extras_require={


### PR DESCRIPTION
*Issue #, if available:* Related to https://github.com/scikit-garden/scikit-garden/pull/112

*Description of changes:* Bounds Cython to <3.0 in the XGBoost test workflow, since scikit-garden (only required there) setup fails with Cython>=3.0.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup