### PR TITLE
Allow VCS install using GLUONTS_FALLBACK_VERSION

### DIFF
--- a/src/gluonts/meta/_version.py
+++ b/src/gluonts/meta/_version.py
@@ -60,9 +60,11 @@ In `setup.py`, you need to import and use this file like this:
     )
 """
 
+import os
 import subprocess
 from pathlib import Path
 
+FALLBACK_VERSION = os.environ.get("GLUONTS_FALLBACK_VERSION", "0.0.0")
 
 GIT_DESCRIBE = [
     "git",
@@ -250,4 +252,4 @@ def cmdclass():
     return {"sdist": sdist, "build_py": build_py}
 
 
-__version__ = get_version(fallback="0.0.0")
+__version__ = get_version(fallback=FALLBACK_VERSION)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Allow pip install from source without having git history locally:
```
export GLUONTS_FALLBACK_VERSION=0.13.8
pip install 'gluonts @ https://github.com/ddelange/gluonts/archive/refs/heads/vcs.zip'
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup