### PR TITLE
Ignore cpflows dependencies in test workflows, fix numpy 2 incompatibilities.

### DIFF
--- a/.github/workflows/tests-torch.yml
+++ b/.github/workflows/tests-torch.yml
@@ -24,7 +24,7 @@ jobs:
         pip install ".[arrow]" \
           -r requirements/requirements-test.txt \
           -r requirements/requirements-extras-m-competitions.txt \
-          -r requirements/requirements-pytorch.txt \
+          -r requirements/requirements-pytorch.txt
         pip install --no-deps -r requirements/requirements-extras-cpflows.txt
     - name: Test with pytest
       run: |

--- a/.github/workflows/tests-torch.yml
+++ b/.github/workflows/tests-torch.yml
@@ -25,7 +25,7 @@ jobs:
           -r requirements/requirements-test.txt \
           -r requirements/requirements-extras-m-competitions.txt \
           -r requirements/requirements-pytorch.txt \
-          -r requirements/requirements-extras-cpflows.txt
+        pip install --no-deps -r requirements/requirements-extras-cpflows.txt
     - name: Test with pytest
       run: |
         pytest -n2 --doctest-modules --ignore test/nursery test

--- a/test/torch/distribution/test_negative_binomial.py
+++ b/test/torch/distribution/test_negative_binomial.py
@@ -48,7 +48,7 @@ def test_custom_neg_bin_cdf(total_count, probs, value):
 
 
 @pytest.mark.skipif(
-    sys.version_info == (3, 9), reason="test fails on python 3.9"
+    sys.version_info.major == 3 and sys.version_info.minor == 9, reason="test fails on python 3.9"
 )
 @pytest.mark.parametrize("probs", [0.1, 0.5, 0.8])
 @pytest.mark.parametrize("total_count", [3, 7, 100])

--- a/test/torch/distribution/test_negative_binomial.py
+++ b/test/torch/distribution/test_negative_binomial.py
@@ -54,7 +54,9 @@ def test_custom_neg_bin_icdf(total_count, probs, value):
     torch_dist = NegativeBinomial(total_count=total_count, probs=probs)
     scipy_dist = torch_dist.scipy_nbinom
 
-    torch_icdf = torch_dist.icdf(torch.as_tensor(value, dtype=torch.float64)).numpy()
+    torch_icdf = torch_dist.icdf(
+        torch.as_tensor(value, dtype=torch.float64)
+    ).numpy()
     scipy_icdf = scipy_dist.ppf(np.asarray(value))
 
     assert np.allclose(torch_icdf, scipy_icdf)

--- a/test/torch/distribution/test_negative_binomial.py
+++ b/test/torch/distribution/test_negative_binomial.py
@@ -47,7 +47,9 @@ def test_custom_neg_bin_cdf(total_count, probs, value):
     assert np.allclose(torch_cdf, scipy_cdf)
 
 
-@pytest.mark.skipif(sys.version_info == (3, 9), reason="test fails on python 3.9")
+@pytest.mark.skipif(
+    sys.version_info == (3, 9), reason="test fails on python 3.9"
+)
 @pytest.mark.parametrize("probs", [0.1, 0.5, 0.8])
 @pytest.mark.parametrize("total_count", [3, 7, 100])
 @pytest.mark.parametrize("value", [0.1, 0.5, 0.9])

--- a/test/torch/distribution/test_negative_binomial.py
+++ b/test/torch/distribution/test_negative_binomial.py
@@ -12,6 +12,7 @@
 # permissions and limitations under the License.
 
 import pytest
+import sys
 
 import numpy as np
 import torch
@@ -46,6 +47,7 @@ def test_custom_neg_bin_cdf(total_count, probs, value):
     assert np.allclose(torch_cdf, scipy_cdf)
 
 
+@pytest.mark.skipif(sys.version_info == (3, 9), reason="test fails on python 3.9")
 @pytest.mark.parametrize("probs", [0.1, 0.5, 0.8])
 @pytest.mark.parametrize("total_count", [3, 7, 100])
 @pytest.mark.parametrize("value", [0.1, 0.5, 0.9])

--- a/test/torch/distribution/test_negative_binomial.py
+++ b/test/torch/distribution/test_negative_binomial.py
@@ -47,9 +47,6 @@ def test_custom_neg_bin_cdf(total_count, probs, value):
     assert np.allclose(torch_cdf, scipy_cdf)
 
 
-@pytest.mark.skipif(
-    sys.version_info.major == 3 and sys.version_info.minor == 9, reason="test fails on python 3.9"
-)
 @pytest.mark.parametrize("probs", [0.1, 0.5, 0.8])
 @pytest.mark.parametrize("total_count", [3, 7, 100])
 @pytest.mark.parametrize("value", [0.1, 0.5, 0.9])
@@ -57,7 +54,7 @@ def test_custom_neg_bin_icdf(total_count, probs, value):
     torch_dist = NegativeBinomial(total_count=total_count, probs=probs)
     scipy_dist = torch_dist.scipy_nbinom
 
-    torch_icdf = torch_dist.icdf(torch.as_tensor(value)).numpy()
+    torch_icdf = torch_dist.icdf(torch.as_tensor(value, dtype=torch.float64)).numpy()
     scipy_icdf = scipy_dist.ppf(np.asarray(value))
 
     assert np.allclose(torch_icdf, scipy_icdf)

--- a/test/torch/distribution/test_negative_binomial.py
+++ b/test/torch/distribution/test_negative_binomial.py
@@ -49,7 +49,7 @@ def test_custom_neg_bin_cdf(total_count, probs, value):
 @pytest.mark.parametrize("probs", [0.1, 0.5, 0.8])
 @pytest.mark.parametrize("total_count", [3, 7, 100])
 @pytest.mark.parametrize("value", [0.1, 0.5, 0.9])
-def test_custom_studentt_icdf(total_count, probs, value):
+def test_custom_neg_bin_icdf(total_count, probs, value):
     torch_dist = NegativeBinomial(total_count=total_count, probs=probs)
     scipy_dist = torch_dist.scipy_nbinom
 

--- a/test/transform/test_transform.py
+++ b/test/transform/test_transform.py
@@ -155,8 +155,8 @@ def test_AddTimeFeatures(start, target, is_train: bool):
     tmp_idx = pd.period_range(
         start=start, freq=start.freq, periods=expected_length
     )
-    assert np.alltrue(mat[0] == time_feature.day_of_week(tmp_idx))
-    assert np.alltrue(mat[1] == time_feature.day_of_month(tmp_idx))
+    assert np.all(mat[0] == time_feature.day_of_week(tmp_idx))
+    assert np.all(mat[1] == time_feature.day_of_month(tmp_idx))
 
 
 @pytest.mark.parametrize("is_train", TEST_VALUES["is_train"])
@@ -285,7 +285,7 @@ def test_InstanceSplitter(
 
     # expected_length = len(target) + (0 if is_train else pred_length)
     # assert len(out['age']) == expected_length
-    # assert np.alltrue(out['age'] == np.log10(2.0 + np.arange(expected_length)))
+    # assert np.all(out['age'] == np.log10(2.0 + np.arange(expected_length)))
 
 
 @pytest.mark.parametrize("is_train", TEST_VALUES["is_train"])


### PR DESCRIPTION
*Issue #, if available:* CPFlows is a dependency for `gluonts.torch.model.mqf2`, but it comes with dependencies constraints that hold us back. So for example, not the latest numpy version was used in CI tests.

*Description of changes:* Ignore dependencies of CPFlows in GitHub workflows. Fix incompatibilities with the latest numpy.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup