### PR TITLE
Recover from a checkpoint if training failed with an exception

### DIFF
--- a/requirements/requirements-pytorch.txt
+++ b/requirements/requirements-pytorch.txt
@@ -1,7 +1,7 @@
 torch>=1.9,<3
-lightning>=2.2.2,<2.5
+lightning>=2.2.2,<2.6
 # Capping `lightning` does not cap `pytorch_lightning`, so we cap manually
-pytorch_lightning>=2.2.2,<2.5
+pytorch_lightning>=2.2.2,<2.6
 # scipy cap can be removed once this is resolved: https://github.com/statsmodels/statsmodels/issues/9584
 scipy<1.16.0; python_version > "3.7.0"
 scipy~=1.7.3; python_version <= "3.7.0"

--- a/src/gluonts/torch/model/estimator.py
+++ b/src/gluonts/torch/model/estimator.py
@@ -206,12 +206,22 @@ class PyTorchLightningEstimator(Estimator):
             }
         )
 
-        trainer.fit(
-            model=training_network,
-            train_dataloaders=training_data_loader,
-            val_dataloaders=validation_data_loader,
-            ckpt_path=ckpt_path,
-        )
+        try:
+            trainer.fit(
+                model=training_network,
+                train_dataloaders=training_data_loader,
+                val_dataloaders=validation_data_loader,
+                ckpt_path=ckpt_path,
+            )
+        except Exception as e:
+            if checkpoint.best_model_path == "":
+                logger.error("Training failed with no checkpoint available")
+                raise
+            else:
+                logger.warning(
+                    "Recovering from a checkpoint after training failed "
+                    f"with the following exception:\n {e}"
+                )
 
         if checkpoint.best_model_path != "":
             logger.info(

--- a/test/torch/model/test_estimators.py
+++ b/test/torch/model/test_estimators.py
@@ -20,6 +20,7 @@ import pytest
 import pandas as pd
 import numpy as np
 from lightning import seed_everything
+from lightning.pytorch.callbacks import Callback
 
 from gluonts.dataset.repository import get_dataset
 from gluonts.model.predictor import Predictor
@@ -400,3 +401,29 @@ def test_estimator_with_features(estimator_constructor):
 
     for f in islice(forecasts, 5):
         f.mean
+
+
+def test_estimator_recovers_if_exception_encountered_during_training():
+    class RaiseOnEpoch(Callback):
+        def __init__(self):
+            self.raised = False
+
+        def on_train_epoch_start(self, trainer, pl_module):
+            if trainer.current_epoch == 3:
+                self.raised = True
+                raise ValueError("Surprise!")
+
+    callback = RaiseOnEpoch()
+
+    dataset = get_dataset("constant")
+    estimator = DeepAREstimator(
+        freq=dataset.metadata.freq,
+        prediction_length=5,
+        batch_size=4,
+        num_batches_per_epoch=5,
+        trainer_kwargs=dict(max_epochs=50, callbacks=[callback]),
+    )
+    predictor = estimator.train(dataset.train)
+    forecast = list(predictor.predict(dataset.train))
+    assert callback.raised
+    assert isinstance(forecast[0].mean, np.ndarray)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- When training models that rely on the `StundentTOutput` (e.g., PatchTST, DeepAR), we occasionally run into numerical issues that turn all models weights to NaNs in the middle of the training:
    ```
    ValueError: Expected parameter df (Tensor of shape (64, 179)) of distribution Chi2() to satisfy the constraint GreaterThan(lower_bound=0.0), but found invalid values:
    tensor([[nan, nan, nan,  ..., nan, nan, nan],
            [nan, nan, nan,  ..., nan, nan, nan],
            [nan, nan, nan,  ..., nan, nan, nan],
            ...,
            [nan, nan, nan,  ..., nan, nan, nan],
            [nan, nan, nan,  ..., nan, nan, nan],
            [nan, nan, nan,  ..., nan, nan, nan]])
    ```
    Currently, this completely breaks the training process. 
    
    With this PR, we attempt to recover the model weights from a checkpoint if an exception is encountered during training.
 
    A potential alternative to this PR would be to fix the numerical issues plaguing the StudentT distribution by, e.g., clipping parameters like the scale. However, this might result in regressions for some existing users. Also, it's not very clear when and why this problem occurs, so even if we introduce clipping now, there might still be other datasets where it won't be sufficient.
- Bump `lightning` upper bound to `<2.6`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup