### PR TITLE
[Hierarchical] Remove dependence on constraint_mat

### DIFF
--- a/src/gluonts/mx/model/deepvar_hierarchical/__init__.py
+++ b/src/gluonts/mx/model/deepvar_hierarchical/__init__.py
@@ -13,7 +13,6 @@
 
 # Relative imports
 from ._estimator import (
-    constraint_mat,
     projection_mat,
     DeepVARHierarchicalEstimator,
 )
@@ -21,7 +20,6 @@ from ._network import reconcile_samples, coherency_error
 
 __all__ = [
     "DeepVARHierarchicalEstimator",
-    "constraint_mat",
     "projection_mat",
     "reconcile_samples",
     "coherency_error",

--- a/src/gluonts/mx/model/deepvar_hierarchical/_estimator.py
+++ b/src/gluonts/mx/model/deepvar_hierarchical/_estimator.py
@@ -41,38 +41,6 @@ from ._network import (
 logger = logging.getLogger(__name__)
 
 
-def constraint_mat(S: np.ndarray) -> np.ndarray:
-    """
-    Generates the constraint matrix in the equation: Ay = 0 (y being the
-    values/forecasts of all time series in the hierarchy).
-
-    Parameters
-    ----------
-    S
-        Summation or aggregation matrix. Shape:
-        (total_num_time_series, num_bottom_time_series)
-
-    Returns
-    -------
-    Numpy ND array
-        Coefficient matrix of the linear constraints, shape
-        (num_agg_time_series, num_time_series)
-    """
-
-    # Re-arrange S matrix to form A matrix
-    # S = [S_agg|I_m_K]^T dim:(m,m_K)
-    # A = [I_magg | -S_agg] dim:(m_agg,m)
-
-    m, m_K = S.shape
-    m_agg = m - m_K
-
-    # The top `m_agg` rows of the matrix `S` give the aggregation constraint
-    # matrix.
-    S_agg = S[:m_agg, :]
-    A = np.hstack((np.eye(m_agg), -S_agg))
-    return A
-
-
 def projection_mat(
     S: np.ndarray,
     D: Optional[np.ndarray] = None,

--- a/src/gluonts/mx/model/deepvar_hierarchical/_network.py
+++ b/src/gluonts/mx/model/deepvar_hierarchical/_network.py
@@ -99,14 +99,14 @@ def reconcile_samples(
 
 def coherency_error(S: np.ndarray, samples: np.ndarray) -> float:
     r"""
-        Computes the maximum relative coherency error
+    Computes the maximum relative coherency error
 
-        .. math::
+    .. math::
 
-                        \max_i | (S @ y_b)_i - y_i | / y_i
+                \max_i | (S @ y_b)_i - y_i | / y_i
 
-        where :math:`y` refers to the `samples` and :math:`y_b` refers to the
-        samples at the bottom level.
+    where :math:`y` refers to the `samples` and :math:`y_b` refers to the
+    samples at the bottom level.
 
     Parameters
     ----------
@@ -121,11 +121,9 @@ def coherency_error(S: np.ndarray, samples: np.ndarray) -> float:
     Float
         Coherency error
     """
-    samples_bottom_level = samples[..., -S.shape[1]:]
+    samples_bottom_level = samples[..., -S.shape[1] :]
 
-    errs = np.abs(
-        samples_bottom_level @ S.T - samples
-    )
+    errs = np.abs(samples_bottom_level @ S.T - samples)
     rel_errs = np.where(
         samples == 0.0,
         errs,
@@ -296,8 +294,7 @@ class DeepVARHierarchicalNetwork(DeepVARNetwork):
         # Show coherency error: A*X_proj
         if self.log_coherency_error:
             coh_error = coherency_error(
-                S=self.S,
-                samples=samples_to_return.asnumpy()
+                S=self.S, samples=samples_to_return.asnumpy()
             )
             logger.info(
                 "Coherency error of the predicted samples for time step"

--- a/src/gluonts/mx/model/deepvar_hierarchical/_network.py
+++ b/src/gluonts/mx/model/deepvar_hierarchical/_network.py
@@ -97,34 +97,22 @@ def reconcile_samples(
         return out
 
 
-def coherency_error(A: Tensor, samples: Tensor) -> float:
+def coherency_error(S: np.ndarray, samples: np.ndarray) -> float:
     r"""
-    Computes the maximum relative coherency error among all the aggregated
-    time series
+        Computes the maximum relative coherency error
 
-    .. math::
+        .. math::
 
-                    \max_i \frac{|y_i - s_i|} {|y_i|},
+                        \max_i | (S @ y_b)_i - y_i | / y_i
 
-    where :math:`i` refers to the aggregated time series index, :math:`y_i` is
-    the (direct) forecast obtained for the :math:`i^{th}` time series
-    and :math:`s_i` is its aggregated forecast obtained by summing the
-    corresponding bottom-level forecasts. If :math:`y_i` is zero, then the
-    absolute difference, :math:`|s_i|`, is used instead.
-
-    This can be comupted as follows given the constraint matrix A:
-
-    .. math::
-
-                    \max \frac{|A \times samples|} {|samples[:r]|},
-
-    where :math:`r` is the number aggregated time series.
+        where :math:`y` refers to the `samples` and :math:`y_b` refers to the
+        samples at the bottom level.
 
     Parameters
     ----------
-    A
-        The constraint matrix A in the equation: Ay = 0 (y being the
-        values/forecasts of all time series in the hierarchy).
+    S
+        The summation matrix S. Shape:
+        (total_num_time_series, num_bottom_time_series)
     samples
         Samples. Shape: `(*batch_shape, target_dim)`.
 
@@ -132,23 +120,18 @@ def coherency_error(A: Tensor, samples: Tensor) -> float:
     -------
     Float
         Coherency error
-
-
     """
+    samples_bottom_level = samples[..., -S.shape[1]:]
 
-    num_agg_ts = A.shape[0]
-    forecasts_agg_ts = samples.slice_axis(
-        axis=-1, begin=0, end=num_agg_ts
-    ).asnumpy()
-
-    abs_err = mx.nd.abs(mx.nd.dot(samples, A, transpose_b=True)).asnumpy()
-    rel_err = np.where(
-        forecasts_agg_ts == 0,
-        abs_err,
-        abs_err / np.abs(forecasts_agg_ts),
+    errs = np.abs(
+        samples_bottom_level @ S.T - samples
     )
-
-    return np.max(rel_err)
+    rel_errs = np.where(
+        samples == 0.0,
+        errs,
+        errs / np.abs(samples),
+    )
+    return rel_errs.max()
 
 
 class DeepVARHierarchicalNetwork(DeepVARNetwork):
@@ -156,7 +139,7 @@ class DeepVARHierarchicalNetwork(DeepVARNetwork):
     def __init__(
         self,
         M,
-        A,
+        S,
         num_layers: int,
         num_cells: int,
         cell_type: str,
@@ -191,7 +174,7 @@ class DeepVARHierarchicalNetwork(DeepVARNetwork):
         )
 
         self.M = M
-        self.A = A
+        self.S = S
         self.seq_axis = seq_axis
 
     def get_samples_for_loss(self, distr: Distribution) -> Tensor:
@@ -312,7 +295,10 @@ class DeepVARHierarchicalNetwork(DeepVARNetwork):
 
         # Show coherency error: A*X_proj
         if self.log_coherency_error:
-            coh_error = coherency_error(self.A, samples=samples_to_return)
+            coh_error = coherency_error(
+                S=self.S,
+                samples=samples_to_return.asnumpy()
+            )
             logger.info(
                 "Coherency error of the predicted samples for time step"
                 f" {self.forecast_time_step}: {coh_error}"

--- a/src/gluonts/nursery/temporal_hierarchical_forecasting/model/cop_deepar/_network.py
+++ b/src/gluonts/nursery/temporal_hierarchical_forecasting/model/cop_deepar/_network.py
@@ -20,10 +20,7 @@ from gluonts.core.component import Type, validated
 from gluonts.itertools import prod
 from gluonts.mx.model.deepar import DeepAREstimator
 from gluonts.mx.model.deepar._network import DeepARPredictionNetwork
-from gluonts.mx.model.deepvar_hierarchical._estimator import (
-    constraint_mat,
-    projection_mat,
-)
+from gluonts.mx.model.deepvar_hierarchical._estimator import projection_mat
 from gluonts.mx.model.deepvar_hierarchical._network import coherency_error
 from gluonts.mx.distribution import Distribution, EmpiricalDistribution
 from gluonts.mx import Tensor
@@ -681,7 +678,7 @@ class COPDeepARPredictionNetwork(COPNetwork):
 
             rec_err = coherency_error(
                 S=self.temporal_hierarchy.agg_mat,
-                samples=reconciled_samples_at_all_levels.asnumpy()
+                samples=reconciled_samples_at_all_levels.asnumpy(),
             )
             print(f"Reconciliation error: {rec_err}")
 

--- a/src/gluonts/nursery/temporal_hierarchical_forecasting/model/cop_deepar/_network.py
+++ b/src/gluonts/nursery/temporal_hierarchical_forecasting/model/cop_deepar/_network.py
@@ -91,14 +91,13 @@ class COPNetwork(mx.gluon.HybridBlock):
         self.loss_function = loss_function
         self.dtype = dtype
 
-        A = constraint_mat(self.temporal_hierarchy.agg_mat)
         if naive_reconciliation:
             M = utils.naive_reconcilation_mat(
                 self.temporal_hierarchy.agg_mat, self.temporal_hierarchy.nodes
             )
         else:
             M = projection_mat(S=self.temporal_hierarchy.agg_mat)
-        self.M, self.A = mx.nd.array(M), mx.nd.array(A)
+        self.M = mx.nd.array(M)
 
         self.estimators = estimators
 
@@ -681,7 +680,8 @@ class COPDeepARPredictionNetwork(COPNetwork):
                 reconciled_samples_at_all_levels = samples_at_all_levels
 
             rec_err = coherency_error(
-                A=self.A, samples=reconciled_samples_at_all_levels
+                S=self.temporal_hierarchy.agg_mat,
+                samples=reconciled_samples_at_all_levels.asnumpy()
             )
             print(f"Reconciliation error: {rec_err}")
 

--- a/test/mx/model/deepvar_hierarchical/test_coherency_error.py
+++ b/test/mx/model/deepvar_hierarchical/test_coherency_error.py
@@ -14,10 +14,8 @@
 import numpy as np
 import pytest
 
-from gluonts.mx.model.deepvar_hierarchical import (
-    constraint_mat,
-    coherency_error,
-)
+from gluonts.mx.model.deepvar_hierarchical import coherency_error
+
 
 TOL = 1e-4
 
@@ -34,7 +32,6 @@ S = np.array(
 )
 
 num_bottom_ts = S.shape[1]
-A = constraint_mat(S)
 
 
 @pytest.mark.parametrize(

--- a/test/mx/model/deepvar_hierarchical/test_coherency_error.py
+++ b/test/mx/model/deepvar_hierarchical/test_coherency_error.py
@@ -11,7 +11,6 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-import mxnet as mx
 import numpy as np
 import pytest
 
@@ -56,4 +55,4 @@ A = constraint_mat(S)
 def test_coherency_error(bottom_ts):
     all_ts = S @ bottom_ts
 
-    assert coherency_error(mx.nd.array(A), mx.nd.array(all_ts)) < TOL
+    assert coherency_error(S, all_ts) < TOL

--- a/test/mx/model/deepvar_hierarchical/test_reconcile_samples.py
+++ b/test/mx/model/deepvar_hierarchical/test_reconcile_samples.py
@@ -16,7 +16,6 @@ import numpy as np
 import pytest
 
 from gluonts.mx.model.deepvar_hierarchical import (
-    constraint_mat,
     projection_mat,
     reconcile_samples,
     coherency_error,

--- a/test/mx/model/deepvar_hierarchical/test_reconcile_samples.py
+++ b/test/mx/model/deepvar_hierarchical/test_reconcile_samples.py
@@ -37,7 +37,6 @@ S = np.array(
 )
 
 num_bottom_ts = S.shape[1]
-A = constraint_mat(S)
 
 
 @pytest.mark.parametrize(
@@ -86,4 +85,4 @@ def test_reconciliation_error(samples, D, seq_axis):
         seq_axis=seq_axis,
     )
 
-    assert coherency_error(mx.nd.array(A), coherent_samples) < TOL
+    assert coherency_error(S, coherent_samples.asnumpy()) < TOL


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR completely gets rid of the constraint matrix used in the earlier implementation of the projection matrix. 

There is still a test that compares the new projection with the earlier one so the this matrix is still available in tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup