### PR TITLE
Unpin pyarrow version

### DIFF
--- a/requirements/requirements-arrow.txt
+++ b/requirements/requirements-arrow.txt
@@ -1,2 +1,1 @@
-pyarrow>=6.0; python_version=='3.6.*'
-pyarrow~=8.0; python_version>='3.7'
+pyarrow


### PR DESCRIPTION
*Description of changes:* PyArrow was pinned at version 8.0, but there should be no problem in allowing later versions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup