### PR TITLE
Add `auto` device for `PyTorchPredictor`

### DIFF
--- a/src/gluonts/torch/model/d_linear/estimator.py
+++ b/src/gluonts/torch/model/d_linear/estimator.py
@@ -247,5 +247,5 @@ class DLinearEstimator(PyTorchLightningEstimator):
             ),
             batch_size=self.batch_size,
             prediction_length=self.prediction_length,
-            device="cuda" if torch.cuda.is_available() else "cpu",
+            device="auto",
         )

--- a/src/gluonts/torch/model/deepar/estimator.py
+++ b/src/gluonts/torch/model/deepar/estimator.py
@@ -420,5 +420,5 @@ class DeepAREstimator(PyTorchLightningEstimator):
             prediction_net=module,
             batch_size=self.batch_size,
             prediction_length=self.prediction_length,
-            device="cuda" if torch.cuda.is_available() else "cpu",
+            device="auto",
         )

--- a/src/gluonts/torch/model/lag_tst/estimator.py
+++ b/src/gluonts/torch/model/lag_tst/estimator.py
@@ -275,5 +275,5 @@ class LagTSTEstimator(PyTorchLightningEstimator):
             ),
             batch_size=self.batch_size,
             prediction_length=self.prediction_length,
-            device="cuda" if torch.cuda.is_available() else "cpu",
+            device="auto",
         )

--- a/src/gluonts/torch/model/patch_tst/estimator.py
+++ b/src/gluonts/torch/model/patch_tst/estimator.py
@@ -279,5 +279,5 @@ class PatchTSTEstimator(PyTorchLightningEstimator):
             ),
             batch_size=self.batch_size,
             prediction_length=self.prediction_length,
-            device="cuda" if torch.cuda.is_available() else "cpu",
+            device="auto",
         )

--- a/src/gluonts/torch/model/predictor.py
+++ b/src/gluonts/torch/model/predictor.py
@@ -110,8 +110,11 @@ class PyTorchPredictor(RepresentablePredictor):
         if device is None:
             device = "cuda" if torch.cuda.is_available() else "cpu"
 
-        predictor.prediction_net.load_state_dict(
-            torch.load(path / "prediction-net-state.pt", map_location=device)
+        predictor.to(device)
+        state_dict = torch.load(
+            path / "prediction-net-state.pt",
+            map_location=device,
         )
+        predictor.prediction_net.load_state_dict(state_dict)
 
         return predictor

--- a/src/gluonts/torch/model/predictor.py
+++ b/src/gluonts/torch/model/predictor.py
@@ -54,12 +54,12 @@ class PyTorchPredictor(RepresentablePredictor):
     ) -> None:
         super().__init__(prediction_length, lead_time=lead_time)
         self.input_names = input_names
-        self.prediction_net = prediction_net.to(device)
         self.batch_size = batch_size
         self.input_transform = input_transform
         self.forecast_generator = forecast_generator
         self.output_transform = output_transform
         self.device = resolve_device(device)
+        self.prediction_net = prediction_net.to(self.device)
         self.required_fields = ["forecast_start", "item_id", "info"]
 
     def to(self, device: Union[str, torch.device]) -> "PyTorchPredictor":

--- a/src/gluonts/torch/model/simple_feedforward/estimator.py
+++ b/src/gluonts/torch/model/simple_feedforward/estimator.py
@@ -247,5 +247,5 @@ class SimpleFeedForwardEstimator(PyTorchLightningEstimator):
             ),
             batch_size=self.batch_size,
             prediction_length=self.prediction_length,
-            device="cuda" if torch.cuda.is_available() else "cpu",
+            device="auto",
         )

--- a/src/gluonts/torch/model/tft/estimator.py
+++ b/src/gluonts/torch/model/tft/estimator.py
@@ -400,7 +400,7 @@ class TemporalFusionTransformerEstimator(PyTorchLightningEstimator):
             prediction_net=module,
             batch_size=self.batch_size,
             prediction_length=self.prediction_length,
-            device="cuda" if torch.cuda.is_available() else "cpu",
+            device="auto",
             forecast_generator=QuantileForecastGenerator(
                 quantiles=[str(q) for q in self.quantiles]
             ),

--- a/src/gluonts/torch/model/wavenet/estimator.py
+++ b/src/gluonts/torch/model/wavenet/estimator.py
@@ -396,5 +396,5 @@ class WaveNetEstimator(PyTorchLightningEstimator):
             prediction_net=module,
             batch_size=self.batch_size,
             prediction_length=self.prediction_length,
-            device="cuda" if torch.cuda.is_available() else "cpu",
+            device="auto",
         )

--- a/src/gluonts/torch/util.py
+++ b/src/gluonts/torch/util.py
@@ -11,10 +11,24 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from typing import List, Optional, Type
+from typing import List, Optional, Type, Union
 import inspect
 
 import torch
+
+
+def resolve_device(
+    device: Union[str, torch.device]
+) -> Union[str, torch.device]:
+    """
+    Resolves a torch device to the most appropriate one.
+
+    The ``"auto"`` device is resolved to ``"cuda"`` if CUDA is available,
+    and to ``"cpu"`` otherwise. Otherwise the device is unchanged.
+    """
+    if isinstance(device, str) and device == "auto":
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+    return device
 
 
 def copy_parameters(

--- a/src/gluonts/torch/util.py
+++ b/src/gluonts/torch/util.py
@@ -26,8 +26,11 @@ def resolve_device(
     The ``"auto"`` device is resolved to ``"cuda"`` if CUDA is available,
     and to ``"cpu"`` otherwise. Otherwise the device is unchanged.
     """
-    if isinstance(device, str) and device == "auto":
-        device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "auto":
+        if torch.cuda.is_available():
+            return "cuda"
+        return "cpu"
+
     return device
 
 


### PR DESCRIPTION
*Description of changes:* Add an `auto` device that can be used in `PyTorchPredictor` through the `resolve_device` util. Use `auto` by default in estimators, so that we avoid the issue of serializing a model with `cuda` and then being unable to load it on a `cpu`-only machine.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup