### PR TITLE
Move LookupValues from Wavenet to gluonts.torch.modules

### DIFF
--- a/src/gluonts/torch/model/wavenet/module.py
+++ b/src/gluonts/torch/model/wavenet/module.py
@@ -18,27 +18,7 @@ import torch.nn as nn
 
 from gluonts.core.component import validated
 from gluonts.torch.modules.feature import FeatureEmbedder
-
-
-class LookupValues(nn.Module):
-    """Lookup bin values from bin indices.
-
-    Parameters
-    ----------
-    bin_values
-        Tensor of bin values with shape (num_bins, ).
-    """
-
-    @validated()
-    def __init__(self, bin_values: torch.Tensor):
-        super().__init__()
-        self.register_buffer("bin_values", bin_values)
-
-    def forward(self, indices: torch.Tensor) -> torch.Tensor:
-        indices = torch.clamp(indices, 0, self.bin_values.shape[0] - 1)
-        return torch.index_select(
-            self.bin_values, 0, indices.reshape(-1)
-        ).view_as(indices)
+from gluonts.torch.modules.lookup_table import LookupValues
 
 
 class CausalDilatedResidualLayer(nn.Module):

--- a/src/gluonts/torch/modules/lookup_table.py
+++ b/src/gluonts/torch/modules/lookup_table.py
@@ -1,0 +1,38 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import torch
+import torch.nn as nn
+
+from gluonts.core.component import validated
+
+
+class LookupValues(nn.Module):
+    """A lookup table mapping bin indices to values.
+
+    Parameters
+    ----------
+    bin_values
+        Tensor of bin values with shape (num_bins, ).
+    """
+
+    @validated()
+    def __init__(self, bin_values: torch.Tensor):
+        super().__init__()
+        self.register_buffer("bin_values", bin_values)
+
+    def forward(self, indices: torch.Tensor) -> torch.Tensor:
+        indices = torch.clamp(indices, 0, self.bin_values.shape[0] - 1)
+        return torch.index_select(
+            self.bin_values, 0, indices.reshape(-1)
+        ).view_as(indices)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This PR moves the `LoopupValues` module from local Wavenet directory to global torch modules.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup