### PR TITLE
Update Predictor checkpoint structure

### DIFF
--- a/src/gluonts/model/predictor.py
+++ b/src/gluonts/model/predictor.py
@@ -77,7 +77,7 @@ class Predictor:
 
     def serialize(self, path: Path) -> None:
         # serialize Predictor type
-        with (path / "gluonts_config.json").open("w") as fp:
+        with (path / "gluonts-config.json").open("w") as fp:
             json.dump(
                 {
                     "model": self.__version__,

--- a/src/gluonts/model/predictor.py
+++ b/src/gluonts/model/predictor.py
@@ -106,7 +106,7 @@ class Predictor:
             with (path / "gluonts-config.json").open("r") as fp:
                 tpe_str = json.load(fp)["type"]
         else:
-            logger.warn(
+            logger.warning(
                 "Deserializing an old version of gluonts predictor. "
                 "Support for old gluonts predictors will be removed in v0.16. "
                 "Consider serializing this predictor again.",

--- a/src/gluonts/model/predictor.py
+++ b/src/gluonts/model/predictor.py
@@ -102,8 +102,8 @@ class Predictor:
             otherwise.
         """
         # deserialize Predictor type
-        if (path / "gluonts_config.json").exists():
-            with (path / "gluonts_config.json").open("r") as fp:
+        if (path / "gluonts-config.json").exists():
+            with (path / "gluonts-config.json").open("r") as fp:
                 tpe_str = json.load(fp)["type"]
         else:
             logger.warn(


### PR DESCRIPTION
*Issue #, if available:* #2875 

*Description of changes:* This PR changes the `Predictor` checkpoint structure from using `type.txt` and `version.json` to `gluonts-config.json` which includes information about both `type` and `version`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup