### PR TITLE
Fix Rotbaum serialization and deserialization

### DIFF
--- a/src/gluonts/ext/rotbaum/_model.py
+++ b/src/gluonts/ext/rotbaum/_model.py
@@ -20,7 +20,7 @@ import xgboost
 import gc
 from collections import defaultdict
 
-from gluonts.core.component import validated
+from gluonts.core.component import equals, validated
 
 
 class QRF:
@@ -120,6 +120,13 @@ class QRX:
                 "objective": "reg:squarederror",
             }
         return xgboost.sklearn.XGBModel(**model_params)
+
+    def __eq__(self, that):
+        """
+        Two QRX instances are considered equal if they have the same
+        constructor arguments.
+        """
+        return equals(self, that)
 
     def fit(
         self,

--- a/src/gluonts/ext/rotbaum/_predictor.py
+++ b/src/gluonts/ext/rotbaum/_predictor.py
@@ -340,6 +340,30 @@ class TreePredictor(RepresentablePredictor):
                 item_id=ts.get("item_id"),
             )
 
+    def serialize(self, path: Path) -> None:
+        """
+        This function calls parent class serialize() in order to serialize
+        the class name, version information and constuctor arguments. It
+        persists the tree predictor by pickling the model list that is
+        generated when pickling the TreePredictor.
+        """
+        super().serialize(path)
+        with (path / "predictor.pkl").open("wb") as f:
+            pickle.dump(self.model_list, f)
+
+    @classmethod
+    def deserialize(cls, path: Path) -> "RepresentablePredictor":
+        """
+        This function loads and returns the serialized model. It calls
+        parent class deserialize() to load the predictor class with the
+        serialized arguments. It then loads the trained model list by
+        reading the pickle file.
+        """
+        predictor = super().deserialize(path)
+        with (path / "predictor.pkl").open("rb") as f:
+            predictor.model_list = pickle.load(f)
+        return predictor
+
     def explain(
         self, importance_type: str = "gain", percentage: bool = True
     ) -> ExplanationResult:

--- a/src/gluonts/ext/rotbaum/_predictor.py
+++ b/src/gluonts/ext/rotbaum/_predictor.py
@@ -13,12 +13,14 @@
 
 import concurrent.futures
 import logging
+import pickle
 from itertools import chain
 from typing import Iterator, List, Optional, Any, Dict
 from toolz import first
 
 import numpy as np
 import pandas as pd
+from pathlib import Path
 from itertools import compress
 
 from gluonts.core.component import validated

--- a/src/gluonts/ext/rotbaum/_predictor.py
+++ b/src/gluonts/ext/rotbaum/_predictor.py
@@ -362,8 +362,8 @@ class TreePredictor(RepresentablePredictor):
         the trained model list by reading the pickle file.
         """
 
-        with (path / "predictor.json").open("r") as fp:
-            predictor = load_json(fp.read())
+        predictor = super().deserialize(path)
+        assert isinstance(predictor, cls)
         with (path / "predictor.pkl").open("rb") as f:
             predictor.model_list = pickle.load(f)
         return predictor

--- a/src/gluonts/ext/rotbaum/_predictor.py
+++ b/src/gluonts/ext/rotbaum/_predictor.py
@@ -24,7 +24,6 @@ from pathlib import Path
 from itertools import compress
 
 from gluonts.core.component import validated
-from gluonts.core.serde import load_json
 from gluonts.dataset.common import Dataset
 from gluonts.dataset.util import forecast_start
 from gluonts.model.forecast import Forecast

--- a/src/gluonts/ext/rotbaum/_predictor.py
+++ b/src/gluonts/ext/rotbaum/_predictor.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from itertools import compress
 
 from gluonts.core.component import validated
-from gluonts.core.serde import dump_json, load_json
+from gluonts.core.serde import load_json
 from gluonts.dataset.common import Dataset
 from gluonts.dataset.util import forecast_start
 from gluonts.model.forecast import Forecast

--- a/src/gluonts/ext/rotbaum/_predictor.py
+++ b/src/gluonts/ext/rotbaum/_predictor.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from itertools import compress
 
 from gluonts.core.component import validated
+from gluonts.core.serde import dump_json, load_json
 from gluonts.dataset.common import Dataset
 from gluonts.dataset.util import forecast_start
 from gluonts.model.forecast import Forecast
@@ -354,14 +355,15 @@ class TreePredictor(RepresentablePredictor):
             pickle.dump(self.model_list, f)
 
     @classmethod
-    def deserialize(cls, path: Path) -> "RepresentablePredictor":
+    def deserialize(cls, path: Path, **kwargs: Any) -> "TreePredictor":
         """
-        This function loads and returns the serialized model. It calls
-        parent class deserialize() to load the predictor class with the
-        serialized arguments. It then loads the trained model list by
-        reading the pickle file.
+        This function loads and returns the serialized model. It loads
+        the predictor class with the serialized arguments. It then loads
+        the trained model list by reading the pickle file.
         """
-        predictor = super().deserialize(path)
+
+        with (path / "predictor.json").open("r") as fp:
+            predictor = load_json(fp.read())
         with (path / "predictor.pkl").open("rb") as f:
             predictor.model_list = pickle.load(f)
         return predictor

--- a/src/gluonts/ext/rotbaum/_preprocess.py
+++ b/src/gluonts/ext/rotbaum/_preprocess.py
@@ -464,7 +464,10 @@ class PreprocessOnlyLagFeatures(PreprocessGeneric):
             if self.use_feat_static_real
             else []
         )
-        if self.cardinality:
+        if (
+            self.cardinality
+            and time_series.get("feat_static_cat", None) is not None
+        ):
             feat_static_cat = (
                 self.encode_one_hot_all(time_series["feat_static_cat"])
                 if self.one_hot_encode

--- a/test/ext/rotbaum/test_model.py
+++ b/test/ext/rotbaum/test_model.py
@@ -34,7 +34,6 @@ def test_accuracy(accuracy_test, hyperparameters, quantiles):
 
 
 def test_serialize(serialize_test, hyperparameters):
-    # serialize_test(TreeEstimator, hyperparameters)
     from gluonts.model.predictor import Predictor
 
     forecaster = from_hyperparameters(TreeEstimator, hyperparameters, dsinfo)

--- a/test/ext/rotbaum/test_model.py
+++ b/test/ext/rotbaum/test_model.py
@@ -11,10 +11,11 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-
+from pathlib import Path
 import pytest
+import tempfile
 
-from gluonts.ext.rotbaum import TreeEstimator
+from gluonts.ext.rotbaum import TreeEstimator, TreePredictor
 
 
 @pytest.fixture()
@@ -33,15 +34,20 @@ def test_accuracy(accuracy_test, hyperparameters, quantiles):
     accuracy_test(TreeEstimator, hyperparameters, accuracy=0.20)
 
 
-def test_serialize(serialize_test, hyperparameters):
-    from gluonts.model.predictor import Predictor
-
-    forecaster = from_hyperparameters(TreeEstimator, hyperparameters, dsinfo)
+def test_serialize(serialize_test, hyperparameters, dsinfo):
+    forecaster = TreeEstimator.from_hyperparameters(
+        freq=dsinfo.freq,
+        **{
+            "prediction_length": dsinfo.prediction_length,
+            "num_parallel_samples": dsinfo.num_parallel_samples,
+        },
+        **hyperparameters,
+    )
 
     predictor_act = forecaster.train(dsinfo.train_ds)
 
     with tempfile.TemporaryDirectory() as temp_dir:
         predictor_act.serialize(Path(temp_dir))
-        predictor_exp = Predictor.deserialize(Path(temp_dir))
+        predictor_exp = TreePredictor.deserialize(Path(temp_dir))
         assert predictor_act == predictor_exp
         assert predictor_act.model_list == predictor_exp.model_list

--- a/test/ext/rotbaum/test_model.py
+++ b/test/ext/rotbaum/test_model.py
@@ -34,4 +34,15 @@ def test_accuracy(accuracy_test, hyperparameters, quantiles):
 
 
 def test_serialize(serialize_test, hyperparameters):
-    serialize_test(TreeEstimator, hyperparameters)
+    # serialize_test(TreeEstimator, hyperparameters)
+    from gluonts.model.predictor import Predictor
+
+    forecaster = from_hyperparameters(TreeEstimator, hyperparameters, dsinfo)
+
+    predictor_act = forecaster.train(dsinfo.train_ds)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        predictor_act.serialize(Path(temp_dir))
+        predictor_exp = Predictor.deserialize(Path(temp_dir))
+        assert predictor_act == predictor_exp
+        assert predictor_act.model_list == predictor_exp.model_list


### PR DESCRIPTION
Description of changes:
Prior to these changes, serializing a TreePredictor would only save the constructor arguments for the class. A trained TreePredictor creates a model_list within the predictor object that includes _n_ trained tree models for _n_ prediction length. This change pickles that model_list during serialization and reads it during deserialization. This change will enable Rotbaum to perform predictions after serialization and deserialization.
This request also includes a guardrail to prevent prediction failures after serialization and deserialization if dataset doesn't contain feat_static_cat and cardinality was initially set to `auto`. In scenarios of `auto` cardinality, PreprocessOnlyLagFeatures class infers the cardinality during training and sets it within the preprocess object in TreePredictor class. Pickling this object during serialization tends to be very memory intensive (100MB+). To avoid pickling this object, this guardrail also checks whether the dataset has feat_static_cat instead of just relying on the value of cardinality.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup