### PR TITLE
Shell: change server from gunicorn to waitress

### DIFF
--- a/.github/workflows/style_type_checks.yml
+++ b/.github/workflows/style_type_checks.yml
@@ -21,6 +21,7 @@ jobs:
         pip install .
         pip install click black mypy
         pip install types-python-dateutil
+        pip install types-waitress
     - name: Style and type checks
       run: |
         just black

--- a/requirements/requirements-extras-shell.txt
+++ b/requirements/requirements-extras-shell.txt
@@ -1,2 +1,2 @@
 flask~=2.0
-gunicorn~=21.2
+waitress~=2.1.2

--- a/requirements/requirements-extras-shell.txt
+++ b/requirements/requirements-extras-shell.txt
@@ -1,2 +1,2 @@
 flask~=2.0
-gunicorn~=19.9
+gunicorn~=21.2

--- a/src/gluonts/shell/__main__.py
+++ b/src/gluonts/shell/__main__.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Optional
 
 import click
+from waitress import serve as waitress_serve
 
 from gluonts.env import env as gluonts_env
 from gluonts.shell.serve import Settings
@@ -82,12 +83,13 @@ def serve_command(
     else:
         forecaster_type = None
 
-    gunicorn_app = serve.make_gunicorn_app(
+    flask_app = serve.make_flask_app(
         env=env,
         forecaster_type=forecaster_type,
         settings=Settings(),
     )
-    gunicorn_app.run()
+
+    waitress_serve(flask_app, listen="*:8080")
 
 
 @cli.command(name="train")

--- a/src/gluonts/shell/__main__.py
+++ b/src/gluonts/shell/__main__.py
@@ -13,7 +13,6 @@
 
 import logging
 import traceback
-import multiprocessing as mp
 from pathlib import Path
 from typing import Optional
 
@@ -150,6 +149,7 @@ if __name__ == "__main__":
 
     from gluonts.env import env
 
+    import torch.multiprocessing as mp
     mp.set_start_method("spawn")
 
     if "TRAINING_JOB_NAME" in os.environ:

--- a/src/gluonts/shell/__main__.py
+++ b/src/gluonts/shell/__main__.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Optional
 
 import click
-from waitress import serve as waitress_serve
+import waitress
 
 from gluonts.env import env as gluonts_env
 from gluonts.shell.serve import Settings
@@ -89,7 +89,7 @@ def serve_command(
         settings=Settings(),
     )
 
-    waitress_serve(flask_app, listen="*:8080")
+    waitress.serve(flask_app, listen="*:8080")
 
 
 @cli.command(name="train")

--- a/src/gluonts/shell/__main__.py
+++ b/src/gluonts/shell/__main__.py
@@ -146,10 +146,6 @@ def train_command(data_path: str, forecaster: Optional[str]) -> None:
 
 
 if __name__ == "__main__":
-    import multiprocessing as mp
-
-    mp.set_start_method("spawn", force=True)
-
     import logging
     import os
 

--- a/src/gluonts/shell/__main__.py
+++ b/src/gluonts/shell/__main__.py
@@ -13,6 +13,7 @@
 
 import logging
 import traceback
+import multiprocessing as mp
 from pathlib import Path
 from typing import Optional
 
@@ -148,6 +149,8 @@ if __name__ == "__main__":
     import os
 
     from gluonts.env import env
+
+    mp.set_start_method("spawn")
 
     if "TRAINING_JOB_NAME" in os.environ:
         env._push(use_tqdm=False)

--- a/src/gluonts/shell/__main__.py
+++ b/src/gluonts/shell/__main__.py
@@ -145,8 +145,9 @@ def train_command(data_path: str, forecaster: Optional[str]) -> None:
 
 if __name__ == "__main__":
     import multiprocessing as mp
+
     mp.set_start_method("spawn", force=True)
-    
+
     import logging
     import os
 

--- a/src/gluonts/shell/__main__.py
+++ b/src/gluonts/shell/__main__.py
@@ -144,13 +144,13 @@ def train_command(data_path: str, forecaster: Optional[str]) -> None:
 
 
 if __name__ == "__main__":
+    import multiprocessing as mp
+    mp.set_start_method("spawn", force=True)
+    
     import logging
     import os
 
     from gluonts.env import env
-
-    import torch.multiprocessing as mp
-    mp.set_start_method("spawn")
 
     if "TRAINING_JOB_NAME" in os.environ:
         env._push(use_tqdm=False)

--- a/src/gluonts/shell/serve/__init__.py
+++ b/src/gluonts/shell/serve/__init__.py
@@ -164,6 +164,7 @@ def make_gunicorn_app(
         config={
             "bind": settings.sagemaker_server_bind,
             "workers": settings.number_of_workers,
+            "worker_class": "uvicorn.workers.UvicornWorker",
             "timeout": settings.sagemaker_server_timeout,
         },
     )

--- a/src/gluonts/shell/serve/__init__.py
+++ b/src/gluonts/shell/serve/__init__.py
@@ -17,7 +17,6 @@ from ipaddress import IPv4Address
 from typing import List, Optional, Type, Union
 
 from flask import Flask
-from gunicorn.app.base import BaseApplication
 from pydantic import BaseSettings
 
 import gluonts
@@ -94,32 +93,11 @@ class Settings(BaseSettings):
             return cpu_count
 
 
-class Application(BaseApplication):
-    def __init__(self, app, config) -> None:
-        self.app = app
-        self.config = config
-        BaseApplication.__init__(self)
-
-    def load_config(self) -> None:
-        for key, value in self.config.items():
-            if key in self.cfg.settings and value is not None:
-                self.cfg.set(key, value)
-
-    def init(self, parser, opts, args):
-        pass
-
-    def load(self) -> Flask:
-        return self.app
-
-    def stop(self, *args, **kwargs):
-        logger.info("Shutting down GluonTS scoring service")
-
-
-def make_gunicorn_app(
+def make_flask_app(
     env: ServeEnv,
     forecaster_type: Optional[Type[Union[Estimator, Predictor]]],
     settings: Settings,
-) -> Application:
+) -> Flask:
     if forecaster_type is not None:
         logger.info("Using dynamic predictor factory")
 
@@ -159,15 +137,4 @@ def make_gunicorn_app(
         settings=settings,
     )
 
-    gunicorn_app = Application(
-        app=flask_app,
-        config={
-            "bind": settings.sagemaker_server_bind,
-            "workers": settings.number_of_workers,
-            "worker_class": "gthread",
-            "threads": settings.number_of_workers,
-            "timeout": settings.sagemaker_server_timeout,
-        },
-    )
-
-    return gunicorn_app
+    return flask_app

--- a/src/gluonts/shell/serve/__init__.py
+++ b/src/gluonts/shell/serve/__init__.py
@@ -164,7 +164,8 @@ def make_gunicorn_app(
         config={
             "bind": settings.sagemaker_server_bind,
             "workers": settings.number_of_workers,
-            "worker_class": "uvicorn.workers.UvicornWorker",
+            "worker_class": "gthread",
+            "threads": settings.number_of_workers,
             "timeout": settings.sagemaker_server_timeout,
         },
     )

--- a/test/shell/require-packages.txt
+++ b/test/shell/require-packages.txt
@@ -1,3 +1,3 @@
 flask
-gunicorn
+waitress
 requests


### PR DESCRIPTION
*Description of changes:* I've run into issues using `gluonts.shell` on GPU machines. Apparently gunicorn relies on process forking to spawn worker processes, with no way to change this behaviour (as far as I can see it just calls `os.fork`). Changing the worker type to `gthread` in gunicorn config also did not work (maybe because at least one worker process is always forked?). In the end, what worked was swapping gunicorn for [waitress](https://github.com/Pylons/waitress).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup