### PR TITLE
Fix edge case in `PyTorchPredictor.deserialize`

### DIFF
--- a/src/gluonts/torch/model/predictor.py
+++ b/src/gluonts/torch/model/predictor.py
@@ -110,8 +110,11 @@ class PyTorchPredictor(RepresentablePredictor):
         if device is None:
             device = "cuda" if torch.cuda.is_available() else "cpu"
 
-        predictor.prediction_net.load_state_dict(
-            torch.load(path / "prediction-net-state.pt", map_location=device)
+        predictor.to(device)
+        state_dict = torch.load(
+            path / "prediction-net-state.pt",
+            map_location=device,
         )
+        predictor.prediction_net.load_state_dict(state_dict)
 
         return predictor


### PR DESCRIPTION
*Description of changes:* Since #2965 (not sure before), if a `PyTorchPredictor` object was serialized from the CPU memory, then `deserialize`ing it with `device="cuda"` would actually not work. This would happen:
1. predictor object created, with parameters of its `torch.nn.Module` model allocated on CPU (since that was the `device` the predictor was serialized with)
2. when deserializing with `device="cuda"`, `torch.load` with `map_location="cuda"` would put the `state_dict` values on GPU as expected
3. `torch.nn.Module.load_state_dict` would however copy the parameters back to CPU
4. since the predictor has the `.device` attribute set to `"cpu"`, prediction would not complain (data & model on the same device) but would be really slow.

This PR makes sure that the predictor object being created is moved `.to(device)` after step 1, so that step 3 actually keeps parameters on GPU.

The same issue happens inverting CPU and GPU, as in the following example

```python
import pandas as pd
import numpy as np
import logging
import tempfile
from gluonts.model import Predictor
from gluonts.torch.model.wavenet import WaveNetEstimator
from pathlib import Path

logging.basicConfig(level=logging.INFO)

data = [
    {
        "start": pd.Period("2012-02-04", freq="D"),
        "target": np.ones(2000),
    }
]

estimator = WaveNetEstimator(
    freq="H",
    prediction_length=24,
    num_batches_per_epoch=2,
    trainer_kwargs=dict(max_epochs=1),
)

predictor = estimator.train(data)

with tempfile.TemporaryDirectory() as td:
    predictor.serialize(Path(td))
    predictor = Predictor.deserialize(Path(td), device="cpu")
    print(f" predictor device is {predictor.device}")
    print(f"module parameters on {next(predictor.prediction_net.parameters()).device}")
```

Expected to have the resulting model on CPU. Output before the PR:

```
 predictor device is cuda
module parameters on cuda:0
```

Output after the PR:

```
 predictor device is cpu
module parameters on cpu
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup