### PR TITLE
Allow disabling scaler for DL models

### DIFF
--- a/src/gluonts/torch/model/d_linear/module.py
+++ b/src/gluonts/torch/model/d_linear/module.py
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from typing import Tuple
+from typing import Optional, Tuple
 
 import torch
 from torch import nn
@@ -87,7 +87,7 @@ class DLinearModel(nn.Module):
         hidden_dimension: int,
         distr_output=StudentTOutput(),
         kernel_size: int = 25,
-        scaling: str = "mean",
+        scaling: Optional[str] = "mean",
     ) -> None:
         super().__init__()
 

--- a/src/gluonts/torch/model/lag_tst/module.py
+++ b/src/gluonts/torch/model/lag_tst/module.py
@@ -55,7 +55,7 @@ class LagTSTModel(nn.Module):
         activation: str,
         norm_first: bool,
         num_encoder_layers: int,
-        scaling: str,
+        scaling: Optional[str],
         lags_seq: Optional[List[int]] = None,
         distr_output=StudentTOutput(),
     ) -> None:

--- a/src/gluonts/torch/model/patch_tst/module.py
+++ b/src/gluonts/torch/model/patch_tst/module.py
@@ -108,7 +108,7 @@ class PatchTSTModel(nn.Module):
         activation: str,
         norm_first: bool,
         num_encoder_layers: int,
-        scaling: str,
+        scaling: Optional[str],
         distr_output=StudentTOutput(),
     ) -> None:
         super().__init__()

--- a/src/gluonts/torch/model/tide/module.py
+++ b/src/gluonts/torch/model/tide/module.py
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import torch
 from torch import nn
@@ -243,7 +243,7 @@ class TiDEModel(nn.Module):
         num_layers_decoder: int,
         layer_norm: bool,
         distr_output: Output,
-        scaling: str,
+        scaling: Optional[str],
     ) -> None:
         super().__init__()
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Currently, the incorrect type hint makes it impossible to set `scaling=None` for TiDE, PatchTST, DLinear and LagTST models. If user sets `scaling=None`, Pydantic will raise the ValidationError. This PR fixes this issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup