### PR TITLE
Fix issues related to new Pandas offset names

### DIFF
--- a/src/gluonts/dataset/artificial/_base.py
+++ b/src/gluonts/dataset/artificial/_base.py
@@ -112,7 +112,7 @@ class ConstantDataset(ArtificialDataset):
         self,
         num_timeseries: int = 10,
         num_steps: int = 30,
-        freq: str = "1H",
+        freq: str = "1h",
         start: str = "2000-01-01 00:00:00",
         # Generates constant dataset of 0s with explicit NaN missing values
         is_nan: bool = False,

--- a/src/gluonts/mx/model/deepstate/_estimator.py
+++ b/src/gluonts/mx/model/deepstate/_estimator.py
@@ -69,11 +69,14 @@ SEASON_INDICATORS_FIELD = "seasonal_indicators"
 # series in the dataset.
 FREQ_LONGEST_PERIOD_DICT = {
     "M": 12,  # yearly seasonality
+    "ME": 12,  # yearly seasonality
     "W": 52,  # yearly seasonality
     "D": 31,  # monthly seasonality
     "B": 22,  # monthly seasonality
     "H": 168,  # weekly seasonality
+    "h": 168,  # weekly seasonality
     "T": 1440,  # daily seasonality
+    "min": 1440,  # daily seasonality
 }
 
 

--- a/src/gluonts/mx/model/deepstate/issm.py
+++ b/src/gluonts/mx/model/deepstate/issm.py
@@ -305,7 +305,7 @@ class CompositeISSM(ISSM):
 
         seasonal_issms: List[SeasonalityISSM] = []
 
-        if offset.name == "M":
+        if offset.name in ["M", "ME"]:
             seasonal_issms = [MonthOfYearSeasonalISSM()]
         elif norm_freq_str(offset.name) == "W":
             seasonal_issms = [WeekOfYearSeasonalISSM()]
@@ -313,12 +313,12 @@ class CompositeISSM(ISSM):
             seasonal_issms = [DayOfWeekSeasonalISSM()]
         elif offset.name == "B":  # TODO: check this case
             seasonal_issms = [DayOfWeekSeasonalISSM()]
-        elif offset.name == "H":
+        elif offset.name in ["H", "h"]:
             seasonal_issms = [
                 HourOfDaySeasonalISSM(),
                 DayOfWeekSeasonalISSM(),
             ]
-        elif offset.name == "T":
+        elif offset.name in ["T", "min"]:
             seasonal_issms = [
                 MinuteOfHourSeasonalISSM(),
                 HourOfDaySeasonalISSM(),

--- a/src/gluonts/mx/model/deepvar/_estimator.py
+++ b/src/gluonts/mx/model/deepvar/_estimator.py
@@ -91,10 +91,12 @@ class FourierDateFeatures:
 def time_features_from_frequency_str(freq_str: str) -> List[TimeFeature]:
     features = {
         "M": ["weekofyear"],
+        "ME": ["weekofyear"],
         "W": ["daysinmonth", "weekofyear"],
         "D": ["dayofweek"],
         "B": ["dayofweek", "dayofyear"],
         "H": ["hour", "dayofweek"],
+        "h": ["hour", "dayofweek"],
         "min": ["minute", "hour", "dayofweek"],
         "T": ["minute", "hour", "dayofweek"],
     }
@@ -114,13 +116,13 @@ def get_lags_for_frequency(
 ) -> List[int]:
     offset = to_offset(freq_str)
 
-    if offset.name == "M":
+    if offset.name in ["M", "ME"]:
         lags = [[1, 12]]
     elif offset.name == "D":
         lags = [[1, 7, 14]]
     elif offset.name == "B":
         lags = [[1, 2]]
-    elif offset.name == "H":
+    elif offset.name in ["H", "h"]:
         lags = [[1, 24, 168]]
     elif offset.name in ("min", "T"):
         lags = [[1, 4, 12, 24, 48]]

--- a/src/gluonts/mx/model/wavenet/_estimator.py
+++ b/src/gluonts/mx/model/wavenet/_estimator.py
@@ -226,9 +226,11 @@ class WaveNetEstimator(GluonEstimator):
                 self.freq,
                 {
                     "H": 7 * 24,
+                    "h": 7 * 24,
                     "D": 7,
                     "W": 52,
                     "M": 12,
+                    "ME": 12,
                     "B": 7 * 5,
                     "min": 24 * 60,
                 },

--- a/src/gluonts/nursery/robust-mts-attack/pts/feature/fourier_date_feature.py
+++ b/src/gluonts/nursery/robust-mts-attack/pts/feature/fourier_date_feature.py
@@ -54,10 +54,12 @@ def fourier_time_features_from_frequency(freq_str: str) -> List[TimeFeature]:
 
     features = {
         "M": ["weekofyear"],
+        "ME": ["weekofyear"],
         "W": ["daysinmonth", "weekofyear"],
         "D": ["dayofweek"],
         "B": ["dayofweek", "dayofyear"],
         "H": ["hour", "dayofweek"],
+        "h": ["hour", "dayofweek"],
         "min": ["minute", "hour", "dayofweek"],
         "T": ["minute", "hour", "dayofweek"],
     }

--- a/src/gluonts/nursery/robust-mts-attack/pts/feature/lags.py
+++ b/src/gluonts/nursery/robust-mts-attack/pts/feature/lags.py
@@ -22,13 +22,13 @@ def lags_for_fourier_time_features_from_frequency(
     offset = to_offset(freq_str)
     multiple, granularity = offset.n, offset.name
 
-    if granularity == "M":
+    if granularity in ("M", "ME"):
         lags = [[1, 12]]
     elif granularity == "D":
         lags = [[1, 7, 14]]
     elif granularity == "B":
         lags = [[1, 2]]
-    elif granularity == "H":
+    elif granularity in ("H", "h"):
         lags = [[1, 24, 168]]
     elif granularity in ("T", "min"):
         lags = [[1, 4, 12, 24, 48]]

--- a/src/gluonts/time_feature/lag.py
+++ b/src/gluonts/time_feature/lag.py
@@ -112,7 +112,7 @@ def get_lags_for_frequency(
             offset.n == 1
         ), "Only multiple 1 is supported for quarterly. Use x month instead."
         lags = _make_lags_for_month(offset.n * 3.0)
-    elif offset_name == "M":
+    elif offset_name in ["M", "ME"]:
         lags = _make_lags_for_month(offset.n)
     elif offset_name == "W":
         lags = _make_lags_for_week(offset.n)
@@ -124,14 +124,14 @@ def get_lags_for_frequency(
         lags = _make_lags_for_day(
             offset.n, days_in_week=5, days_in_month=22
         ) + _make_lags_for_week(offset.n / 5.0)
-    elif offset_name == "H":
+    elif offset_name in ["H", "h"]:
         lags = (
             _make_lags_for_hour(offset.n)
             + _make_lags_for_day(offset.n / 24)
             + _make_lags_for_week(offset.n / (24 * 7))
         )
     # minutes
-    elif offset_name == "T":
+    elif offset_name in ["T", "min"]:
         lags = (
             _make_lags_for_minute(offset.n)
             + _make_lags_for_hour(offset.n / 60)
@@ -139,7 +139,7 @@ def get_lags_for_frequency(
             + _make_lags_for_week(offset.n / (60 * 24 * 7))
         )
     # second
-    elif offset_name == "S":
+    elif offset_name in ["S", "s"]:
         lags = (
             _make_lags_for_second(offset.n)
             + _make_lags_for_minute(offset.n / 60)

--- a/src/gluonts/time_feature/lag.py
+++ b/src/gluonts/time_feature/lag.py
@@ -147,7 +147,7 @@ def get_lags_for_frequency(
         )
     else:
         raise ValueError(
-            f"invalid frequency | `freq_str={freq_str}` -> `offset_name={offset_name}`"
+            f"invalid frequency: {freq_str=}, {offset_name=}"
         )
 
     # flatten lags list and filter

--- a/src/gluonts/time_feature/lag.py
+++ b/src/gluonts/time_feature/lag.py
@@ -105,9 +105,9 @@ def get_lags_for_frequency(
     # normalize offset name, so that both `W` and `W-SUN` refer to `W`
     offset_name = norm_freq_str(offset.name)
 
-    if offset_name == "A":
+    if offset_name in ["A", "Y", "YE"]:
         lags = []
-    elif offset_name == "Q":
+    elif offset_name in ["Q", "QE"]:
         assert (
             offset.n == 1
         ), "Only multiple 1 is supported for quarterly. Use x month instead."

--- a/src/gluonts/time_feature/lag.py
+++ b/src/gluonts/time_feature/lag.py
@@ -146,9 +146,7 @@ def get_lags_for_frequency(
             + _make_lags_for_hour(offset.n / (60 * 60))
         )
     else:
-        raise ValueError(
-            f"invalid frequency: {freq_str=}, {offset_name=}"
-        )
+        raise ValueError(f"invalid frequency: {freq_str=}, {offset_name=}")
 
     # flatten lags list and filter
     lags = [

--- a/src/gluonts/time_feature/seasonality.py
+++ b/src/gluonts/time_feature/seasonality.py
@@ -22,12 +22,15 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_SEASONALITIES = {
     "S": 3600,  # 1 hour
+    "s": 3600,  # 1 hour
     "T": 1440,  # 1 day
+    "min": 1440,  # 1 day
     "H": 24,  # 1 day
     "h": 24,  # 1 day
     "D": 1,  # 1 day
     "W": 1,  # 1 week
     "M": 12,
+    "ME": 12,
     "B": 5,
     "Q": 4,
 }

--- a/src/gluonts/time_feature/seasonality.py
+++ b/src/gluonts/time_feature/seasonality.py
@@ -24,6 +24,7 @@ DEFAULT_SEASONALITIES = {
     "S": 3600,  # 1 hour
     "T": 1440,  # 1 day
     "H": 24,  # 1 day
+    "h": 24,  # 1 day
     "D": 1,  # 1 day
     "W": 1,  # 1 week
     "M": 12,
@@ -36,7 +37,7 @@ def get_seasonality(freq: str, seasonalities=DEFAULT_SEASONALITIES) -> int:
     """
     Return the seasonality of a given frequency:
 
-    >>> get_seasonality("2H")
+    >>> get_seasonality("2h")
     12
     """
     offset = pd.tseries.frequencies.to_offset(freq)

--- a/test/time_feature/test_base.py
+++ b/test/time_feature/test_base.py
@@ -17,15 +17,15 @@ from gluonts.time_feature import norm_freq_str
 
 
 def test_norm_freq_str():
-    assert norm_freq_str(to_offset("Y").name) == "A"
-    assert norm_freq_str(to_offset("YS").name) == "A"
-    assert norm_freq_str(to_offset("A").name) == "A"
-    assert norm_freq_str(to_offset("AS").name) == "A"
+    assert norm_freq_str(to_offset("Y").name) in ["A", "YE"]
+    assert norm_freq_str(to_offset("YS").name) in ["A", "Y"]
+    assert norm_freq_str(to_offset("A").name) in ["A", "YE"]
+    assert norm_freq_str(to_offset("AS").name) in ["A", "Y"]
 
-    assert norm_freq_str(to_offset("Q").name) == "Q"
+    assert norm_freq_str(to_offset("Q").name) in ["Q", "QE"]
     assert norm_freq_str(to_offset("QS").name) == "Q"
 
-    assert norm_freq_str(to_offset("M").name) == "M"
-    assert norm_freq_str(to_offset("MS").name) == "M"
+    assert norm_freq_str(to_offset("M").name) in ["M", "ME"]
+    assert norm_freq_str(to_offset("MS").name) in ["M", "ME"]
 
-    assert norm_freq_str(to_offset("S").name) == "S"
+    assert norm_freq_str(to_offset("S").name) in ["S", "s"]


### PR DESCRIPTION
*Description of changes:* hour offset in pandas 2.2 has now `.name == h` and not `H`. Others have change as well, breaking some of the time features and lags logic. This PR makes things work for both pandas <2.2 and >=2.2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup