### PR TITLE
ev: Batch data for faster evaluation.

### DIFF
--- a/src/gluonts/model/evaluation.py
+++ b/src/gluonts/model/evaluation.py
@@ -13,7 +13,7 @@
 
 import logging
 from collections import ChainMap
-from typing import Iterable, Optional, Union
+from typing import Iterable, List, Optional, Union
 from dataclasses import dataclass
 from toolz import first, valmap
 
@@ -23,10 +23,9 @@ from tqdm import tqdm
 
 from gluonts.dataset import DataEntry
 from gluonts.dataset.split import TestData
-from gluonts.time_feature.seasonality import get_seasonality
 from gluonts.model import Forecast, Predictor
 from gluonts.ev.ts_stats import seasonal_error
-from gluonts.itertools import prod
+from gluonts.itertools import batcher, prod
 
 logger = logging.getLogger(__name__)
 
@@ -39,12 +38,14 @@ class BatchForecast:
     ``gluonts.ev``.
     """
 
-    forecast: Forecast
+    forecasts: List[Forecast]
     allow_nan: bool = False
 
     def __getitem__(self, name):
-        value = self.forecast[name]
-        if np.isnan(value).any():
+        values = [forecast[name].T for forecast in self.forecasts]
+        res = np.stack(values, axis=0)
+
+        if np.isnan(res).any():
             if not self.allow_nan:
                 raise ValueError("Forecast contains NaN values")
 
@@ -52,40 +53,38 @@ class BatchForecast:
                 "Forecast contains NaN values. Metrics may be incorrect."
             )
 
-        return np.expand_dims(value.T, axis=0)
+        return res
 
 
 def _get_data_batch(
-    input_: DataEntry,
-    label: DataEntry,
-    forecast: Forecast,
-    seasonality: Optional[int] = None,
+    input_batch: List[DataEntry],
+    label_batch: List[DataEntry],
+    forecast_batch: List[Forecast],
+    seasonality: int = 1,
     mask_invalid_label: bool = True,
     allow_nan_forecast: bool = False,
 ) -> ChainMap:
-    forecast_dict = BatchForecast(forecast, allow_nan=allow_nan_forecast)
-
-    freq = forecast.start_date.freqstr
-    if seasonality is None:
-        seasonality = get_seasonality(freq=freq)
-
-    label_target = label["target"]
-    input_target = input_["target"]
+    label_target = np.stack([label["target"] for label in label_batch], axis=0)
     if mask_invalid_label:
         label_target = np.ma.masked_invalid(label_target)
-        input_target = np.ma.masked_invalid(input_target)
 
     other_data = {
-        "label": np.expand_dims(label_target, axis=0),
-        "seasonal_error": np.expand_dims(
-            seasonal_error(
-                input_target, seasonality=seasonality, time_axis=-1
-            ),
-            axis=0,
-        ),
+        "label": label_target,
     }
 
-    return ChainMap(other_data, forecast_dict)  # type: ignore
+    seasonal_error_values = []
+    for input_ in input_batch:
+        input_target = input_["target"]
+        if mask_invalid_label:
+            input_target = np.ma.masked_invalid(input_target)
+        seasonal_error_values.append(
+            seasonal_error(input_target, seasonality=seasonality, time_axis=-1)
+        )
+    other_data["seasonal_error"] = np.array(seasonal_error_values)
+
+    return ChainMap(
+        other_data, BatchForecast(forecast_batch, allow_nan=allow_nan_forecast)
+    )
 
 
 def evaluate_forecasts_raw(
@@ -94,9 +93,10 @@ def evaluate_forecasts_raw(
     test_data: TestData,
     metrics,
     axis: Optional[Union[int, tuple]] = None,
+    batch_size: int = 100,
     mask_invalid_label: bool = True,
     allow_nan_forecast: bool = False,
-    seasonality: Optional[int] = None
+    seasonality: int = 1
 ) -> dict:
     """
     Evaluate ``forecasts`` by comparing them with ``test_data``, according
@@ -130,16 +130,26 @@ def evaluate_forecasts_raw(
 
     index_data = []
 
-    for input_, label, forecast in tqdm(
-        zip(test_data.input, test_data.label, forecasts)
+    input_batches = batcher(test_data.input, batch_size=batch_size)
+    label_batches = batcher(test_data.label, batch_size=batch_size)
+    forecast_batches = batcher(forecasts, batch_size=batch_size)
+
+    pbar = tqdm()
+    for input_batch, label_batch, forecast_batch in zip(
+        input_batches, label_batches, forecast_batches
     ):
         if 0 not in axis:
-            index_data.append((forecast.item_id, forecast.start_date))
+            index_data.extend(
+                [
+                    (forecast.item_id, forecast.start_date)
+                    for forecast in forecast_batch
+                ]
+            )
 
         data_batch = _get_data_batch(
-            input_,
-            label,
-            forecast,
+            input_batch,
+            label_batch,
+            forecast_batch,
             seasonality=seasonality,
             mask_invalid_label=mask_invalid_label,
             allow_nan_forecast=allow_nan_forecast,
@@ -147,6 +157,9 @@ def evaluate_forecasts_raw(
 
         for evaluator in evaluators.values():
             evaluator.update(data_batch)
+
+        pbar.update(len(forecast_batch))
+    pbar.close()
 
     metrics_values = {
         metric_name: evaluator.get()
@@ -165,9 +178,10 @@ def evaluate_forecasts(
     test_data: TestData,
     metrics,
     axis: Optional[Union[int, tuple]] = None,
+    batch_size: int = 100,
     mask_invalid_label: bool = True,
     allow_nan_forecast: bool = False,
-    seasonality: Optional[int] = None
+    seasonality: int = 1
 ) -> pd.DataFrame:
     """
     Evaluate ``forecasts`` by comparing them with ``test_data``, according
@@ -188,6 +202,7 @@ def evaluate_forecasts(
         test_data=test_data,
         metrics=metrics,
         axis=axis,
+        batch_size=batch_size,
         mask_invalid_label=mask_invalid_label,
         allow_nan_forecast=allow_nan_forecast,
         seasonality=seasonality,
@@ -217,9 +232,10 @@ def evaluate_model(
     test_data: TestData,
     metrics,
     axis: Optional[Union[int, tuple]] = None,
+    batch_size: int = 100,
     mask_invalid_label: bool = True,
     allow_nan_forecast: bool = False,
-    seasonality: Optional[int] = None
+    seasonality: int = 1
 ) -> pd.DataFrame:
     """
     Evaluate ``model`` when applied to ``test_data``, according
@@ -242,6 +258,7 @@ def evaluate_model(
         test_data=test_data,
         metrics=metrics,
         axis=axis,
+        batch_size=batch_size,
         mask_invalid_label=mask_invalid_label,
         allow_nan_forecast=allow_nan_forecast,
         seasonality=seasonality,

--- a/src/gluonts/model/evaluation.py
+++ b/src/gluonts/model/evaluation.py
@@ -83,7 +83,7 @@ def _get_data_batch(
     other_data["seasonal_error"] = np.array(seasonal_error_values)
 
     return ChainMap(
-        other_data, BatchForecast(forecast_batch, allow_nan=allow_nan_forecast)
+        other_data, BatchForecast(forecast_batch, allow_nan=allow_nan_forecast)  # type: ignore
     )
 
 

--- a/src/gluonts/model/evaluation.py
+++ b/src/gluonts/model/evaluation.py
@@ -104,7 +104,7 @@ def evaluate_forecasts_raw(
     batch_size: int = 100,
     mask_invalid_label: bool = True,
     allow_nan_forecast: bool = False,
-    seasonality: Optional[int] = None,
+    seasonality: Optional[int] = None
 ) -> dict:
     """
     Evaluate ``forecasts`` by comparing them with ``test_data``, according
@@ -189,7 +189,7 @@ def evaluate_forecasts(
     batch_size: int = 100,
     mask_invalid_label: bool = True,
     allow_nan_forecast: bool = False,
-    seasonality: Optional[int] = None,
+    seasonality: Optional[int] = None
 ) -> pd.DataFrame:
     """
     Evaluate ``forecasts`` by comparing them with ``test_data``, according
@@ -243,7 +243,7 @@ def evaluate_model(
     batch_size: int = 100,
     mask_invalid_label: bool = True,
     allow_nan_forecast: bool = False,
-    seasonality: Optional[int] = None,
+    seasonality: Optional[int] = None
 ) -> pd.DataFrame:
     """
     Evaluate ``model`` when applied to ``test_data``, according


### PR DESCRIPTION
*Description of changes:* Add batching to `gluonts.model.evaluation`, reaching speedups of ~6x in some cases (speedup depends also on how many metrics are being evaluated, more metrics => more speedup). The following example is using `m4_daily` data:

```
4227it [00:46, 91.83it/s]
evaluation (batch_size=1): 46.04444639701978
4227it [00:27, 152.03it/s]
evaluation (batch_size=2): 27.80498409701977
4227it [00:15, 277.03it/s]
evaluation (batch_size=5): 15.259674712986453
4227it [00:11, 371.23it/s]
evaluation (batch_size=10): 11.387762713013217
4227it [00:09, 451.05it/s]
evaluation (batch_size=20): 9.372666671988554
4227it [00:08, 512.34it/s]
evaluation (batch_size=50): 8.252159972995287
4227it [00:07, 546.00it/s]
evaluation (batch_size=100): 7.743695029988885
4227it [00:07, 561.83it/s]
evaluation (batch_size=200): 7.524872001988115
4227it [00:07, 576.23it/s]
evaluation (batch_size=500): 7.336895904998528
```

Code:

```python
import timeit
import numpy as np
import pandas as pd

from gluonts.ev.metrics import (
    SMAPE,
    MASE,
    NRMSE,
    ND,
    MeanWeightedSumQuantileLoss,
    AverageMeanScaledQuantileLoss,
    MAECoverage,
)
from gluonts.dataset.repository import get_dataset
from gluonts.dataset.split import split
from gluonts.model.evaluation import evaluate_forecasts
from gluonts.model import SampleForecast


quantile_levels = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]

METRICS = [
    SMAPE(),
    MASE(),
    NRMSE(),
    ND(),
    MeanWeightedSumQuantileLoss(quantile_levels=quantile_levels),
    AverageMeanScaledQuantileLoss(quantile_levels=quantile_levels),
    MAECoverage(quantile_levels=quantile_levels),
]


if __name__ == "__main__":
    data = list(get_dataset("m4_daily").test)
    test_data = split(data, offset=-14)[1].generate_instances(
        prediction_length=14
    )
    inputs = list(test_data.input)
    labels = list(test_data.label)

    forecasts = [
        SampleForecast(
            start_date=entry["start"],
            samples=np.random.normal(size=(100, 14)),
        )
        for entry in labels
    ]

    batch_sizes = [1, 2, 5, 10, 20, 50, 100, 200, 500]

    ref = None

    for batch_size in batch_sizes:
        t0 = timeit.default_timer()
        res = evaluate_forecasts(
            forecasts,
            test_data=test_data,
            metrics=METRICS,
            batch_size=batch_size,
            seasonality=7,
        )
        t1 = timeit.default_timer()
        if ref is None:
            ref = res
        else:
            pd.testing.assert_frame_equal(ref, res)
        print(f"evaluation ({batch_size=}): {t1 - t0}")
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup