### PR TITLE
Fix testutils for gluonts.shell on recent python versions

### DIFF
--- a/src/gluonts/testutil/shell.py
+++ b/src/gluonts/testutil/shell.py
@@ -21,7 +21,7 @@ import time
 import typing
 import waitress
 from contextlib import closing, contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from multiprocessing.context import ForkContext
 from pathlib import Path
 from typing import Any, ContextManager, Dict, Iterable, List, Optional, Type
@@ -119,7 +119,7 @@ def free_port() -> int:
 class Server:
     env: ServeEnv
     forecaster_type: Optional[Type[Predictor]]
-    settings: Settings = Settings()
+    settings: Settings = field(default_factory=Settings)
 
     def run(self):
         flask_app = make_flask_app(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -30,7 +30,7 @@ from gluonts.dataset.common import ListDataset
 
 try:
     import mxnet as mx
-except ImportError:
+except (ImportError, OSError):
     mx = None
 
 try:


### PR DESCRIPTION
*Issue #, if available:* Running tests for gluonts.shell raises
```
E   ValueError: mutable default <class 'gluonts.shell.serve.Settings'> for field settings is not allowed: use default_factory
```
on Python 3.11.

*Description of changes:* Fix the above issues. Also, one conditional mxnet import fails with an `OSError` on my machine which is not caught, so I'm adding it to the try/catch.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup