### PR TITLE
Fix Forecast plot method

### DIFF
--- a/requirements/requirements-docs.txt
+++ b/requirements/requirements-docs.txt
@@ -15,4 +15,4 @@ click
 orjson
 black
 holidays~=0.9
-matplotlib
+matplotlib~=3.6

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -8,4 +8,4 @@ ujson
 orjson
 requests
 holidays~=0.9
-matplotlib
+matplotlib~=3.6

--- a/src/gluonts/model/forecast.py
+++ b/src/gluonts/model/forecast.py
@@ -316,7 +316,7 @@ class Forecast:
         # If no color is provided, we use matplotlib's internal color cycle.
         # Note: This is an internal API and might change in the future.
         color = maybe.unwrap_or_else(
-            color, lambda: next(ax._get_lines.prop_cycler)["color"]
+            color, lambda: ax._get_lines.get_next_color()
         )
 
         # Plot median forecast


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* changes in matplotlib broke the plot method.

```python
from gluonts.model import SampleForecast
import matplotlib.pyplot as plt
import pandas as pd
import numpy as np

forecast = SampleForecast(
    samples=np.random.normal(size=(100, 24)),
    start_date=pd.Period("2023-04-05", freq="D"),
)

forecast.plot()
plt.show()
```

![image](https://github.com/awslabs/gluonts/assets/433963/3f14c325-e0a3-439a-950e-32b1e36effdf)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup