### PR TITLE
Enable QuantileOutput for TiDE model

### DIFF
--- a/src/gluonts/torch/distributions/distribution_output.py
+++ b/src/gluonts/torch/distributions/distribution_output.py
@@ -91,14 +91,6 @@ class DistributionOutput(Output):
         return nll
 
     @property
-    def event_shape(self) -> Tuple:
-        r"""
-        Shape of each individual event contemplated by the distributions that
-        this object constructs.
-        """
-        raise NotImplementedError()
-
-    @property
     def event_dim(self) -> int:
         r"""
         Number of event dimensions, i.e., length of the `event_shape` tuple, of

--- a/src/gluonts/torch/distributions/output.py
+++ b/src/gluonts/torch/distributions/output.py
@@ -106,6 +106,13 @@ class Output:
         raise NotImplementedError()
 
     @property
+    def event_shape(self) -> Tuple:
+        r"""
+        Shape of each individual event compatible with the output object.
+        """
+        raise NotImplementedError()
+
+    @property
     def forecast_generator(self) -> ForecastGenerator:
         raise NotImplementedError()
 

--- a/src/gluonts/torch/distributions/quantile_output.py
+++ b/src/gluonts/torch/distributions/quantile_output.py
@@ -37,6 +37,10 @@ class QuantileOutput(Output):
     def forecast_generator(self) -> ForecastGenerator:
         return QuantileForecastGenerator(quantiles=self.quantiles)
 
+    @property
+    def event_shape(self) -> Tuple:
+        return ()
+
     def domain_map(self, *args: torch.Tensor) -> Tuple[torch.Tensor, ...]:
         return args
 

--- a/src/gluonts/torch/model/tide/estimator.py
+++ b/src/gluonts/torch/model/tide/estimator.py
@@ -21,7 +21,6 @@ from gluonts.dataset.common import Dataset
 from gluonts.dataset.field_names import FieldName
 from gluonts.dataset.loader import as_stacked_batches
 from gluonts.itertools import Cyclic
-from gluonts.model.forecast_generator import DistributionForecastGenerator
 from gluonts.time_feature import (
     minute_of_hour,
     hour_of_day,

--- a/src/gluonts/torch/model/tide/estimator.py
+++ b/src/gluonts/torch/model/tide/estimator.py
@@ -49,10 +49,7 @@ from gluonts.transform import (
 
 from gluonts.torch.model.estimator import PyTorchLightningEstimator
 from gluonts.torch.model.predictor import PyTorchPredictor
-from gluonts.torch.distributions import (
-    DistributionOutput,
-    StudentTOutput,
-)
+from gluonts.torch.distributions import Output, StudentTOutput
 
 from .lightning_module import TiDELightningModule
 
@@ -174,7 +171,7 @@ class TiDEEstimator(PyTorchLightningEstimator):
         weight_decay: float = 1e-8,
         patience: int = 10,
         scaling: Optional[str] = "mean",
-        distr_output: DistributionOutput = StudentTOutput(),
+        distr_output: Output = StudentTOutput(),
         batch_size: int = 32,
         num_batches_per_epoch: int = 50,
         trainer_kwargs: Optional[Dict[str, Any]] = None,
@@ -403,9 +400,7 @@ class TiDEEstimator(PyTorchLightningEstimator):
             input_transform=transformation + prediction_splitter,
             input_names=PREDICTION_INPUT_NAMES,
             prediction_net=module,
-            forecast_generator=DistributionForecastGenerator(
-                self.distr_output
-            ),
+            forecast_generator=self.distr_output.forecast_generator,
             batch_size=self.batch_size,
             prediction_length=self.prediction_length,
             device="auto",

--- a/src/gluonts/torch/model/tide/module.py
+++ b/src/gluonts/torch/model/tide/module.py
@@ -19,7 +19,7 @@ from torch import nn
 from gluonts.core.component import validated
 from gluonts.torch.modules.feature import FeatureEmbedder
 from gluonts.model import Input, InputSpec
-from gluonts.torch.distributions import DistributionOutput
+from gluonts.torch.distributions import Output
 from gluonts.torch.scaler import StdScaler, MeanScaler, NOPScaler
 from gluonts.torch.model.simple_feedforward import make_linear_layer
 from gluonts.torch.util import weighted_average
@@ -242,7 +242,7 @@ class TiDEModel(nn.Module):
         num_layers_encoder: int,
         num_layers_decoder: int,
         layer_norm: bool,
-        distr_output: DistributionOutput,
+        distr_output: Output,
         scaling: str,
     ) -> None:
         super().__init__()

--- a/test/torch/model/test_estimators.py
+++ b/test/torch/model/test_estimators.py
@@ -148,6 +148,14 @@ from gluonts.torch.distributions import ImplicitQuantileNetworkOutput
             num_batches_per_epoch=3,
             trainer_kwargs=dict(max_epochs=2),
         ),
+        lambda dataset: TiDEEstimator(
+            freq=dataset.metadata.freq,
+            prediction_length=dataset.metadata.prediction_length,
+            distr_output=QuantileOutput(quantiles=[0.1, 0.6, 0.85]),
+            batch_size=4,
+            num_batches_per_epoch=3,
+            trainer_kwargs=dict(max_epochs=2),
+        ),
         lambda dataset: WaveNetEstimator(
             freq=dataset.metadata.freq,
             prediction_length=dataset.metadata.prediction_length,


### PR DESCRIPTION
*Description of changes:*
- Make the `TiDE` model compatible with arbitrary `Output` objects (not only `DistributionOutput`).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup