### PR TITLE
Added future_known RTS into fourier.arima method 

### DIFF
--- a/src/gluonts/ext/r_forecast/_univariate_predictor.py
+++ b/src/gluonts/ext/r_forecast/_univariate_predictor.py
@@ -34,6 +34,7 @@ UNIVARIATE_QUANTILE_FORECAST_METHODS = [
     "thetaf",
     "stlar",
     "fourier.arima",
+    "fourier.arima.xreg",
 ]
 UNIVARIATE_POINT_FORECAST_METHODS = ["croston", "mlp"]
 SUPPORTED_UNIVARIATE_METHODS = (
@@ -136,7 +137,29 @@ class RForecastPredictor(RBasePredictor):
         r_params = self._robjects.vectors.ListVector(self.params)
         vec = self._robjects.FloatVector(data["target"])
         ts = make_ts(vec, frequency=self.period)
-        forecast = self._r_method(ts, r_params)
+
+        if (
+            "feat_dynamic_real" in data
+            and self.method_name == "fourier.arima.xreg"
+        ):
+            import rpy2.robjects.numpy2ri
+
+            rpy2.robjects.numpy2ri.activate()
+            data["feat_dynamic_real"] = np.transpose(data["feat_dynamic_real"])
+            nrow, ncol = data["feat_dynamic_real"].shape
+            xreg_in = self._robjects.r.matrix(
+                data["feat_dynamic_real"][: -self.prediction_length],
+                nrow=nrow - self.prediction_length,
+                ncol=ncol,
+            )
+            xreg_out = self._robjects.r.matrix(
+                data["feat_dynamic_real"][-self.prediction_length :],
+                nrow=self.prediction_length,
+                ncol=ncol,
+            )
+            forecast = self._r_method(ts, r_params, xreg_in, xreg_out)
+        else:
+            forecast = self._r_method(ts, r_params)
 
         forecast_dict = dict(zip(forecast.names, map(unlist, list(forecast))))
 

--- a/test/ext/r_forecast/test_r_multi_seasonality.py
+++ b/test/ext/r_forecast/test_r_multi_seasonality.py
@@ -146,7 +146,7 @@ def test_compare_arimas():
 
     assert fourier_arima_eval_metrics["MASE"] < arima_eval_metrics["MASE"]
 
-## Below shows improvement in metric when proper x_regressors are included   
+## Below shows improvement in metric when proper x_regressors are included #   
 
 dataset_xreg = [
     {

--- a/test/ext/r_forecast/test_r_multi_seasonality.py
+++ b/test/ext/r_forecast/test_r_multi_seasonality.py
@@ -146,6 +146,7 @@ def test_compare_arimas():
 
     assert fourier_arima_eval_metrics["MASE"] < arima_eval_metrics["MASE"]
 
+## Below shows improvement in metric when proper x_regressors are included   
 
 dataset_xreg = [
     {

--- a/test/ext/r_forecast/test_r_multi_seasonality.py
+++ b/test/ext/r_forecast/test_r_multi_seasonality.py
@@ -145,3 +145,78 @@ def test_compare_arimas():
     )
 
     assert fourier_arima_eval_metrics["MASE"] < arima_eval_metrics["MASE"]
+
+
+dataset_xreg = [
+    {
+        "start": pd.Period("1990-01-01 00", freq=freq),
+        "target": np.array(
+            [
+                item
+                for i in range(21)
+                for item in np.sin(
+                    2 * np.pi / period * np.arange(1, period + 1, 1)
+                )
+            ]
+        )
+        + np.random.normal(0, 0.5, period * 21)
+        + np.array(
+            [
+                item
+                for i in range(3)
+                for item in [0 for i in range(167)] + [8 for i in range(0, 1)]
+            ]
+        ),
+        "feat_dynamic_real": np.array(
+            [
+                [
+                    item
+                    for i in range(3)
+                    for item in [0 for i in range(167)]
+                    + [1 for i in range(0, 1)]
+                ]
+            ]
+        ),
+    }
+]
+
+
+def test_compare_arimas_xreg():
+    evaluator = Evaluator(quantiles=[0.1, 0.5, 0.9])
+    prediction_length = 24 * 7
+
+    fourier_arima = RForecastPredictor(
+        freq=freq,
+        prediction_length=prediction_length,
+        period=period,
+        params={
+            "quantiles": [0.50, 0.10, 0.90],
+            "output_types": ["mean", "quantiles"],
+        },
+        method_name="fourier.arima",
+    )
+    fourier_arima_eval_metrics, _ = backtest_metrics(
+        test_dataset=dataset_xreg, predictor=fourier_arima, evaluator=evaluator
+    )
+
+    fourier_arima_xreg = RForecastPredictor(
+        freq=freq,
+        prediction_length=prediction_length,
+        period=period,
+        params={
+            "quantiles": [0.50, 0.10, 0.90],
+            "output_types": ["mean", "quantiles"],
+        },
+        method_name="fourier.arima.xreg",
+    )
+
+    fourier_arima_xreg_eval_metrics, _ = backtest_metrics(
+        test_dataset=dataset_xreg,
+        predictor=fourier_arima_xreg,
+        evaluator=evaluator,
+    )
+
+    assert (
+        fourier_arima_xreg_eval_metrics["mean_wQuantileLoss"]
+        < fourier_arima_eval_metrics["mean_wQuantileLoss"]
+    )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The current ARIMA method does not consider any external regressors. This PR enables the inclusion of external RTS features with known future values.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup