### PR TITLE
Remove freq attribute from NPTS

### DIFF
--- a/src/gluonts/model/npts/_predictor.py
+++ b/src/gluonts/model/npts/_predictor.py
@@ -38,7 +38,7 @@ class NPTSPredictor(RepresentablePredictor):
 
     Forecasts of NPTS for time step :math:`T` are one of the previous values
     of the time series (these could be known values or predictions), sampled
-    according to the (un-normalized) distribution :math:`q_T(t) > 0`, where
+    according to the (un-normalized) distribution :math:`q_T(t) > 0` where
     :math:`0 <= t < T`.
 
     The distribution :math:`q_T` is expressed in terms of a feature map
@@ -95,9 +95,9 @@ class NPTSPredictor(RepresentablePredictor):
       Forecaster (i.e., with the `exponential` kernel) and no features for the
       Climatological Forecaster (i.e., the `uniform` kernel).
 
-      For seasonal NPTS and seasonal Climatological, time features determined
-      based on the frequency of the time series are added to the default
-      feature map.
+      For seasonal NPTS and seasonal Climatological, time features are
+      determined based on the frequency of the time series are added to the
+      default feature map.
 
       The default time features for various frequencies are
 
@@ -242,6 +242,7 @@ class NPTSPredictor(RepresentablePredictor):
             number of samples to draw
         item_id
             item_id to identify the time series
+
         Returns
         -------
         Forecast

--- a/src/gluonts/model/npts/_predictor.py
+++ b/src/gluonts/model/npts/_predictor.py
@@ -122,8 +122,6 @@ class NPTSPredictor(RepresentablePredictor):
     Parameters
     ----------
 
-    freq
-        time frequency string
     prediction_length
         number of time steps to predict
     context_length
@@ -153,7 +151,6 @@ class NPTSPredictor(RepresentablePredictor):
     @validated()
     def __init__(
         self,
-        freq: str,
         prediction_length: int,
         context_length: Optional[int] = None,
         kernel_type: KernelType = KernelType.exponential,
@@ -174,7 +171,6 @@ class NPTSPredictor(RepresentablePredictor):
         self.use_seasonal_model = use_seasonal_model
         self.use_default_time_features = use_default_time_features
         self.feature_scale = feature_scale
-        self.freq = freq
 
         if not self._is_exp_kernel():
             self.kernel = NPTS.uniform_kernel()
@@ -197,9 +193,7 @@ class NPTSPredictor(RepresentablePredictor):
         for data in dataset:
             start = data["start"]
             target = np.asarray(data["target"], np.float32)
-            index = pd.period_range(
-                start=start, freq=self.freq, periods=len(target)
-            )
+            index = pd.period_range(start=start, periods=len(target))
             item_id = data.get("item_id", None)
 
             # Slice the time series until context_length or history length

--- a/src/gluonts/model/npts/_predictor.py
+++ b/src/gluonts/model/npts/_predictor.py
@@ -193,7 +193,9 @@ class NPTSPredictor(RepresentablePredictor):
         for data in dataset:
             start = data["start"]
             target = np.asarray(data["target"], np.float32)
-            index = pd.period_range(start=start, periods=len(target))
+            index = pd.period_range(
+                start=start, freq=start.freq, periods=len(target)
+            )
             item_id = data.get("item_id", None)
 
             # Slice the time series until context_length or history length

--- a/test/model/npts/test_npts.py
+++ b/test/model/npts/test_npts.py
@@ -96,7 +96,6 @@ def test_climatological_forecaster(
     predictor = NPTSPredictor(
         prediction_length=pred_length,
         context_length=context_length,
-        freq=freq,
         use_seasonal_model=use_seasonal_model,
         kernel_type=KernelType.uniform,
     )
@@ -259,7 +258,6 @@ def test_npts_forecaster(
     predictor = NPTSPredictor(
         prediction_length=pred_length,
         context_length=context_length,
-        freq=freq,
         kernel_type=KernelType.exponential,
         feature_scale=feature_scale,
         use_seasonal_model=use_seasonal_model,
@@ -422,7 +420,6 @@ def test_npts_custom_features(
 
     predictor = NPTSPredictor(
         prediction_length=pred_length,
-        freq=freq,
         context_length=context_length,
         kernel_type=KernelType.exponential,
         feature_scale=feature_scale,
@@ -532,20 +529,14 @@ def _test_nans_in_target(predictor: NPTSPredictor, dataset: Dataset) -> None:
     """
 
     # a copy of dataset with 90% of the target entries NaNs
-    ds_090pct_nans = ListDataset(
-        data_iter=[
-            _inject_nans_in_target(data_entry, p=0.9) for data_entry in dataset
-        ],
-        freq=predictor.freq,
-    )
+    ds_090pct_nans = [
+        _inject_nans_in_target(data_entry, p=0.9) for data_entry in dataset
+    ]
 
     # a copy of dataset with 100% of the target entries NaNs
-    ds_100pct_nans = ListDataset(
-        data_iter=[
-            _inject_nans_in_target(data_entry, p=1.0) for data_entry in dataset
-        ],
-        freq=predictor.freq,
-    )
+    ds_100pct_nans = [
+        _inject_nans_in_target(data_entry, p=1.0) for data_entry in dataset
+    ]
 
     # assert that we can tolerate a high percentage of NaNs
     for forecast in predictor.predict(ds_090pct_nans):


### PR DESCRIPTION
*Description of changes:* Frequency information in NPTS does not need to be hard-coded in the predictor object, as it can be extracted from the time index of each individual series.

Marked as breaking since the constructor obviously changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup