### PR TITLE
Fix item_id for M5 dataset

### DIFF
--- a/src/gluonts/dataset/repository/_m5.py
+++ b/src/gluonts/dataset/repository/_m5.py
@@ -112,16 +112,17 @@ def generate_m5_dataset(
         len(state_ids_un),
     ]
 
-    # Build target series
-    train_ids = (
-        sales_train_validation["item_id"].str
+    # Compute unique ID in case `id` column is missing
+    sales_train_validation["id"] = (
+        sales_train_validation["item_id"].astype("str")
         + "_"
-        + sales_train_validation["store_id"].str
+        + sales_train_validation["store_id"].astype("str")
     )
+    # Build target series
+    train_ids = sales_train_validation["id"]
     train_df = sales_train_validation.drop(
         ["id", "item_id", "dept_id", "cat_id", "store_id", "state_id"],
         axis=1,
-        errors="ignore",
     )
     test_target_values = train_df.values.copy()
     train_target_values = [ts[:-prediction_length] for ts in train_df.values]

--- a/src/gluonts/dataset/repository/_m5.py
+++ b/src/gluonts/dataset/repository/_m5.py
@@ -113,11 +113,12 @@ def generate_m5_dataset(
     ]
 
     # Compute unique ID in case `id` column is missing
-    sales_train_validation["id"] = (
-        sales_train_validation["item_id"].astype("str")
-        + "_"
-        + sales_train_validation["store_id"].astype("str")
-    )
+    if "id" not in sales_train_validation.columns:
+        sales_train_validation["id"] = (
+            sales_train_validation["item_id"].astype("str")
+            + "_"
+            + sales_train_validation["store_id"].astype("str")
+        )
     # Build target series
     train_ids = sales_train_validation["id"]
     train_df = sales_train_validation.drop(


### PR DESCRIPTION
*Description of changes:*
- Fix the `item_id` calculation for the M5 dataset in case `id` column is missing in the original dataset

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup