### PR TITLE
Change torch state_dict file name to prediction-net-state.pt

### DIFF
--- a/src/gluonts/torch/model/predictor.py
+++ b/src/gluonts/torch/model/predictor.py
@@ -98,7 +98,7 @@ class PyTorchPredictor(RepresentablePredictor):
         super().serialize(path)
 
         torch.save(
-            self.prediction_net.state_dict(), path / "prediction_net_state"
+            self.prediction_net.state_dict(), path / "prediction-net-state.pt"
         )
 
     @classmethod
@@ -111,7 +111,7 @@ class PyTorchPredictor(RepresentablePredictor):
             device = "cuda" if torch.cuda.is_available() else "cpu"
 
         predictor.prediction_net.load_state_dict(
-            torch.load(path / "prediction_net_state", map_location=device)
+            torch.load(path / "prediction-net-state.pt", map_location=device)
         )
 
         return predictor


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Change torch state dict name in checkpoints to `prediction-net-state.pt` from `prediction_net_state`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup