### PR TITLE
Loosen toolz dependency

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,7 +2,7 @@ numpy>=1.16,<2.2
 pandas>=1.0,<3
 pydantic>=1.7,<3
 tqdm~=4.23
-toolz~=0.10
+toolz>=0.10,<2
 
 # used for Protocol, can be removed once Python 3.8 is required
 typing-extensions~=4.0


### PR DESCRIPTION
Support never versions of toolz

toolz 1.0 is around for a year and it probably does not break anything while forcing dependent projects to stick to older toolz.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.