### PR TITLE
Move QuantizeScaled from Wavenet to gluonts.transform, rename to QuantizeMeanScaled

### DIFF
--- a/src/gluonts/torch/model/wavenet/estimator.py
+++ b/src/gluonts/torch/model/wavenet/estimator.py
@@ -18,7 +18,7 @@ import torch
 import numpy as np
 
 from gluonts.core.component import validated
-from gluonts.dataset.common import DataEntry, Dataset
+from gluonts.dataset.common import Dataset
 from gluonts.dataset.field_names import FieldName
 from gluonts.dataset.loader import as_stacked_batches
 from gluonts.itertools import Cyclic
@@ -41,7 +41,7 @@ from gluonts.transform import (
     InstanceSplitter,
     SetField,
     RemoveFields,
-    SimpleTransformation,
+    QuantizeMeanScaled,
     VstackFeatures,
     Identity,
     TestSplitSampler,
@@ -65,70 +65,6 @@ TRAINING_INPUT_NAMES = PREDICTION_INPUT_NAMES + [
     "future_target",
     "future_observed_values",
 ]
-
-
-class QuantizeScaled(SimpleTransformation):
-    """Rescale and quantize the target variable.
-    Requires `past_target_field`, and `future_target_field` to be present.
-
-    The mean absolute value of the past_target is used to rescale
-    past_target and future_target. Then the bin_edges are used to quantize
-    the rescaled target.
-
-    The calculated scale is stored in the `scale_field`.
-
-    Parameters
-    ----------
-    bin_edges
-        The bin edges for quantization.
-    past_target_field, optional
-        The field name that contains `past_target`,
-        by default "past_target"
-    past_observed_values_field, optional
-        The field name that contains `past_observed_values`,
-        by default "past_observed_values"
-    future_target_field, optional
-        The field name that contains `future_target`,
-        by default "future_target"
-    scale_field, optional
-        The field name where scale will be stored,
-        by default "scale"
-    """
-
-    @validated()
-    def __init__(
-        self,
-        bin_edges: List[float],
-        past_target_field: str = "past_target",
-        past_observed_values_field: str = "past_observed_values",
-        future_target_field: str = "future_target",
-        scale_field: str = "scale",
-    ):
-        self.bin_edges = np.array(bin_edges)
-        self.future_target_field = future_target_field
-        self.past_target_field = past_target_field
-        self.past_observed_values_field = past_observed_values_field
-        self.scale_field = scale_field
-
-    def transform(self, data: DataEntry) -> DataEntry:
-        target = data[self.past_target_field]
-        weights = data.get(
-            self.past_observed_values_field, np.ones_like(target)
-        )
-        m = np.sum(np.abs(target) * weights) / np.sum(weights)
-        scale = m if m > 0 else 1.0
-        data[self.future_target_field] = np.digitize(
-            data[self.future_target_field] / scale,
-            bins=self.bin_edges,
-            right=False,
-        )
-        data[self.past_target_field] = np.digitize(
-            data[self.past_target_field] / scale,
-            bins=self.bin_edges,
-            right=False,
-        )
-        data[self.scale_field] = np.array([scale], dtype=np.float32)
-        return data
 
 
 class WaveNetEstimator(PyTorchLightningEstimator):
@@ -392,7 +328,7 @@ class WaveNetEstimator(PyTorchLightningEstimator):
                 FieldName.FEAT_TIME,
                 FieldName.OBSERVED_VALUES,
             ],
-        ) + QuantizeScaled(bin_edges=self.bin_edges)
+        ) + QuantizeMeanScaled(bin_edges=self.bin_edges)
 
     def create_training_data_loader(
         self,

--- a/src/gluonts/transform/__init__.py
+++ b/src/gluonts/transform/__init__.py
@@ -41,6 +41,7 @@ __all__ = [
     "InstanceSplitter",
     "ListFeatures",
     "MapTransformation",
+    "QuantizeMeanScaled",
     "RemoveFields",
     "RenameFields",
     "SampleTargetDim",
@@ -89,6 +90,7 @@ from .convert import (
     VstackFeatures,
     cdf_to_gaussian_forward_transform,
     Valmap,
+    QuantizeMeanScaled,
 )
 from .feature import (
     AddAgeFeature,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This PR moves `QuantizeScaled` from local wavenet module to `torch.transform` and renames it to `QuantizeMeanScaled` to more accurately reflect what it is doing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup