### PR TITLE
Load checkpoints with weights_only=False in torch estimator

### DIFF
--- a/src/gluonts/torch/model/estimator.py
+++ b/src/gluonts/torch/model/estimator.py
@@ -228,7 +228,8 @@ class PyTorchLightningEstimator(Estimator):
                 f"Loading best model from {checkpoint.best_model_path}"
             )
             best_model = training_network.__class__.load_from_checkpoint(
-                checkpoint.best_model_path
+                checkpoint.best_model_path,
+                weights_only=False,
             )
         else:
             best_model = training_network


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Since [this `lignthing` commit](https://github.com/Lightning-AI/pytorch-lightning/commit/29abe6e47deefc628b7ede09601c05838fcf140b), the following test fails:
```
FAILED test/torch/test_torch_item_id_info.py::test_item_id_info[dataset0-estimator0] - _pickle.UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, do those steps only if you trust the source of the checkpoint.
        (1) In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
        (2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.
        WeightsUnpickler error: Unsupported global: GLOBAL functools.partial was not an allowed global by default. Please use `torch.serialization.add_safe_globals([functools.partial])` or the `torch.serialization.safe_globals([functools.partial])` context manager to allowlist this global if you trust this class/function.

Check the documentation of torch.load to learn more about types accepted by default with weights_only https://pytorch.org/docs/stable/generated/torch.load.html.
```

This PR explicitly set `weights_only` to `False` in `src/gluonts/torch/model/estimator.py` (when calling `training_network.__class__.load_from_checkpoint()`).


- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup
