### PR TITLE
Adjust rotbaum requirements

### DIFF
--- a/requirements/requirements-rotbaum.txt
+++ b/requirements/requirements-rotbaum.txt
@@ -1,2 +1,2 @@
-xgboost>=0.90
-scikit-learn~=0.22
+xgboost>=0.90,<2
+scikit-learn>=0.22,<2


### PR DESCRIPTION
*Description of changes:* Some workflow failed trying to install a rather old version of `sklearn`, see eg [this one](https://github.com/awslabs/gluonts/actions/runs/6039530231/job/16388382866?pr=2988). Bumping the requirements for Rotbaum to allow more recent version being used.

Also setting an upper bound on `xgboost` version, because unbounded requirements are not ideal.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup