### PR TITLE
Set `observed=True` inside `DataFrame.groupby` in `PandasDataset` to silence the FutureWarning

### DIFF
--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -305,7 +305,7 @@ class PandasDataset:
             other_static_features = pd.DataFrame()
 
         logger.info(f"Grouping data by '{item_id}'; this may take some time.")
-        pairs = list(dataframe.groupby(item_id))
+        pairs = list(dataframe.groupby(item_id, observed=True))
 
         return cls(
             dataframes=pairs,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Set `observed=True` inside `DataFrame.groupby` in `PandasDataset` to silence the FutureWarning. Relevant pandas documentation: https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.groupby.html#pandas-dataframe-groupby.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup