### PR TITLE
Fix pytorch_lightning imports

### DIFF
--- a/docs/tutorials/advanced_topics/howto_pytorch_lightning.md.template
+++ b/docs/tutorials/advanced_topics/howto_pytorch_lightning.md.template
@@ -134,7 +134,7 @@ To train the model using PyTorch Lightning, we only need to extend the class wit
 
 
 ```python
-import lightning.pytorch as pl
+import pytorch_lightning as pl
 ```
 
 

--- a/requirements/requirements-pytorch.txt
+++ b/requirements/requirements-pytorch.txt
@@ -1,6 +1,4 @@
 torch>=1.9,<3
-lightning>=1.8,<2.2
-# Capping `lightning` does not cap `pytorch_lightning`, so we cap manually
 pytorch_lightning>=1.8,<2.2
 # Need to pin protobuf (for now)
 # See: https://github.com/PyTorchLightning/pytorch-lightning/issues/13159

--- a/src/gluonts/torch/model/d_linear/estimator.py
+++ b/src/gluonts/torch/model/d_linear/estimator.py
@@ -14,7 +14,7 @@
 from typing import Optional, Iterable, Dict, Any
 
 import torch
-import lightning.pytorch as pl
+import pytorch_lightning as pl
 
 from gluonts.core.component import validated
 from gluonts.dataset.common import Dataset

--- a/src/gluonts/torch/model/d_linear/lightning_module.py
+++ b/src/gluonts/torch/model/d_linear/lightning_module.py
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-import lightning.pytorch as pl
+import pytorch_lightning as pl
 import torch
 
 from gluonts.core.component import validated

--- a/src/gluonts/torch/model/deepar/lightning_module.py
+++ b/src/gluonts/torch/model/deepar/lightning_module.py
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-import lightning.pytorch as pl
+import pytorch_lightning as pl
 import torch
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 

--- a/src/gluonts/torch/model/estimator.py
+++ b/src/gluonts/torch/model/estimator.py
@@ -15,7 +15,7 @@ from typing import NamedTuple, Optional, Iterable, Dict, Any
 import logging
 
 import numpy as np
-import lightning.pytorch as pl
+import pytorch_lightning as pl
 import torch.nn as nn
 
 from gluonts.core.component import validated

--- a/src/gluonts/torch/model/lag_tst/estimator.py
+++ b/src/gluonts/torch/model/lag_tst/estimator.py
@@ -14,7 +14,7 @@
 from typing import Optional, Iterable, Dict, Any, List
 
 import torch
-import lightning.pytorch as pl
+import pytorch_lightning as pl
 
 from gluonts.core.component import validated
 from gluonts.dataset.common import Dataset

--- a/src/gluonts/torch/model/lag_tst/lightning_module.py
+++ b/src/gluonts/torch/model/lag_tst/lightning_module.py
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-import lightning.pytorch as pl
+import pytorch_lightning as pl
 import torch
 
 from gluonts.core.component import validated

--- a/src/gluonts/torch/model/lightning_util.py
+++ b/src/gluonts/torch/model/lightning_util.py
@@ -13,7 +13,7 @@
 
 from packaging import version
 
-import lightning.pytorch as pl
+import pytorch_lightning as pl
 
 
 def has_validation_loop(trainer: pl.Trainer):

--- a/src/gluonts/torch/model/mqf2/lightning_module.py
+++ b/src/gluonts/torch/model/mqf2/lightning_module.py
@@ -13,7 +13,7 @@
 
 from typing import Dict
 
-import lightning.pytorch as pl
+import pytorch_lightning as pl
 import torch
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 

--- a/src/gluonts/torch/model/patch_tst/estimator.py
+++ b/src/gluonts/torch/model/patch_tst/estimator.py
@@ -14,7 +14,7 @@
 from typing import Optional, Iterable, Dict, Any
 
 import torch
-import lightning.pytorch as pl
+import pytorch_lightning as pl
 
 from gluonts.core.component import validated
 from gluonts.dataset.common import Dataset

--- a/src/gluonts/torch/model/patch_tst/lightning_module.py
+++ b/src/gluonts/torch/model/patch_tst/lightning_module.py
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-import lightning.pytorch as pl
+import pytorch_lightning as pl
 import torch
 
 from gluonts.core.component import validated

--- a/src/gluonts/torch/model/simple_feedforward/estimator.py
+++ b/src/gluonts/torch/model/simple_feedforward/estimator.py
@@ -14,7 +14,7 @@
 from typing import List, Optional, Iterable, Dict, Any
 
 import torch
-import lightning.pytorch as pl
+import pytorch_lightning as pl
 
 from gluonts.core.component import validated
 from gluonts.dataset.common import Dataset

--- a/src/gluonts/torch/model/simple_feedforward/lightning_module.py
+++ b/src/gluonts/torch/model/simple_feedforward/lightning_module.py
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-import lightning.pytorch as pl
+import pytorch_lightning as pl
 import torch
 
 from gluonts.core.component import validated

--- a/src/gluonts/torch/model/tft/lightning_module.py
+++ b/src/gluonts/torch/model/tft/lightning_module.py
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-import lightning.pytorch as pl
+import pytorch_lightning as pl
 import torch
 from gluonts.core.component import validated
 from gluonts.itertools import select


### PR DESCRIPTION
*Description of changes:*
- Make the code compatible with `pytorch_lightning>=1.8,<2.2` by using the old import style.
- This is required since adding the requirement on `lightning` caps the compatibility to `pytorch_lightning>=2.0`, which may conflict with downstream requirements

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup