### PR TITLE
Set number of torch threads to 1 in `gluonts.shell`

### DIFF
--- a/src/gluonts/shell/__main__.py
+++ b/src/gluonts/shell/__main__.py
@@ -28,6 +28,13 @@ from .util import Forecaster, forecaster_type_by_name
 
 logger = logging.getLogger(__name__)
 
+try:
+    import torch
+
+    torch.set_num_threads(1)
+except ModuleNotFoundError:
+    pass
+
 
 @click.group()
 def cli() -> None:


### PR DESCRIPTION
*Description of changes:* The `gluonts.shell` multiprocessing setup interferes in a strange way with tensor operations from `torch`: when trying to serve an example model of mine, requests end up freezing the worker processes, even though the model works fine when invoked manually from the Python REPL.

I think this may be related to [this issue](https://github.com/pytorch/pytorch/issues/82843), and in fact the solution suggested there works.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup