### PR TITLE
Fix ArrowDecoder.decode to return instead of yield

### DIFF
--- a/src/gluonts/dataset/arrow/dec.py
+++ b/src/gluonts/dataset/arrow/dec.py
@@ -32,7 +32,7 @@ class ArrowDecoder:
         )
 
     def decode(self, batch, row_number: int):
-        yield from self.decode_batch(batch.slice(row_number, row_number + 1))
+        return next(self.decode_batch(batch.slice(row_number, row_number + 1)))
 
     def decode_batch(self, batch):
         for row in batch.to_pandas().to_dict("records"):

--- a/test/dataset/test_arrow.py
+++ b/test/dataset/test_arrow.py
@@ -90,7 +90,7 @@ def test_arrow(writer, flatten_arrays):
         assert len(dataset[10:]) == len(data[10:])
         assert_equal(dataset[10:], data[10:])
 
-        assert len(dataset[3:7]) == len(data[3: 7])
+        assert len(dataset[3:7]) == len(data[3:7])
         assert_equal(dataset[3:7], data[3:7])
 
         assert len(dataset[3:7][1:-1]) == len(data[3:7][1:-1])

--- a/test/dataset/test_arrow.py
+++ b/test/dataset/test_arrow.py
@@ -82,13 +82,15 @@ def test_arrow(writer, flatten_arrays):
 
         assert_equal(data, dataset)
 
+        assert_equal(dataset[4], data[4])
+
         assert len(dataset[:5]) == len(data[:5])
         assert_equal(dataset[:5], data[:5])
 
         assert len(dataset[10:]) == len(data[10:])
         assert_equal(dataset[10:], data[10:])
 
-        assert len(dataset[3:7]) == len(data[3:7])
+        assert len(dataset[3:7]) == len(data[3: 7])
         assert_equal(dataset[3:7], data[3:7])
 
         assert len(dataset[3:7][1:-1]) == len(data[3:7][1:-1])


### PR DESCRIPTION
*Description of changes:* `ArrowDecoder.decode` used to `yield from` something, effectively returning a generator. This meant for example that `ArrowFile.__getitem__` also returns a generator when given an integer index, [see here](https://github.com/awslabs/gluonts/blob/dev/src/gluonts/dataset/arrow/file.py#L162). This PR fixes it to make them return a record from the file instead.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup