### PR TITLE
Fix version range for lightning

### DIFF
--- a/requirements/requirements-pytorch.txt
+++ b/requirements/requirements-pytorch.txt
@@ -1,9 +1,6 @@
 torch>=1.9,<3
-lightning>=1.8,<2.2
+lightning>=2.0,<2.2
 # Capping `lightning` does not cap `pytorch_lightning`, so we cap manually
-pytorch_lightning>=1.8,<2.2
-# Need to pin protobuf (for now)
-# See: https://github.com/PyTorchLightning/pytorch-lightning/issues/13159
-protobuf~=3.19.0
+pytorch_lightning>=2.0,<2.2
 scipy~=1.10; python_version > "3.7.0"
 scipy~=1.7.3; python_version <= "3.7.0"


### PR DESCRIPTION
*Description of changes:*
- In v0.14, we move to the new style of `lightning` imports. These imports are only compatible with `lightning>=2.0` and `pytorch_lightning>=2.0`, so the version range has been updated accordingly.
- Remove the pinned `protobuf` version as the respective issue has been fixed https://github.com/Lightning-AI/lightning/issues/13159.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup