### PR TITLE
Fix `iterable.Cached`.

### DIFF
--- a/src/gluonts/itertools.py
+++ b/src/gluonts/itertools.py
@@ -317,15 +317,19 @@ class Cached:
     """
 
     iterable: SizedIterable
+    _iterable: Iterable = field(init=False)
     cache: list = field(default_factory=list, init=False)
 
+    def __post_init__(self):
+        # ensure we only iterate once over the iterable
+        self._iterable = iter(self.iterable)
+
     def __iter__(self):
-        if not self.cache:
-            for element in self.iterable:
-                yield element
-                self.cache.append(element)
-        else:
-            yield from self.cache
+        yield from self.cache
+
+        for element in self._iterable:
+            self.cache.append(element)
+            yield element
 
     def __len__(self) -> int:
         return len(self.iterable)

--- a/src/gluonts/torch/model/estimator.py
+++ b/src/gluonts/torch/model/estimator.py
@@ -17,7 +17,6 @@ import logging
 import numpy as np
 import lightning.pytorch as pl
 import torch.nn as nn
-import torch.utils.data
 
 from gluonts.core.component import validated
 from gluonts.dataset.common import Dataset
@@ -28,17 +27,6 @@ from gluonts.torch.model.predictor import PyTorchPredictor
 from gluonts.transform import Transformation, TransformedDataset
 
 logger = logging.getLogger(__name__)
-
-
-class IterableDataset(torch.utils.data.IterableDataset):
-    def __init__(self, dataset):
-        self.dataset = dataset
-
-    def __iter__(self):
-        for num, el in enumerate(self.dataset, start=1):
-            print(num, len(el))
-            yield el
-        print("END")
 
 
 class TrainOutput(NamedTuple):
@@ -196,11 +184,9 @@ class PyTorchLightningEstimator(Estimator):
                         transformed_validation_data
                     )
 
-                validation_data_loader = IterableDataset(
-                    self.create_validation_data_loader(
-                        transformed_validation_data,
-                        training_network,
-                    )
+                validation_data_loader = self.create_validation_data_loader(
+                    transformed_validation_data,
+                    training_network,
                 )
 
         if from_predictor is not None:

--- a/src/gluonts/torch/model/estimator.py
+++ b/src/gluonts/torch/model/estimator.py
@@ -17,6 +17,7 @@ import logging
 import numpy as np
 import lightning.pytorch as pl
 import torch.nn as nn
+import torch.utils.data
 
 from gluonts.core.component import validated
 from gluonts.dataset.common import Dataset
@@ -27,6 +28,17 @@ from gluonts.torch.model.predictor import PyTorchPredictor
 from gluonts.transform import Transformation, TransformedDataset
 
 logger = logging.getLogger(__name__)
+
+
+class IterableDataset(torch.utils.data.IterableDataset):
+    def __init__(self, dataset):
+        self.dataset = dataset
+
+    def __iter__(self):
+        for num, el in enumerate(self.dataset, start=1):
+            print(num, len(el))
+            yield el
+        print("END")
 
 
 class TrainOutput(NamedTuple):
@@ -184,9 +196,11 @@ class PyTorchLightningEstimator(Estimator):
                         transformed_validation_data
                     )
 
-                validation_data_loader = self.create_validation_data_loader(
-                    transformed_validation_data,
-                    training_network,
+                validation_data_loader = IterableDataset(
+                    self.create_validation_data_loader(
+                        transformed_validation_data,
+                        training_network,
+                    )
                 )
 
         if from_predictor is not None:

--- a/test/test_itertools.py
+++ b/test/test_itertools.py
@@ -119,6 +119,16 @@ def test_pickle(iterable: Iterable, assert_content: bool):
         assert data == data_copy
 
 
+def test_cached_reentry():
+    data = Cached(range(10))
+
+    assert len(data) == 10
+    assert list(take(5, data)) == list(range(5))
+    assert len(data) == 10
+    assert list(take(10, data)) == list(range(10))
+    assert len(data) == 10
+
+
 @pytest.mark.parametrize(
     "given, expected",
     [


### PR DESCRIPTION
Previously, we only cached elements that were consumed on the first iteration.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup