### PR TITLE
extend exception for invalid `offset_name`

### DIFF
--- a/src/gluonts/time_feature/lag.py
+++ b/src/gluonts/time_feature/lag.py
@@ -146,7 +146,7 @@ def get_lags_for_frequency(
             + _make_lags_for_hour(offset.n / (60 * 60))
         )
     else:
-        raise Exception("invalid frequency")
+        raise ValueError(f"invalid frequency | `freq_str={freq_str}` -> `offset_name={offset_name}`")
 
     # flatten lags list and filter
     lags = [


### PR DESCRIPTION
*Issue #, if available:* it is quite hard to understand why the exception was raised when you do not see the values

*Description of changes:* extend the exception, which will help a user understand what went wrong...


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup

cc: @jaheba, @lostella, @kashif, @rshyamsundar