### PR TITLE
[R] Bug fix for running R methods via ParallelizedPredictor

### DIFF
--- a/src/gluonts/ext/r_forecast/_univariate_predictor.py
+++ b/src/gluonts/ext/r_forecast/_univariate_predictor.py
@@ -121,6 +121,7 @@ class RForecastPredictor(RBasePredictor):
             params["intervals"] = sorted(
                 set([level for level, _ in intervals_info])
             )
+            params.pop("quantiles")
 
         self.params.update(params)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently cannot run `RForecastPredictor` in parallel via `ParallelizedPredictor` when `quantiles` are passed in `params`. The reason is that `ParallelizedPredictor` serializes and de-serializes the predictor before making predictions.

When the predictor is serialized `params` is [updated with `intervals` key](https://github.com/awslabs/gluonts/blob/dev/src/gluonts/ext/r_forecast/_univariate_predictor.py#L121-L123) but still keeps `quantiles` key. When de-serialized, [this assertion](https://github.com/awslabs/gluonts/blob/dev/src/gluonts/ext/r_forecast/_univariate_predictor.py#L115-L117) fails as `params` now contain both keys.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup