### PR TITLE
[torch-DeepAR] allow user to set `max_epochs`

### DIFF
--- a/src/gluonts/torch/model/deepar/estimator.py
+++ b/src/gluonts/torch/model/deepar/estimator.py
@@ -181,9 +181,10 @@ class DeepAREstimator(PyTorchLightningEstimator):
         train_sampler: Optional[InstanceSampler] = None,
         validation_sampler: Optional[InstanceSampler] = None,
         nonnegative_pred_samples: bool = False,
+        max_epochs: int = 100,
     ) -> None:
         default_trainer_kwargs = {
-            "max_epochs": 100,
+            "max_epochs": max_epochs,
             "gradient_clip_val": 10.0,
         }
         if trainer_kwargs is not None:


### PR DESCRIPTION
*Description of changes:*
In torch-DeepAR it is currently hardcoded the value of `max_epochs`. In this PR we allow the user to set it up as desired.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup