### PR TITLE
temporally freeze `pandas<2.2` to unblock tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ line-length = 79
 minversion = "6.0"
 timeout = 60
 addopts = """
+    --color=yes
     --doctest-modules
     --ignore src/gluonts/block.py
     --ignore src/gluonts/distribution.py

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -1,4 +1,4 @@
-pandas>=1.1
+pandas>=1.1,<2.2.0  # todo: unpin when resolved deprecated frequency
 flaky~=3.6
 pytest-cov==2.6.*
 pytest-timeout~=1.3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 numpy~=1.16
-pandas>=1.0,<3
+pandas>=1.0,<2.2.0  # todo: unpin when resolved deprecated frequency
 pydantic>=1.7,<3
 tqdm~=4.23
 toolz~=0.10

--- a/src/gluonts/time_feature/lag.py
+++ b/src/gluonts/time_feature/lag.py
@@ -146,9 +146,7 @@ def get_lags_for_frequency(
             + _make_lags_for_hour(offset.n / (60 * 60))
         )
     else:
-        raise ValueError(
-            f"invalid frequency | `freq_str={freq_str}` -> `offset_name={offset_name}`"
-        )
+        raise ValueError(f"invalid frequency: {freq_str=}, {offset_name=}")
 
     # flatten lags list and filter
     lags = [


### PR DESCRIPTION
*Issue #, if available:* seems the frequency is broken now also on master

*Description of changes:*
temporarily freeze `pandas` version until the conversion patch lands
also, implement update from https://github.com/awslabs/gluonts/pull/3115#discussion_r1475078016

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup