### PR TITLE
Fix edge cases in metric computation

### DIFF
--- a/src/gluonts/ev/aggregations.py
+++ b/src/gluonts/ev/aggregations.py
@@ -69,8 +69,10 @@ class Sum(Aggregation):
         assert self.axis is None or isinstance(self.axis, tuple)
 
         if self.axis is None or 0 in self.axis:
+            assert isinstance(self.partial_result, np.ndarray)
             return np.copy(self.partial_result)
 
+        assert isinstance(self.partial_result, list)
         return np.concatenate(self.partial_result)
 
 
@@ -123,4 +125,5 @@ class Mean(Aggregation):
             assert isinstance(self.partial_result, np.ndarray)
             return self.partial_result / self.n
 
+        assert isinstance(self.partial_result, list)
         return np.ma.concatenate(self.partial_result)

--- a/src/gluonts/ev/aggregations.py
+++ b/src/gluonts/ev/aggregations.py
@@ -109,7 +109,7 @@ class Mean(Aggregation):
             if self.partial_result is None:
                 self.partial_result = []
 
-            mean_values = np.ma.mean(values, axis=self.axis)
+            mean_values = np.nanmean(values, axis=self.axis)
             assert isinstance(self.partial_result, list)
             self.partial_result.append(mean_values)
 
@@ -121,4 +121,4 @@ class Mean(Aggregation):
             return self.partial_result / self.n
 
         assert isinstance(self.partial_result, list)
-        return np.ma.concatenate(self.partial_result)
+        return np.concatenate(self.partial_result)

--- a/src/gluonts/ev/aggregations.py
+++ b/src/gluonts/ev/aggregations.py
@@ -13,7 +13,6 @@
 
 from dataclasses import dataclass
 from typing import List, Optional, Union
-from typing_extensions import Self
 
 import numpy as np
 
@@ -48,7 +47,7 @@ class Sum(Aggregation):
 
     partial_result: Optional[Union[List[np.ndarray], np.ndarray]] = None
 
-    def step(self, values: np.ndarray) -> Self:
+    def step(self, values: np.ndarray) -> None:
         assert self.axis is None or isinstance(self.axis, tuple)
 
         summed_values = np.nansum(values, axis=self.axis)
@@ -62,8 +61,6 @@ class Sum(Aggregation):
                 self.partial_result = []
             assert isinstance(self.partial_result, list)
             self.partial_result.append(summed_values)
-
-        return self
 
     def get(self) -> np.ndarray:
         assert self.axis is None or isinstance(self.axis, tuple)
@@ -94,7 +91,7 @@ class Mean(Aggregation):
     partial_result: Optional[Union[List[np.ndarray], np.ndarray]] = None
     n: Optional[Union[int, np.ndarray]] = None
 
-    def step(self, values: np.ndarray) -> Self:
+    def step(self, values: np.ndarray) -> None:
         assert self.axis is None or isinstance(self.axis, tuple)
 
         if self.axis is None or 0 in self.axis:
@@ -115,8 +112,6 @@ class Mean(Aggregation):
             mean_values = np.ma.mean(values, axis=self.axis)
             assert isinstance(self.partial_result, list)
             self.partial_result.append(mean_values)
-
-        return self
 
     def get(self) -> np.ndarray:
         assert self.axis is None or isinstance(self.axis, tuple)

--- a/src/gluonts/ev/aggregations.py
+++ b/src/gluonts/ev/aggregations.py
@@ -25,7 +25,7 @@ class Aggregation:
         if isinstance(self.axis, int):
             self.axis = (self.axis,)
 
-    def step(self, values: np.ndarray) -> Self:
+    def step(self, values: np.ndarray) -> None:
         raise NotImplementedError
 
     def get(self) -> np.ndarray:

--- a/src/gluonts/ev/metrics.py
+++ b/src/gluonts/ev/metrics.py
@@ -492,7 +492,7 @@ class MeanSumQuantileLoss(BaseMetricDefinition):
             [quantile_loss for quantile_loss in quantile_losses.values()],
             axis=0,
         )
-        return np.ma.mean(stacked_quantile_losses, axis=0)
+        return np.mean(stacked_quantile_losses, axis=0)
 
     def __call__(self, axis: Optional[int] = None) -> DerivedMetric:
         return DerivedMetric(
@@ -515,7 +515,7 @@ class MeanWeightedSumQuantileLoss(BaseMetricDefinition):
             [quantile_loss for quantile_loss in quantile_losses.values()],
             axis=0,
         )
-        return np.ma.mean(stacked_quantile_losses, axis=0)
+        return np.mean(stacked_quantile_losses, axis=0)
 
     def __call__(self, axis: Optional[int] = None) -> DerivedMetric:
         return DerivedMetric(
@@ -538,7 +538,7 @@ class AverageMeanScaledQuantileLoss(BaseMetricDefinition):
             [quantile_loss for quantile_loss in quantile_losses.values()],
             axis=0,
         )
-        return np.ma.mean(stacked_quantile_losses, axis=0)
+        return np.mean(stacked_quantile_losses, axis=0)
 
     def __call__(self, axis: Optional[int] = None) -> DerivedMetric:
         return DerivedMetric(
@@ -565,7 +565,7 @@ class MAECoverage(BaseMetricDefinition):
             [np.abs(coverages[f"coverage[{q}]"] - q) for q in quantile_levels],
             axis=0,
         )
-        return np.ma.mean(intermediate_result, axis=0)
+        return np.mean(intermediate_result, axis=0)
 
     def __call__(self, axis: Optional[int] = None) -> DerivedMetric:
         return DerivedMetric(

--- a/test/ev/test_aggregations.py
+++ b/test/ev/test_aggregations.py
@@ -33,20 +33,24 @@ from gluonts.itertools import power_set
             np.zeros(9),
         ),
         (
-            np.ma.masked_invalid([
-                np.full((3, 5), np.nan),
-                np.full((3, 5), np.nan),
-                np.full((3, 5), np.nan),
-            ]),
+            np.ma.masked_invalid(
+                [
+                    np.full((3, 5), np.nan),
+                    np.full((3, 5), np.nan),
+                    np.full((3, 5), np.nan),
+                ]
+            ),
             0,
             np.zeros(5),
             np.zeros(9),
         ),
         (
-            np.ma.masked_invalid([
-                np.array([[0, np.nan], [0, 0]]),
-                np.array([[0, 5], [-5, np.nan]]),
-            ]),
+            np.ma.masked_invalid(
+                [
+                    np.array([[0, np.nan], [0, 0]]),
+                    np.array([[0, 5], [-5, np.nan]]),
+                ]
+            ),
             0,
             np.array([-5, 5]),
             np.array([0, 0, 5, -5]),
@@ -87,20 +91,24 @@ def test_Sum(value_stream, res_axis_none, res_axis_0, res_axis_1):
             np.zeros(9),
         ),
         (
-            np.ma.masked_invalid([
-                np.full((3, 5), np.nan),
-                np.full((3, 5), np.nan),
-                np.full((3, 5), np.nan),
-            ]),
+            np.ma.masked_invalid(
+                [
+                    np.full((3, 5), np.nan),
+                    np.full((3, 5), np.nan),
+                    np.full((3, 5), np.nan),
+                ]
+            ),
             np.nan,
             np.full(5, np.nan),
             np.full(9, np.nan),
         ),
         (
-            np.ma.masked_invalid([
-                np.array([[0, np.nan], [0, 0]]),
-                np.array([[0, 5], [-5, np.nan]]),
-            ]),
+            np.ma.masked_invalid(
+                [
+                    np.array([[0, np.nan], [0, 0]]),
+                    np.array([[0, 5], [-5, np.nan]]),
+                ]
+            ),
             0,
             np.array([-1.25, 2.5]),
             np.array([0, 0, 2.5, -5]),

--- a/test/ev/test_aggregations.py
+++ b/test/ev/test_aggregations.py
@@ -24,19 +24,29 @@ from gluonts.itertools import power_set
     [
         (
             [
-                np.full((3, 5), np.nan),
-                np.full((3, 5), np.nan),
-                np.full((3, 5), np.nan),
+                np.full((3, 5), 0.0),
+                np.full((3, 5), 0.0),
+                np.full((3, 5), 0.0),
             ],
+            0.0,
+            np.zeros(5),
+            np.zeros(9),
+        ),
+        (
+            np.ma.masked_invalid([
+                np.full((3, 5), np.nan),
+                np.full((3, 5), np.nan),
+                np.full((3, 5), np.nan),
+            ]),
             0,
             np.zeros(5),
             np.zeros(9),
         ),
         (
-            [
+            np.ma.masked_invalid([
                 np.array([[0, np.nan], [0, 0]]),
                 np.array([[0, 5], [-5, np.nan]]),
-            ],
+            ]),
             0,
             np.array([-5, 5]),
             np.array([0, 0, 5, -5]),
@@ -58,7 +68,7 @@ def test_Sum(value_stream, res_axis_none, res_axis_0, res_axis_1):
     ):
         sum = Sum(axis=axis)
         for values in value_stream:
-            sum.step(np.ma.masked_invalid(values))
+            sum.step(values)
 
         np.testing.assert_almost_equal(sum.get(), expected_result)
 
@@ -68,19 +78,29 @@ def test_Sum(value_stream, res_axis_none, res_axis_0, res_axis_1):
     [
         (
             [
-                np.full((3, 5), np.nan),
-                np.full((3, 5), np.nan),
-                np.full((3, 5), np.nan),
+                np.full((3, 5), 0.0),
+                np.full((3, 5), 0.0),
+                np.full((3, 5), 0.0),
             ],
+            0.0,
+            np.zeros(5),
+            np.zeros(9),
+        ),
+        (
+            np.ma.masked_invalid([
+                np.full((3, 5), np.nan),
+                np.full((3, 5), np.nan),
+                np.full((3, 5), np.nan),
+            ]),
             np.nan,
             np.full(5, np.nan),
             np.full(9, np.nan),
         ),
         (
-            [
+            np.ma.masked_invalid([
                 np.array([[0, np.nan], [0, 0]]),
                 np.array([[0, 5], [-5, np.nan]]),
-            ],
+            ]),
             0,
             np.array([-1.25, 2.5]),
             np.array([0, 0, 2.5, -5]),
@@ -102,7 +122,7 @@ def test_Mean(value_stream, res_axis_none, res_axis_0, res_axis_1):
     ):
         mean = Mean(axis=axis)
         for values in value_stream:
-            mean.step(np.ma.masked_invalid(values))
+            mean.step(values)
 
         np.testing.assert_almost_equal(mean.get(), expected_result)
 

--- a/test/ev/test_metrics.py
+++ b/test/ev/test_metrics.py
@@ -59,7 +59,7 @@ METRICS = [
     METRICS,
 )
 @pytest.mark.parametrize("axis", [None, (0, 1), (0,), (1,), ()])
-def test_metric(metric: MetricDefinition, axis: Optional[tuple]):
+def test_metric_shape(metric: MetricDefinition, axis: Optional[tuple]):
     input_length = 20
     label_length = 5
     num_entries = 7
@@ -98,3 +98,40 @@ def test_metric(metric: MetricDefinition, axis: Optional[tuple]):
         raise ValueError("unsupported axis")
 
     return metric_value
+
+
+@pytest.mark.parametrize(
+    "metric",
+    [
+        ND(),
+        MASE(),
+        WeightedSumQuantileLoss(0.5),
+        MeanWeightedSumQuantileLoss([0.1, 0.5, 0.9]),
+        MeanScaledQuantileLoss(0.5),
+        AverageMeanScaledQuantileLoss([0.1, 0.5, 0.9]),
+    ],
+)
+@pytest.mark.parametrize("axis", [None, (0, 1), (0,), (1,), ()])
+def test_metric_inf(metric: MetricDefinition, axis: Optional[tuple]):
+    time_series_length = 3
+    number_of_entries = 2
+
+    data = {
+        "label": np.zeros((1, time_series_length)),
+        "0.5": np.ones((1, time_series_length)),
+        "0.1": np.ones((1, time_series_length)),
+        "0.9": np.ones((1, time_series_length)),
+        "seasonal_error": 0.0,
+    }
+
+    evaluator = metric(axis=axis)
+    for _ in range(number_of_entries):
+        evaluator.update(data)
+
+    result = evaluator.get()
+    expected = np.full((number_of_entries, time_series_length), np.inf).sum(
+        axis=axis
+    )
+
+    assert result.shape == expected.shape
+    assert np.allclose(result, expected)

--- a/test/ev/test_metrics.py
+++ b/test/ev/test_metrics.py
@@ -105,6 +105,7 @@ def test_metric_shape(metric: MetricDefinition, axis: Optional[tuple]):
     [
         ND(),
         MASE(),
+        NRMSE(),
         WeightedSumQuantileLoss(0.5),
         MeanWeightedSumQuantileLoss([0.1, 0.5, 0.9]),
         MeanScaledQuantileLoss(0.5),
@@ -121,6 +122,7 @@ def test_metric_inf(metric: MetricDefinition, axis: Optional[tuple]):
         "0.5": np.ones((1, time_series_length)),
         "0.1": np.ones((1, time_series_length)),
         "0.9": np.ones((1, time_series_length)),
+        "mean": np.ones((1, time_series_length)),
         "seasonal_error": 0.0,
     }
 

--- a/test/ev/test_metrics.py
+++ b/test/ev/test_metrics.py
@@ -138,3 +138,44 @@ def test_metric_inf(metric: MetricDefinition, axis: Optional[tuple]):
 
     assert result.shape == expected.shape
     assert np.allclose(result, expected)
+
+
+@pytest.mark.parametrize(
+    "metric",
+    [
+        ND(),
+        MASE(),
+        MAPE(),
+        SMAPE(),
+        NRMSE(),
+        WeightedSumQuantileLoss(0.5),
+        MeanWeightedSumQuantileLoss([0.1, 0.5, 0.9]),
+        MeanScaledQuantileLoss(0.5),
+        AverageMeanScaledQuantileLoss([0.1, 0.5, 0.9]),
+    ],
+)
+@pytest.mark.parametrize("axis", [None, (0, 1), (0,), (1,), ()])
+def test_metric_nan(metric: MetricDefinition, axis: Optional[tuple]):
+    time_series_length = 3
+    number_of_entries = 2
+
+    data = {
+        "label": np.zeros((1, time_series_length)),
+        "0.5": np.zeros((1, time_series_length)),
+        "0.1": np.zeros((1, time_series_length)),
+        "0.9": np.zeros((1, time_series_length)),
+        "mean": np.zeros((1, time_series_length)),
+        "seasonal_error": 0.0,
+    }
+
+    evaluator = metric(axis=axis)
+    for _ in range(number_of_entries):
+        evaluator.update(data)
+
+    result = evaluator.get()
+    expected = np.full((number_of_entries, time_series_length), np.nan).sum(
+        axis=axis
+    )
+
+    assert result.shape == expected.shape
+    assert np.allclose(result, expected, equal_nan=True)

--- a/test/ev/test_metrics.py
+++ b/test/ev/test_metrics.py
@@ -105,6 +105,7 @@ def test_metric_shape(metric: MetricDefinition, axis: Optional[tuple]):
     [
         ND(),
         MASE(),
+        MAPE(),
         NRMSE(),
         WeightedSumQuantileLoss(0.5),
         MeanWeightedSumQuantileLoss([0.1, 0.5, 0.9]),


### PR DESCRIPTION
*Issue #, if available:* #3034

*Description of changes:* Excessive usage of numpy masked arrays resulted in incorrect metric value aggregation. Added extensive testing for cases where metrics are expected to evaluate to `inf` or `nan`, using different aggregations: 45/95 of the test cases added in `test_metrics.py` would fail on `dev`.

Minor changes: small refactoring and added test cases to `test_aggregations.py`.

TODOs:
- [x] add test cases

MWE:

```python
import numpy as np
from gluonts.ev.metrics import (
    ND,
    WeightedSumQuantileLoss,
    MeanWeightedSumQuantileLoss,
    MeanScaledQuantileLoss,
    AverageMeanScaledQuantileLoss,
)

data = {
    "label": np.zeros((20)),
    "0.5": np.ones(20),
    "0.1": np.ones(20),
    "0.9": np.ones(20),
    "seasonal_error": 0.0,
}


def print_with_type(v):
    print(f"{type(v)}: {v}")


metrics = [
    ND(),
    WeightedSumQuantileLoss(0.5),
    MeanWeightedSumQuantileLoss([0.1, 0.5, 0.9]),
    MeanScaledQuantileLoss(0.5),
    AverageMeanScaledQuantileLoss([0.1, 0.5, 0.9]),
]

for metric in metrics:
    print_with_type(metric().update(data).get())
```

Before:

```
<class 'numpy.ma.core.MaskedConstant'>: --
<class 'numpy.ma.core.MaskedConstant'>: --
<class 'numpy.float64'>: 0.0
/Users/stellalo/gluonts/src/gluonts/ev/stats.py:101: RuntimeWarning: divide by zero encountered in divide
  return quantile_loss(data, q) / data["seasonal_error"]
<class 'numpy.float64'>: inf
<class 'numpy.ma.core.MaskedConstant'>: --
```

After:

```
/Users/stellalo/gluonts/src/gluonts/ev/metrics.py:393: RuntimeWarning: divide by zero encountered in divide
  return sum_absolute_error / sum_absolute_label
<class 'numpy.float64'>: inf
/Users/stellalo/gluonts/src/gluonts/ev/metrics.py:472: RuntimeWarning: divide by zero encountered in divide
  return sum_quantile_loss / sum_absolute_label
<class 'numpy.float64'>: inf
<class 'numpy.float64'>: inf
/Users/stellalo/gluonts/src/gluonts/ev/stats.py:101: RuntimeWarning: divide by zero encountered in divide
  return quantile_loss(data, q) / data["seasonal_error"]
<class 'numpy.float64'>: inf
<class 'numpy.float64'>: inf
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup