### PR TITLE
Add Tweedie distribution 

### DIFF
--- a/src/gluonts/torch/distributions/__init__.py
+++ b/src/gluonts/torch/distributions/__init__.py
@@ -38,6 +38,7 @@ from .spliced_binned_pareto import (
 )
 from .studentT import StudentTOutput
 from .truncated_normal import TruncatedNormal, TruncatedNormalOutput
+from .tweedie import Tweedie, TweedieOutput
 
 __all__ = [
     "AffineTransformed",
@@ -66,4 +67,6 @@ __all__ = [
     "StudentTOutput",
     "TruncatedNormal",
     "TruncatedNormalOutput",
+    "Tweedie",
+    "TweedieOutput",
 ]

--- a/src/gluonts/torch/distributions/tweedie.py
+++ b/src/gluonts/torch/distributions/tweedie.py
@@ -1,0 +1,266 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""
+Tweedie distribution implementation for GluonTS.
+
+The Tweedie distribution is a family of probability distributions that includes
+Gaussian, Poisson, Gamma, and compound Poisson-Gamma as special cases. It is
+particularly useful for modeling non-negative data with exact zeros, such as
+insurance claims, rainfall amounts, and intermittent demand.
+
+The distribution is parameterized by:
+- mu: mean (must be positive)
+- dispersion: dispersion parameter (must be positive)
+- power: variance power parameter (must be in range (1, 2) for compound Poisson-Gamma)
+
+The variance is: Var(Y) = dispersion * mu^power
+
+This implementation is based on:
+- PyTorch PR #171705: https://github.com/pytorch/pytorch/pull/171705
+- Dunn, P.K. and Smyth, G.K. (2005). "Series evaluation of Tweedie exponential
+  dispersion model densities". Statistics and Computing, 15(4), 267-280.
+- R statmod package for the saddle-point approximation approach.
+"""
+
+from typing import Dict, Optional, Tuple, Union
+
+import math
+import torch
+import torch.nn.functional as F
+from torch.distributions import Distribution, Gamma, Poisson, constraints
+
+from .distribution_output import DistributionOutput
+
+
+class Tweedie(Distribution):
+    """
+    Tweedie distribution with compound Poisson-Gamma representation.
+
+    The Tweedie distribution is characterized by the variance function:
+        Var(Y) = dispersion * mu^power
+
+    For power in (1, 2), this is a compound Poisson-Gamma distribution with
+    a point mass at zero.
+
+    Parameters
+    ----------
+    mu
+        Mean parameter (must be positive).
+    dispersion
+        Dispersion parameter (must be positive).
+    power
+        Variance power parameter (must be in (1, 2)).
+    validate_args
+        Whether to validate input arguments.
+    """
+
+    arg_constraints = {
+        "mu": constraints.positive,
+        "dispersion": constraints.positive,
+        "power": constraints.interval(1.0, 2.0),
+    }
+    support = constraints.greater_than_eq(0)
+    has_rsample = False
+
+    def __init__(
+        self,
+        mu: torch.Tensor,
+        dispersion: torch.Tensor,
+        power: torch.Tensor,
+        validate_args: Optional[bool] = None,
+    ):
+        self.mu = mu
+        self.dispersion = dispersion
+        self.power = power
+
+        batch_shape = torch.broadcast_shapes(
+            mu.shape, dispersion.shape, power.shape
+        )
+        event_shape = torch.Size([])
+        super().__init__(batch_shape, event_shape, validate_args=validate_args)
+
+    @property
+    def mean(self) -> torch.Tensor:
+        return self.mu
+
+    @property
+    def variance(self) -> torch.Tensor:
+        return self.dispersion * torch.pow(self.mu, self.power)
+
+    def _lambda(self) -> torch.Tensor:
+        """Poisson rate parameter for compound Poisson-Gamma representation."""
+        return torch.pow(self.mu, 2 - self.power) / (
+            self.dispersion * (2 - self.power)
+        )
+
+    def _alpha(self) -> torch.Tensor:
+        """Gamma shape parameter for compound Poisson-Gamma representation."""
+        return (2 - self.power) / (self.power - 1)
+
+    def _beta(self) -> torch.Tensor:
+        """Gamma rate parameter for compound Poisson-Gamma representation."""
+        return 1.0 / (
+            self.dispersion
+            * (self.power - 1)
+            * torch.pow(self.mu, self.power - 1)
+        )
+
+    def sample(self, sample_shape: torch.Size = torch.Size()) -> torch.Tensor:
+        """
+        Sample from the Tweedie distribution using compound Poisson-Gamma.
+
+        Algorithm:
+        1. Sample N ~ Poisson(lambda)
+        2. If N > 0: Sample Y = sum of N Gamma(alpha, beta) random variables
+        3. If N = 0: Y = 0
+        """
+        with torch.no_grad():
+            shape = self._extended_shape(sample_shape)
+
+            lam = self._lambda().expand(shape)
+            alpha = self._alpha().expand(shape)
+            beta = self._beta().expand(shape)
+
+            # Sample Poisson counts
+            n_samples = torch.poisson(lam)
+
+            # Initialize output
+            y = torch.zeros_like(n_samples)
+
+            # For non-zero counts, sample from Gamma
+            # Use the property that sum of N Gamma(alpha, beta) = Gamma(N*alpha, beta)
+            mask = n_samples > 0
+            if mask.any():
+                # Create Gamma distribution for non-zero samples
+                # Gamma(N*alpha, beta) where we parameterize by shape and rate
+                gamma_shape = n_samples[mask] * alpha[mask]
+                gamma_rate = beta[mask]
+
+                # PyTorch Gamma uses concentration (shape) and rate
+                gamma_dist = Gamma(concentration=gamma_shape, rate=gamma_rate)
+                y[mask] = gamma_dist.sample()
+
+            return y
+
+    def log_prob(self, value: torch.Tensor) -> torch.Tensor:
+        """
+        Compute log probability of observed values.
+
+        Uses the saddle-point approximation for numerical stability.
+        Based on Dunn & Smyth (2005) and the implementation approach from
+        the R statmod package.
+        """
+        if self._validate_args:
+            self._validate_sample(value)
+
+        # Broadcast parameters to match value shape
+        mu = self.mu.expand(value.shape)
+        phi = self.dispersion.expand(value.shape)
+        p = self.power.expand(value.shape)
+
+        # Initialize log_prob tensor
+        log_prob = torch.zeros_like(value)
+
+        # Handle zero values: P(Y=0) = exp(-lambda)
+        # where lambda = mu^(2-p) / (phi * (2-p))
+        zero_mask = value == 0
+        if zero_mask.any():
+            lam = torch.pow(mu, 2 - p) / (phi * (2 - p))
+            log_prob = torch.where(zero_mask, -lam, log_prob)
+
+        # Handle positive values using saddle-point approximation
+        pos_mask = value > 0
+        if pos_mask.any():
+            # Compute the unit deviance
+            # d(y, mu) = 2 * (y^(2-p)/((1-p)(2-p)) - y*mu^(1-p)/(1-p) + mu^(2-p)/(2-p))
+            y = value
+
+            # For numerical stability, compute each term carefully
+            term1 = torch.pow(y.clamp(min=1e-10), 2 - p) / ((1 - p) * (2 - p))
+            term2 = y * torch.pow(mu, 1 - p) / (1 - p)
+            term3 = torch.pow(mu, 2 - p) / (2 - p)
+
+            deviance = 2 * (term1 - term2 + term3)
+
+            # Log-likelihood using saddle-point approximation:
+            # log f(y; mu, phi, p) = -deviance/(2*phi) - log(y) - 0.5*log(2*pi*phi*V(y))
+            # where V(y) = y^p is the variance function evaluated at y
+
+            # Variance function at y
+            V_y = torch.pow(y.clamp(min=1e-10), p)
+
+            # Saddle-point log-likelihood
+            log_prob_pos = (
+                -deviance / (2 * phi)
+                - torch.log(y.clamp(min=1e-10))
+                - 0.5 * torch.log(2 * math.pi * phi * V_y)
+            )
+
+            log_prob = torch.where(pos_mask, log_prob_pos, log_prob)
+
+        return log_prob
+
+
+class TweedieOutput(DistributionOutput):
+    """
+    Distribution output class for Tweedie distribution.
+
+    Maps neural network outputs to Tweedie distribution parameters.
+    """
+
+    args_dim: Dict[str, int] = {"mu": 1, "dispersion": 1, "power": 1}
+    distr_cls: type = Tweedie
+
+    @classmethod
+    def domain_map(
+        cls, mu: torch.Tensor, dispersion: torch.Tensor, power: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        Map unbounded neural network outputs to valid distribution parameters.
+
+        Parameters
+        ----------
+        mu
+            Unbounded tensor, mapped to positive via softplus + epsilon.
+        dispersion
+            Unbounded tensor, mapped to positive via softplus + epsilon.
+        power
+            Unbounded tensor, mapped to (1, 2) via 1 + sigmoid.
+
+        Returns
+        -------
+        Tuple of transformed tensors (mu, dispersion, power).
+        """
+        epsilon = torch.finfo(mu.dtype).eps
+
+        # mu must be positive
+        mu = F.softplus(mu) + epsilon
+
+        # dispersion must be positive
+        dispersion = F.softplus(dispersion) + epsilon
+
+        # power must be in (1, 2)
+        # Using 1 + sigmoid maps to approximately (1, 2)
+        # Add small margin to avoid boundary issues
+        power = 1.0 + 0.01 + 0.98 * torch.sigmoid(power)
+
+        return mu.squeeze(-1), dispersion.squeeze(-1), power.squeeze(-1)
+
+    @property
+    def event_shape(self) -> Tuple:
+        return ()
+
+    @property
+    def value_in_support(self) -> float:
+        return 0.5

--- a/test/torch/modules/test_tweedie_distribution_inference.py
+++ b/test/torch/modules/test_tweedie_distribution_inference.py
@@ -1,0 +1,291 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""
+Test that maximizing likelihood allows to correctly recover Tweedie distribution
+parameters.
+"""
+from typing import List
+
+import numpy as np
+import pytest
+from lightning import seed_everything
+
+import torch
+import torch.nn as nn
+from torch.nn.utils import clip_grad_norm_
+from torch.optim import SGD
+from torch.utils.data import DataLoader, TensorDataset
+
+from gluonts.pydantic import PositiveFloat, PositiveInt
+from gluonts.torch.distributions import (
+    DistributionOutput,
+    TweedieOutput,
+    Tweedie,
+)
+
+NUM_SAMPLES = 5_000
+BATCH_SIZE = 64
+TOL = 0.30
+START_TOL_MULTIPLE = 1
+
+np.random.seed(42)
+torch.manual_seed(42)
+
+
+def inv_softplus(y: np.ndarray) -> np.ndarray:
+    """Inverse of softplus: x = log(exp(y) - 1)."""
+    return np.log(np.exp(y) - 1)
+
+
+def inv_sigmoid(y: float) -> float:
+    """Inverse of sigmoid: x = log(y / (1 - y))."""
+    return np.log(y / (1 - y))
+
+
+def maximum_likelihood_estimate_sgd(
+    distr_output: DistributionOutput,
+    samples: torch.Tensor,
+    init_biases: List[np.ndarray] = None,
+    num_epochs: PositiveInt = PositiveInt(5),
+    learning_rate: PositiveFloat = PositiveFloat(1e-2),
+):
+    """
+    Estimate distribution parameters using maximum likelihood via SGD.
+
+    Parameters
+    ----------
+    distr_output
+        The distribution output class to use.
+    samples
+        Tensor of samples from the true distribution.
+    init_biases
+        Initial biases for the neural network layers.
+    num_epochs
+        Number of training epochs.
+    learning_rate
+        Learning rate for SGD optimizer.
+
+    Returns
+    -------
+    List of estimated parameters.
+    """
+    arg_proj = distr_output.get_args_proj(in_features=1)
+    if init_biases is not None:
+        for param, bias in zip(arg_proj.proj, init_biases):
+            nn.init.constant_(param.bias, bias)
+    dummy_data = torch.ones((len(samples), 1))
+    dataset = TensorDataset(dummy_data, samples)
+    train_data = DataLoader(dataset, batch_size=BATCH_SIZE, shuffle=True)
+    optimizer = SGD(arg_proj.parameters(), lr=learning_rate)
+    for e in range(num_epochs):
+        cumulative_loss = 0
+        num_batches = 0
+        for i, (data, sample_label) in enumerate(train_data):
+            optimizer.zero_grad()
+            distr_args = arg_proj(data)
+            distr = distr_output.distribution(distr_args)
+            loss = -distr.log_prob(sample_label).mean()
+            if torch.isnan(loss) or torch.isinf(loss):
+                continue
+            loss.backward()
+            clip_grad_norm_(arg_proj.parameters(), 10.0)
+            optimizer.step()
+            num_batches += 1
+            cumulative_loss += loss.item()
+    if len(distr_args[0].shape) == 1:
+        return [
+            param.detach().numpy() for param in arg_proj(torch.ones((1, 1)))
+        ]
+    return [
+        param[0].detach().numpy() for param in arg_proj(torch.ones((1, 1)))
+    ]
+
+
+@pytest.mark.flaky(retries=3)
+@pytest.mark.parametrize(
+    "mu, dispersion, power",
+    [
+        (2.0, 1.0, 1.5),  # Standard case in middle of power range
+        (5.0, 0.5, 1.3),  # Higher mean, lower dispersion, power near Poisson
+        (1.0, 2.0, 1.7),  # Lower mean, higher dispersion, power near Gamma
+    ],
+)
+def test_tweedie_likelihood(mu: float, dispersion: float, power: float) -> None:
+    """
+    Test to check that maximizing the likelihood recovers the parameters.
+    """
+    seed_everything(42)
+
+    # Generate samples using the Tweedie distribution
+    mus = torch.zeros((NUM_SAMPLES,)) + mu
+    dispersions = torch.zeros((NUM_SAMPLES,)) + dispersion
+    powers = torch.zeros((NUM_SAMPLES,)) + power
+
+    distr = Tweedie(mu=mus, dispersion=dispersions, power=powers)
+    samples = distr.sample()
+
+    # Compute initial biases (inverse of domain_map transformations)
+    # mu: softplus(x) + eps = mu => x = inv_softplus(mu - eps)
+    # dispersion: softplus(x) + eps = dispersion => x = inv_softplus(dispersion - eps)
+    # power: 1 + 0.01 + 0.98 * sigmoid(x) = power => sigmoid(x) = (power - 1.01) / 0.98
+    eps = np.finfo(np.float32).eps
+
+    mu_init = inv_softplus(mu * (1 - START_TOL_MULTIPLE * TOL) - eps)
+    disp_init = inv_softplus(dispersion * (1 - START_TOL_MULTIPLE * TOL) - eps)
+    power_normalized = (power * (1 - START_TOL_MULTIPLE * TOL * 0.1) - 1.01) / 0.98
+    power_init = inv_sigmoid(np.clip(power_normalized, 0.01, 0.99))
+
+    init_biases = [mu_init, disp_init, power_init]
+
+    mu_hat, dispersion_hat, power_hat = maximum_likelihood_estimate_sgd(
+        TweedieOutput(),
+        samples,
+        init_biases=init_biases,
+        learning_rate=PositiveFloat(0.01),
+        num_epochs=PositiveInt(20),
+    )
+
+    assert (
+        np.abs(mu_hat - mu) < TOL * mu
+    ), f"mu did not match: mu = {mu}, mu_hat = {mu_hat}"
+    assert (
+        np.abs(dispersion_hat - dispersion) < TOL * dispersion
+    ), f"dispersion did not match: dispersion = {dispersion}, dispersion_hat = {dispersion_hat}"
+    assert (
+        np.abs(power_hat - power) < TOL * power
+    ), f"power did not match: power = {power}, power_hat = {power_hat}"
+
+
+@pytest.mark.flaky(retries=3)
+def test_tweedie_sampling_properties() -> None:
+    """
+    Test that Tweedie sampling produces expected statistical properties.
+    """
+    seed_everything(42)
+
+    mu = 3.0
+    dispersion = 1.5
+    power = 1.5
+
+    mus = torch.zeros((NUM_SAMPLES,)) + mu
+    dispersions = torch.zeros((NUM_SAMPLES,)) + dispersion
+    powers = torch.zeros((NUM_SAMPLES,)) + power
+
+    distr = Tweedie(mu=mus, dispersion=dispersions, power=powers)
+    samples = distr.sample()
+
+    # Check basic properties
+    assert (samples >= 0).all(), "Tweedie samples should be non-negative"
+
+    # Check that there are some zeros (characteristic of Tweedie for power in (1,2))
+    zero_proportion = (samples == 0).float().mean().item()
+    assert zero_proportion > 0.01, "Should have some zero samples"
+    assert zero_proportion < 0.99, "Should have some non-zero samples"
+
+    # Check mean is approximately correct (with tolerance)
+    sample_mean = samples.mean().item()
+    assert (
+        np.abs(sample_mean - mu) < 0.3 * mu
+    ), f"Sample mean {sample_mean} should be close to {mu}"
+
+    # Check variance approximately follows V = phi * mu^p
+    expected_variance = dispersion * (mu ** power)
+    sample_variance = samples.var().item()
+    assert (
+        np.abs(sample_variance - expected_variance) < 0.5 * expected_variance
+    ), f"Sample variance {sample_variance} should be close to {expected_variance}"
+
+
+@pytest.mark.flaky(retries=3)
+def test_tweedie_mean_variance_properties() -> None:
+    """
+    Test that Tweedie distribution correctly computes mean and variance.
+    """
+    mu = torch.tensor([1.0, 2.0, 3.0])
+    dispersion = torch.tensor([0.5, 1.0, 1.5])
+    power = torch.tensor([1.3, 1.5, 1.7])
+
+    distr = Tweedie(mu=mu, dispersion=dispersion, power=power)
+
+    # Check mean equals mu
+    assert torch.allclose(
+        distr.mean, mu
+    ), "Mean should equal mu"
+
+    # Check variance equals dispersion * mu^power
+    expected_variance = dispersion * torch.pow(mu, power)
+    assert torch.allclose(
+        distr.variance, expected_variance
+    ), "Variance should equal dispersion * mu^power"
+
+
+@pytest.mark.flaky(retries=3)
+def test_tweedie_log_prob_shape() -> None:
+    """
+    Test that log_prob returns correct shapes.
+    """
+    batch_size = 10
+    mu = torch.ones(batch_size) * 2.0
+    dispersion = torch.ones(batch_size) * 1.0
+    power = torch.ones(batch_size) * 1.5
+
+    distr = Tweedie(mu=mu, dispersion=dispersion, power=power)
+
+    # Test with matching shape
+    values = torch.rand(batch_size) * 5
+    log_probs = distr.log_prob(values)
+    assert log_probs.shape == torch.Size(
+        [batch_size]
+    ), f"Expected shape {[batch_size]}, got {log_probs.shape}"
+
+    # Test with zeros (should handle point mass at zero)
+    values_with_zeros = torch.zeros(batch_size)
+    log_probs_zeros = distr.log_prob(values_with_zeros)
+    assert log_probs_zeros.shape == torch.Size(
+        [batch_size]
+    ), f"Expected shape {[batch_size]}, got {log_probs_zeros.shape}"
+    assert torch.isfinite(
+        log_probs_zeros
+    ).all(), "Log prob for zeros should be finite"
+
+
+@pytest.mark.flaky(retries=3)
+def test_tweedie_output_domain_map() -> None:
+    """
+    Test that TweedieOutput.domain_map produces valid parameters.
+    """
+    # Random unbounded inputs
+    torch.manual_seed(42)
+    mu_raw = torch.randn(10, 1)
+    dispersion_raw = torch.randn(10, 1)
+    power_raw = torch.randn(10, 1)
+
+    mu, dispersion, power = TweedieOutput.domain_map(
+        mu_raw, dispersion_raw, power_raw
+    )
+
+    # Check constraints
+    assert (mu > 0).all(), "mu should be positive"
+    assert (dispersion > 0).all(), "dispersion should be positive"
+    assert (power > 1).all(), "power should be > 1"
+    assert (power < 2).all(), "power should be < 2"
+
+    # Check shapes (should squeeze last dimension)
+    assert mu.shape == torch.Size([10]), f"Expected shape [10], got {mu.shape}"
+    assert dispersion.shape == torch.Size(
+        [10]
+    ), f"Expected shape [10], got {dispersion.shape}"
+    assert power.shape == torch.Size(
+        [10]
+    ), f"Expected shape [10], got {power.shape}"


### PR DESCRIPTION
## Summary
- Add Tweedie distribution implementation for modeling non-negative data with exact zeros
- Suitable for insurance claims, rainfall amounts, intermittent demand forecasting

## Changes
- **Tweedie class**: PyTorch distribution with compound Poisson-Gamma sampling and saddle-point log_prob
- **TweedieOutput class**: GluonTS output for use with DeepAR and other estimators
- **Unit tests**: Parameter recovery via MLE, distribution properties

## References
- Based on PyTorch PR #171705: https://github.com/pytorch/pytorch/pull/171705
- Dunn & Smyth (2005) "Series evaluation of Tweedie exponential dispersion model densities"

## Test plan
- [x] Unit tests pass: `pytest test/torch/modules/test_tweedie_distribution_inference.py`
- [x] Import test: `from gluonts.torch.distributions import TweedieOutput`
- [x] Integration tested with DeepAR on synthetic and electricity datasets

🤖 Generated with [Claude Code](https://claude.ai/code)